### PR TITLE
Handle storage write failures in agent store

### DIFF
--- a/src/lib/agent-store.ts
+++ b/src/lib/agent-store.ts
@@ -114,13 +114,17 @@ class AgentStore {
   // Storage management
   private saveToStorage(): void {
     if (typeof window === 'undefined') return;
-    
+
     const data = {
       agents: Array.from(this.agents.entries()),
       sessions: Array.from(this.sessions.entries()),
     };
-    
-    localStorage.setItem(this.storageKey, JSON.stringify(data));
+
+    try {
+      localStorage.setItem(this.storageKey, JSON.stringify(data));
+    } catch (error) {
+      console.error('Failed to save data to storage:', error);
+    }
   }
 
   private loadFromStorage(): void {


### PR DESCRIPTION
## Summary
- wrap `localStorage.setItem` in a `try...catch` block
- log failures to help diagnose storage write issues

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 25 problems, 8 errors and 17 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b1948c5ef48325a3b16666d32e7ae2