### PR TITLE
feat: confirm agent deletion with dialog

### DIFF
--- a/src/components/agents/AgentDashboard.tsx
+++ b/src/components/agents/AgentDashboard.tsx
@@ -2,12 +2,11 @@
 
 import React, { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { DragDropProvider } from './DragDropProvider';
 import { DraggableAgentCard } from './DraggableAgentCard';
-import { DropZone } from './DropZone';
 import { AgentForm } from './AgentForm';
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { AgentConfig } from '@/types/agent';
 import { DragEndEvent } from '@dnd-kit/core';
 import { agentStore } from '@/lib/agent-store';
@@ -22,7 +21,9 @@ export function AgentDashboard({ onStartChat, onStartVoice }: AgentDashboardProp
   const [agents, setAgents] = useState<AgentConfig[]>([]);
   const [showForm, setShowForm] = useState(false);
   const [editingAgent, setEditingAgent] = useState<AgentConfig | null>(null);
-  const [sessions, setSessions] = useState<any[]>([]);
+  const [sessions] = useState<unknown[]>([]);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [agentToDelete, setAgentToDelete] = useState<string | null>(null);
 
   useEffect(() => {
     // Load agents from store
@@ -56,10 +57,17 @@ export function AgentDashboard({ onStartChat, onStartVoice }: AgentDashboardProp
   };
 
   const handleDeleteAgent = (agentId: string) => {
-    if (confirm('Are you sure you want to delete this agent?')) {
-      agentStore.deleteAgent(agentId);
-      setAgents(prev => prev.filter(a => a.id !== agentId));
+    setAgentToDelete(agentId);
+    setDeleteDialogOpen(true);
+  };
+
+  const confirmDeleteAgent = () => {
+    if (agentToDelete) {
+      agentStore.deleteAgent(agentToDelete);
+      setAgents(prev => prev.filter(a => a.id !== agentToDelete));
     }
+    setDeleteDialogOpen(false);
+    setAgentToDelete(null);
   };
 
   const handleCancelForm = () => {
@@ -110,6 +118,18 @@ export function AgentDashboard({ onStartChat, onStartVoice }: AgentDashboardProp
 
   return (
     <DragDropProvider agents={agents} onDragEnd={handleDragEnd}>
+        <ConfirmDialog
+          open={deleteDialogOpen}
+          title="Delete Agent"
+          description="Are you sure you want to delete this agent?"
+          confirmLabel="Delete"
+          cancelLabel="Cancel"
+          onConfirm={confirmDeleteAgent}
+          onCancel={() => {
+            setDeleteDialogOpen(false);
+            setAgentToDelete(null);
+          }}
+        />
       <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100">
         {/* Modern Header */}
         <div className="glass-effect border-b border-blue-100">

--- a/src/components/ui/confirm-dialog.tsx
+++ b/src/components/ui/confirm-dialog.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import * as React from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) {
+          onCancel();
+        }
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          {description && <DialogDescription>{description}</DialogDescription>}
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel}>
+            {cancelLabel}
+          </Button>
+          <Button variant="destructive" onClick={onConfirm}>
+            {confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+


### PR DESCRIPTION
## Summary
- extract reusable ConfirmDialog component
- use ConfirmDialog in AgentDashboard for agent deletion prompt

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any. Specify a different type)


------
https://chatgpt.com/codex/tasks/task_e_68b1948772a483259746a52d0d042edb