### PR TITLE
feat: add agent marketplace endpoints and UI

### DIFF
--- a/src/app/api/marketplace/agents/[id]/route.ts
+++ b/src/app/api/marketplace/agents/[id]/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import { marketplaceStore } from '@/lib/marketplace-store';
+
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const agent = marketplaceStore.getAgent(params.id);
+  if (!agent) {
+    return NextResponse.json({ error: 'Agent not found' }, { status: 404 });
+  }
+  return NextResponse.json(agent);
+}

--- a/src/app/api/marketplace/agents/route.ts
+++ b/src/app/api/marketplace/agents/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import { marketplaceStore } from '@/lib/marketplace-store';
+import { AgentConfig } from '@/types/agent';
+
+export async function GET() {
+  const agents = marketplaceStore.listAgents();
+  return NextResponse.json(agents);
+}
+
+export async function POST(request: Request) {
+  const data: AgentConfig = await request.json();
+  const agent = marketplaceStore.publishAgent(data);
+  return NextResponse.json(agent, { status: 201 });
+}

--- a/src/app/marketplace/page.tsx
+++ b/src/app/marketplace/page.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { AgentConfig } from '@/types/agent';
+import { agentStore } from '@/lib/agent-store';
+import { AgentMarketplaceCard } from '@/components/marketplace/AgentMarketplaceCard';
+
+export default function MarketplacePage() {
+  const [agents, setAgents] = useState<AgentConfig[]>([]);
+
+  useEffect(() => {
+    fetch('/api/marketplace/agents')
+      .then(res => res.json())
+      .then(setAgents)
+      .catch(console.error);
+  }, []);
+
+  const handleImport = (agent: AgentConfig) => {
+    const { id, createdAt, updatedAt, ...rest } = agent;
+    agentStore.createAgent(rest);
+  };
+
+  return (
+    <div className="container mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-6">Agent Marketplace</h1>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {agents.map(agent => (
+          <AgentMarketplaceCard
+            key={agent.id}
+            agent={agent}
+            onImport={() => handleImport(agent)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/agents/AgentDashboard.tsx
+++ b/src/components/agents/AgentDashboard.tsx
@@ -71,6 +71,22 @@ export function AgentDashboard({ onStartChat, onStartVoice }: AgentDashboardProp
     setDeleteDialogOpen(true);
   };
 
+  const handleShareAgent = async (agent: AgentConfig) => {
+    try {
+      await fetch('/api/marketplace/agents', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ...agent,
+          visibility: 'public',
+          version: agent.version || '1.0.0',
+        }),
+      });
+    } catch (error) {
+      console.error('Failed to share agent:', error);
+    }
+  };
+
   const confirmDeleteAgent = () => {
     if (agentToDelete) {
       agentStore.deleteAgent(agentToDelete);
@@ -292,6 +308,7 @@ export function AgentDashboard({ onStartChat, onStartVoice }: AgentDashboardProp
                   onDelete={handleDeleteAgent}
                   onStartChat={handleStartChat}
                   onStartVoice={handleStartVoice}
+                  onShare={handleShareAgent}
                 />
               ))}
             </div>

--- a/src/components/agents/DraggableAgentCard.tsx
+++ b/src/components/agents/DraggableAgentCard.tsx
@@ -13,7 +13,7 @@ import {
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu';
 import { AgentConfig } from '@/types/agent';
-import { MessageSquare, Mic, Edit, Trash2, GripVertical, MoreHorizontal, Settings } from 'lucide-react';
+import { MessageSquare, Mic, Edit, Trash2, GripVertical, MoreHorizontal, Settings, Share2 } from 'lucide-react';
 
 interface DraggableAgentCardProps {
   agent: AgentConfig;
@@ -21,6 +21,7 @@ interface DraggableAgentCardProps {
   onDelete?: (agentId: string) => void;
   onStartChat?: (agent: AgentConfig) => void;
   onStartVoice?: (agent: AgentConfig) => void;
+  onShare?: (agent: AgentConfig) => void;
 }
 
 export const DraggableAgentCard: React.FC<DraggableAgentCardProps> = ({
@@ -28,7 +29,8 @@ export const DraggableAgentCard: React.FC<DraggableAgentCardProps> = ({
   onEdit,
   onDelete,
   onStartChat,
-  onStartVoice
+  onStartVoice,
+  onShare
 }) => {
   const {
     attributes,
@@ -125,16 +127,23 @@ export const DraggableAgentCard: React.FC<DraggableAgentCardProps> = ({
                    <Settings className="mr-2 h-4 w-4" />
                    Edit Agent
                  </DropdownMenuItem>
-                 <DropdownMenuItem 
-                   onClick={() => onDelete?.(agent.id)}
-                   className="text-red-600 hover:bg-red-50 hover:text-red-700"
-                 >
-                   <Trash2 className="mr-2 h-4 w-4" />
-                   Delete Agent
-                 </DropdownMenuItem>
-               </DropdownMenuContent>
-             </DropdownMenu>
-          </div>
+                <DropdownMenuItem
+                  onClick={() => onDelete?.(agent.id)}
+                  className="text-red-600 hover:bg-red-50 hover:text-red-700"
+                >
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  Delete Agent
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={() => onShare?.(agent)}
+                  className="hover:bg-green-50 hover:text-green-700"
+                >
+                  <Share2 className="mr-2 h-4 w-4" />
+                  Share to Marketplace
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+         </div>
           
           <p className="text-slate-600 mb-6 line-clamp-3 leading-relaxed">
              {agent.systemPrompt || 'This agent is ready to assist with various tasks and conversations.'}

--- a/src/components/marketplace/AgentMarketplaceCard.tsx
+++ b/src/components/marketplace/AgentMarketplaceCard.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { AgentConfig } from '@/types/agent';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+
+interface AgentMarketplaceCardProps {
+  agent: AgentConfig;
+  onImport: () => void;
+}
+
+export function AgentMarketplaceCard({ agent, onImport }: AgentMarketplaceCardProps) {
+  return (
+    <Card className="agent-card border-0 shadow-lg">
+      <CardHeader>
+        <CardTitle>{agent.name}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="text-slate-600 mb-4">{agent.description}</p>
+        <Button onClick={onImport}>Import</Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/agent-store.ts
+++ b/src/lib/agent-store.ts
@@ -19,6 +19,10 @@ class AgentStore {
   // Agent management
   createAgent(config: Omit<AgentConfig, 'id' | 'createdAt' | 'updatedAt'>): AgentConfig {
     const agent: AgentConfig = {
+      version: '1.0.0',
+      visibility: 'private',
+      screenshots: [],
+      rating: 0,
       ...config,
       id: generateId(),
       createdAt: new Date(),

--- a/src/lib/marketplace-store.ts
+++ b/src/lib/marketplace-store.ts
@@ -1,0 +1,27 @@
+import { AgentConfig } from '@/types/agent';
+import { generateId } from './utils';
+
+class MarketplaceStore {
+  private agents: Map<string, AgentConfig> = new Map();
+
+  listAgents(): AgentConfig[] {
+    return Array.from(this.agents.values());
+  }
+
+  getAgent(id: string): AgentConfig | null {
+    return this.agents.get(id) || null;
+  }
+
+  publishAgent(config: AgentConfig): AgentConfig {
+    const agent: AgentConfig = {
+      ...config,
+      id: config.id || generateId(),
+      createdAt: config.createdAt ? new Date(config.createdAt) : new Date(),
+      updatedAt: new Date(),
+    };
+    this.agents.set(agent.id, agent);
+    return agent;
+  }
+}
+
+export const marketplaceStore = new MarketplaceStore();

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -24,6 +24,10 @@ export interface AgentConfig {
     speed: number;
     pitch: number;
   };
+  version?: string;
+  visibility?: 'public' | 'private';
+  screenshots?: string[];
+  rating?: number;
   createdAt: Date;
   updatedAt: Date;
 }


### PR DESCRIPTION
## Summary
- extend AgentConfig with marketplace metadata
- add in-memory marketplace store and REST API routes
- build marketplace page and card component for browsing/importing agents
- allow sharing agents to marketplace from dashboard

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype; Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68b198e852d08325ac44bf13bd98c1c6