### PR TITLE
Add analytics tracking and alerting

### DIFF
--- a/src/components/agents/AgentForm.tsx
+++ b/src/components/agents/AgentForm.tsx
@@ -35,7 +35,10 @@ export function AgentForm({ agent, onSave, onCancel }: AgentFormProps) {
 
   const [errors, setErrors] = useState<Record<string, string>>({});
 
-  const handleInputChange = (field: string, value: any) => {
+  const handleInputChange = (
+    field: keyof typeof formData,
+    value: string | number
+  ) => {
     setFormData(prev => ({ ...prev, [field]: value }));
     // Clear error when user starts typing
     if (errors[field]) {

--- a/src/components/analytics/AnalyticsDashboard.tsx
+++ b/src/components/analytics/AnalyticsDashboard.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { getAllMetrics, AgentMetrics } from '@/lib/analytics';
+import { agentStore } from '@/lib/agent-store';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+} from '@/components/ui/card';
+
+function average(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+export default function AnalyticsDashboard() {
+  const [metrics, setMetrics] = useState<Record<string, AgentMetrics>>({});
+
+  useEffect(() => {
+    const update = () => setMetrics({ ...getAllMetrics() });
+    update();
+    if (typeof window !== 'undefined') {
+      window.addEventListener('analytics-updated', update);
+      return () => window.removeEventListener('analytics-updated', update);
+    }
+  }, []);
+
+  const agents = agentStore.getAllAgents();
+  const maxTokens = Math.max(1, ...Object.values(metrics).map(m => m.tokensUsed));
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Analytics Dashboard</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left">
+              <th className="pb-2">Agent</th>
+              <th className="pb-2">Avg Response (ms)</th>
+              <th className="pb-2">Errors</th>
+              <th className="pb-2">Tokens Used</th>
+            </tr>
+          </thead>
+          <tbody>
+            {Object.entries(metrics).map(([id, data]) => {
+              const agent = agents.find(a => a.id === id);
+              const avgResponse = average(data.responseTimes).toFixed(0);
+              const tokenPercent = (data.tokensUsed / maxTokens) * 100;
+              return (
+                <tr key={id} className="border-t">
+                  <td className="py-2">{agent ? agent.name : id}</td>
+                  <td className="py-2">{avgResponse}</td>
+                  <td className="py-2">{data.errorCount}</td>
+                  <td className="py-2">
+                    <div className="w-full bg-gray-200 h-2 rounded">
+                      <div
+                        className="bg-blue-500 h-2 rounded"
+                        style={{ width: `${tokenPercent}%` }}
+                      />
+                    </div>
+                    <div className="text-xs text-muted-foreground mt-1">
+                      {data.tokensUsed}
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/chat/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface.tsx
@@ -28,7 +28,7 @@ export function ChatInterface({ agent, onBack }: ChatInterfaceProps) {
   useEffect(() => {
     // Initialize API client
     try {
-      const client = new APIClient(agent.modelConfig);
+      const client = new APIClient(agent.modelConfig, agent.id);
       setApiClient(client);
     } catch (error) {
       console.error('Failed to initialize API client:', error);

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,8 +1,7 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
-export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {

--- a/src/components/voice/VoiceInterface.tsx
+++ b/src/components/voice/VoiceInterface.tsx
@@ -32,7 +32,7 @@ export function VoiceInterface({ agent, onBack }: VoiceInterfaceProps) {
   useEffect(() => {
     // Initialize API client
     try {
-      const client = new APIClient(agent.modelConfig);
+      const client = new APIClient(agent.modelConfig, agent.id);
       setApiClient(client);
     } catch (error) {
       console.error('Failed to initialize API client:', error);

--- a/src/lib/agent-store.ts
+++ b/src/lib/agent-store.ts
@@ -1,5 +1,6 @@
 import { AgentConfig, AgentSession, ChatMessage } from '@/types/agent';
 import { generateId } from './utils';
+import { recordTokens } from './analytics';
 
 class AgentStore {
   private agents: Map<string, AgentConfig> = new Map();
@@ -108,7 +109,13 @@ class AgentStore {
 
     session.messages.push(newMessage);
     session.updatedAt = new Date();
-    
+
+    // Approximate token usage by word count
+    if (newMessage.agentId) {
+      const tokens = newMessage.content.split(/\s+/).filter(Boolean).length;
+      recordTokens(newMessage.agentId, tokens);
+    }
+
     this.sessions.set(sessionId, session);
     this.saveToStorage();
     return newMessage;

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,137 @@
+export interface AgentMetrics {
+  responseTimes: number[];
+  errorCount: number;
+  tokensUsed: number;
+}
+
+interface Thresholds {
+  responseTimeMs?: number;
+  errorCount?: number;
+  tokensUsed?: number;
+}
+
+const metrics: Record<string, AgentMetrics> = {};
+let thresholds: Thresholds = {
+  responseTimeMs: Number(process.env.ANALYTICS_RESPONSE_TIME_THRESHOLD) || undefined,
+  errorCount: Number(process.env.ANALYTICS_ERROR_THRESHOLD) || undefined,
+  tokensUsed: Number(process.env.ANALYTICS_TOKENS_THRESHOLD) || undefined,
+};
+
+export type AlertHandler = (
+  agentId: string,
+  metric: keyof Thresholds,
+  value: number
+) => void | Promise<void>;
+
+const alertHandlers: AlertHandler[] = [];
+
+function ensureAgent(agentId: string) {
+  if (!metrics[agentId]) {
+    metrics[agentId] = { responseTimes: [], errorCount: 0, tokensUsed: 0 };
+  }
+}
+
+function notifyUpdate() {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new Event('analytics-updated'));
+  }
+}
+
+function checkAlert(agentId: string, metric: keyof Thresholds, value: number) {
+  const threshold = thresholds[metric];
+  if (threshold !== undefined && value > threshold) {
+    for (const handler of alertHandlers) {
+      try {
+        handler(agentId, metric, value);
+      } catch (err) {
+        console.error('Alert handler failed', err);
+      }
+    }
+  }
+}
+
+export function recordResponseTime(agentId: string, ms: number) {
+  ensureAgent(agentId);
+  metrics[agentId].responseTimes.push(ms);
+  checkAlert(agentId, 'responseTimeMs', ms);
+  notifyUpdate();
+}
+
+export function incrementError(agentId: string) {
+  ensureAgent(agentId);
+  metrics[agentId].errorCount += 1;
+  checkAlert(agentId, 'errorCount', metrics[agentId].errorCount);
+  notifyUpdate();
+}
+
+export function recordTokens(agentId: string, tokens: number) {
+  ensureAgent(agentId);
+  metrics[agentId].tokensUsed += tokens;
+  checkAlert(agentId, 'tokensUsed', metrics[agentId].tokensUsed);
+  notifyUpdate();
+}
+
+export function getMetrics(agentId: string): AgentMetrics | undefined {
+  return metrics[agentId];
+}
+
+export function getAllMetrics(): Record<string, AgentMetrics> {
+  return metrics;
+}
+
+export function setThresholds(newThresholds: Thresholds) {
+  thresholds = { ...thresholds, ...newThresholds };
+}
+
+export function onAlert(handler: AlertHandler) {
+  alertHandlers.push(handler);
+}
+
+export async function sendSlackAlert(
+  agentId: string,
+  metric: keyof Thresholds,
+  value: number
+) {
+  if (!process.env.SLACK_WEBHOOK_URL) return;
+  try {
+    await fetch(process.env.SLACK_WEBHOOK_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        text: `Agent ${agentId} exceeded ${metric}: ${value}`,
+      }),
+    });
+  } catch (err) {
+    console.error('Failed to send Slack alert', err);
+  }
+}
+
+export async function sendEmailAlert(
+  agentId: string,
+  metric: keyof Thresholds,
+  value: number
+) {
+  if (!process.env.EMAIL_WEBHOOK_URL) return;
+  try {
+    await fetch(process.env.EMAIL_WEBHOOK_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agentId, metric, value }),
+    });
+  } catch (err) {
+    console.error('Failed to send email alert', err);
+  }
+}
+
+// Register default alert handlers if environment variables are provided
+if (process.env.SLACK_WEBHOOK_URL) {
+  onAlert((agentId, metric, value) => {
+    sendSlackAlert(agentId, metric, value);
+  });
+}
+
+if (process.env.EMAIL_WEBHOOK_URL) {
+  onAlert((agentId, metric, value) => {
+    sendEmailAlert(agentId, metric, value);
+  });
+}

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -1,12 +1,20 @@
 import OpenAI from 'openai';
+import type { AudioSpeechCreateParams } from 'openai/resources/audio/speech';
 import { ModelConfig, ChatMessage } from '@/types/agent';
+import {
+  recordResponseTime,
+  recordTokens,
+  incrementError,
+} from './analytics';
 
 export class APIClient {
   private config: ModelConfig;
-  private client: any;
+  private client!: OpenAI;
+  private agentId?: string;
 
-  constructor(config: ModelConfig) {
+  constructor(config: ModelConfig, agentId?: string) {
     this.config = config;
+    this.agentId = agentId;
     this.initializeClient();
   }
 
@@ -45,6 +53,7 @@ export class APIClient {
     temperature: number = 0.7,
     maxTokens: number = 1000
   ): Promise<string> {
+    const start = Date.now();
     try {
       const formattedMessages = [
         { role: 'system', content: systemPrompt },
@@ -63,6 +72,11 @@ export class APIClient {
             temperature,
             max_tokens: maxTokens,
           });
+          if (this.agentId) {
+            recordResponseTime(this.agentId, Date.now() - start);
+            const tokens = response.usage?.total_tokens;
+            if (tokens) recordTokens(this.agentId, tokens);
+          }
           return response.choices[0]?.message?.content || '';
 
         case 'azure-openai':
@@ -72,30 +86,44 @@ export class APIClient {
             temperature,
             max_tokens: maxTokens,
           });
+          if (this.agentId) {
+            recordResponseTime(this.agentId, Date.now() - start);
+            const tokens = azureResponse.usage?.total_tokens;
+            if (tokens) recordTokens(this.agentId, tokens);
+          }
           return azureResponse.choices[0]?.message?.content || '';
 
         default:
           throw new Error(`Unsupported provider: ${this.config.provider}`);
       }
     } catch (error) {
+      if (this.agentId) incrementError(this.agentId);
       console.error('API Error:', error);
       throw new Error('Failed to send message to AI provider');
     }
   }
 
-  async generateSpeech(text: string, voice: string = 'alloy'): Promise<ArrayBuffer> {
+  async generateSpeech(
+    text: string,
+    voice: AudioSpeechCreateParams['voice'] = 'alloy'
+  ): Promise<ArrayBuffer> {
     if (this.config.provider !== 'openai') {
       throw new Error('Speech generation only supported with OpenAI');
     }
 
+    const start = Date.now();
     try {
       const response = await this.client.audio.speech.create({
         model: 'tts-1',
-        voice: voice as any,
+        voice,
         input: text,
       });
+      if (this.agentId) {
+        recordResponseTime(this.agentId, Date.now() - start);
+      }
       return await response.arrayBuffer();
     } catch (error) {
+      if (this.agentId) incrementError(this.agentId);
       console.error('Speech generation error:', error);
       throw new Error('Failed to generate speech');
     }
@@ -106,13 +134,18 @@ export class APIClient {
       throw new Error('Audio transcription only supported with OpenAI');
     }
 
+    const start = Date.now();
     try {
       const response = await this.client.audio.transcriptions.create({
         file: audioFile,
         model: 'whisper-1',
       });
+      if (this.agentId) {
+        recordResponseTime(this.agentId, Date.now() - start);
+      }
       return response.text;
     } catch (error) {
+      if (this.agentId) incrementError(this.agentId);
       console.error('Transcription error:', error);
       throw new Error('Failed to transcribe audio');
     }


### PR DESCRIPTION
## Summary
- add analytics library to track response times, errors, and token usage
- instrument API client and session store to record metrics
- create analytics dashboard component for per-agent stats

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b198e9e2e483259a077b84cf455a38