### PR TITLE
fix: align agent API route with Next.js 15

### DIFF
--- a/src/app/api/marketplace/agents/[id]/route.ts
+++ b/src/app/api/marketplace/agents/[id]/route.ts
@@ -1,11 +1,12 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { marketplaceStore } from '@/lib/marketplace-store';
 
 export async function GET(
-  request: Request,
-  { params }: { params: { id: string } }
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
 ) {
-  const agent = marketplaceStore.getAgent(params.id);
+  const { id } = await params;
+  const agent = marketplaceStore.getAgent(id);
   if (!agent) {
     return NextResponse.json({ error: 'Agent not found' }, { status: 404 });
   }


### PR DESCRIPTION
## Summary
- handle dynamic agent requests using `NextRequest` and async params to match Next.js 15 route types

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build` (fails: Failed to fetch `Geist` fonts)


------
https://chatgpt.com/codex/tasks/task_e_68b19ae45e84832599f57b4e2104584d