### PR TITLE
Add toast feedback and disable duplicate agent sharing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "react-dnd": "^16.0.1",
         "react-dnd-html5-backend": "^16.0.1",
         "react-dom": "19.1.0",
+        "react-hot-toast": "^2.4.1",
         "reactflow": "^11.11.4",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7",
@@ -4225,7 +4226,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-color": {
@@ -5504,6 +5504,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
       }
     },
     "node_modules/gopd": {
@@ -7216,6 +7225,22 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.4.1.tgz",
+      "integrity": "sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==",
+      "license": "MIT",
+      "dependencies": {
+        "goober": "^2.1.10"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
   "name": "agents-sandbox",
   "version": "0.1.0",
   "private": true,
-    "scripts": {
-      "dev": "next dev --turbopack",
-      "build": "next build --turbopack",
-      "start": "next start",
-      "lint": "eslint",
-      "plugins": "tsx src/lib/plugin-system.ts",
-      "scaffold:plugin": "tsx scripts/scaffold-plugin.ts"
-    },
+  "scripts": {
+    "dev": "next dev --turbopack",
+    "build": "next build --turbopack",
+    "start": "next start",
+    "lint": "eslint",
+    "plugins": "tsx src/lib/plugin-system.ts",
+    "scaffold:plugin": "tsx scripts/scaffold-plugin.ts"
+  },
   "dependencies": {
     "@azure/openai": "^2.0.0",
     "@dnd-kit/core": "^6.3.1",
@@ -29,6 +29,7 @@
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "19.1.0",
+    "react-hot-toast": "^2.4.1",
     "reactflow": "^11.11.4",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",

--- a/src/components/agents/DraggableAgentCard.tsx
+++ b/src/components/agents/DraggableAgentCard.tsx
@@ -22,6 +22,7 @@ interface DraggableAgentCardProps {
   onStartChat?: (agent: AgentConfig) => void;
   onStartVoice?: (agent: AgentConfig) => void;
   onShare?: (agent: AgentConfig) => void;
+  shareDisabled?: boolean;
 }
 
 export const DraggableAgentCard: React.FC<DraggableAgentCardProps> = ({
@@ -30,7 +31,8 @@ export const DraggableAgentCard: React.FC<DraggableAgentCardProps> = ({
   onDelete,
   onStartChat,
   onStartVoice,
-  onShare
+  onShare,
+  shareDisabled,
 }) => {
   const {
     attributes,
@@ -136,7 +138,8 @@ export const DraggableAgentCard: React.FC<DraggableAgentCardProps> = ({
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   onClick={() => onShare?.(agent)}
-                  className="hover:bg-green-50 hover:text-green-700"
+                  disabled={shareDisabled}
+                  className={`hover:bg-green-50 hover:text-green-700 ${shareDisabled ? 'opacity-50 cursor-not-allowed' : ''}`}
                 >
                   <Share2 className="mr-2 h-4 w-4" />
                   Share to Marketplace


### PR DESCRIPTION
## Summary
- add react-hot-toast for user notifications
- prevent repeated agent sharing while request is pending or already shared
- surface server validation errors when sharing agents

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b19cd1bb1483258a05c15a1a941b8f