### PR TITLE
feat: use js-tiktoken for token counting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@radix-ui/react-toast": "^1.2.15",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "js-tiktoken": "^1.0.21",
         "lucide-react": "^0.542.0",
         "next": "15.5.2",
         "openai": "^5.16.0",
@@ -3990,6 +3991,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -6162,6 +6183,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tiktoken": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.5.1"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -2,14 +2,15 @@
   "name": "agents-sandbox",
   "version": "0.1.0",
   "private": true,
-    "scripts": {
-      "dev": "next dev --turbopack",
-      "build": "next build --turbopack",
-      "start": "next start",
-      "lint": "eslint",
-      "plugins": "tsx src/lib/plugin-system.ts",
-      "scaffold:plugin": "tsx scripts/scaffold-plugin.ts"
-    },
+  "scripts": {
+    "dev": "next dev --turbopack",
+    "build": "next build --turbopack",
+    "start": "next start",
+    "lint": "eslint",
+    "plugins": "tsx src/lib/plugin-system.ts",
+    "scaffold:plugin": "tsx scripts/scaffold-plugin.ts",
+    "test": "tsx --test src/**/*.test.ts"
+  },
   "dependencies": {
     "@azure/openai": "^2.0.0",
     "@dnd-kit/core": "^6.3.1",
@@ -22,6 +23,7 @@
     "@radix-ui/react-toast": "^1.2.15",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "js-tiktoken": "^1.0.21",
     "lucide-react": "^0.542.0",
     "next": "15.5.2",
     "openai": "^5.16.0",

--- a/src/lib/agent-store.ts
+++ b/src/lib/agent-store.ts
@@ -114,10 +114,8 @@ class AgentStore {
     session.messages.push(newMessage);
     session.updatedAt = new Date();
 
-    // Approximate token usage by word count
     if (newMessage.agentId) {
-      const tokens = newMessage.content.split(/\s+/).filter(Boolean).length;
-      recordTokens(newMessage.agentId, tokens);
+      recordTokens(newMessage.agentId, newMessage.content);
     }
 
     this.sessions.set(sessionId, session);

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,3 +1,5 @@
+import { countTokens } from './utils';
+
 export interface AgentMetrics {
   responseTimes: number[];
   errorCount: number;
@@ -64,8 +66,10 @@ export function incrementError(agentId: string) {
   notifyUpdate();
 }
 
-export function recordTokens(agentId: string, tokens: number) {
+export function recordTokens(agentId: string, textOrTokens: string | number) {
   ensureAgent(agentId);
+  const tokens =
+    typeof textOrTokens === 'number' ? textOrTokens : countTokens(textOrTokens);
   metrics[agentId].tokensUsed += tokens;
   checkAlert(agentId, 'tokensUsed', metrics[agentId].tokensUsed);
   notifyUpdate();

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { countTokens } from './utils';
+import { recordTokens, getMetrics } from './analytics';
+
+test('countTokens counts tokens using tiktoken', () => {
+  assert.equal(countTokens('Hello world'), 2);
+});
+
+test('recordTokens counts tokens from text', () => {
+  const agentId = 'test-agent';
+  recordTokens(agentId, 'Hello world from tests');
+  const metrics = getMetrics(agentId);
+  assert.equal(metrics?.tokensUsed, countTokens('Hello world from tests'));
+});

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,5 @@
 import { type ClassValue, clsx } from "clsx";
+import { encodingForModel } from "js-tiktoken";
 import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
@@ -45,4 +46,15 @@ export function getModelsByProvider(provider: string): string[] {
     default:
       return [];
   }
+}
+
+const encoders: Record<string, ReturnType<typeof encodingForModel>> = {};
+
+export function countTokens(text: string, model = 'gpt-3.5-turbo'): number {
+  let encoder = encoders[model];
+  if (!encoder) {
+    encoder = encodingForModel(model);
+    encoders[model] = encoder;
+  }
+  return encoder.encode(text).length;
 }


### PR DESCRIPTION
## Summary
- add js-tiktoken dependency and countTokens utility
- track token usage with tokenizer instead of word splitting
- add tests covering token counting

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b19cd4eedc83259f9541a04a8c71cb