### PR TITLE
feat: add plugin settings and persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 # misc
 .DS_Store
 *.pem
+plugins/plugin-state.json
 
 # debug
 npm-debug.log*

--- a/package.json
+++ b/package.json
@@ -2,14 +2,15 @@
   "name": "agents-sandbox",
   "version": "0.1.0",
   "private": true,
-    "scripts": {
-      "dev": "next dev --turbopack",
-      "build": "next build --turbopack",
-      "start": "next start",
-      "lint": "eslint",
-      "plugins": "tsx src/lib/plugin-system.ts",
-      "scaffold:plugin": "tsx scripts/scaffold-plugin.ts"
-    },
+  "scripts": {
+    "dev": "next dev --turbopack",
+    "build": "next build --turbopack",
+    "start": "next start",
+    "lint": "eslint",
+    "plugins": "tsx src/lib/plugin-system.ts",
+    "scaffold:plugin": "tsx scripts/scaffold-plugin.ts",
+    "test": "tsx --test src/**/*.test.ts"
+  },
   "dependencies": {
     "@azure/openai": "^2.0.0",
     "@dnd-kit/core": "^6.3.1",

--- a/src/app/plugins/plugin-settings.tsx
+++ b/src/app/plugins/plugin-settings.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useState } from 'react';
+import type { Plugin } from '@/lib/plugin-system';
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+
+interface PluginSettingsProps {
+  plugin: Plugin;
+  action: (formData: FormData) => void | Promise<void>;
+}
+
+export default function PluginSettings({ plugin, action }: PluginSettingsProps) {
+  const [options, setOptions] = useState(
+    JSON.stringify(plugin.options ?? {}, null, 2),
+  );
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <button className="rounded border px-2 py-1 text-sm">Settings</button>
+      </DialogTrigger>
+      <DialogContent>
+        <form action={action} className="space-y-4">
+          <DialogHeader>
+            <DialogTitle>{plugin.name} Settings</DialogTitle>
+          </DialogHeader>
+          <input type="hidden" name="id" value={plugin.id} />
+          <label className="flex items-center space-x-2">
+            <input
+              type="checkbox"
+              name="enabled"
+              defaultChecked={plugin.enabled}
+              className="h-4 w-4"
+            />
+            <span>Enabled</span>
+          </label>
+          <div>
+            <label className="mb-1 block text-sm font-medium">Options (JSON)</label>
+            <textarea
+              name="options"
+              value={options}
+              onChange={(e) => setOptions(e.target.value)}
+              className="h-40 w-full rounded border p-2 font-mono text-sm"
+            />
+          </div>
+          <DialogFooter>
+            <button
+              type="submit"
+              className="rounded border px-4 py-1 text-sm"
+            >
+              Save
+            </button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/src/lib/plugin-system.test.ts
+++ b/src/lib/plugin-system.test.ts
@@ -1,0 +1,53 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import {
+  loadPlugins,
+  getPlugins,
+  enablePlugin,
+  disablePlugin,
+  updatePluginOptions,
+} from './plugin-system';
+
+function createTempPluginDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'plugins-'));
+  const pluginFile = path.join(dir, 'sample.ts');
+  fs.writeFileSync(
+    pluginFile,
+    `export default { id: 'sample', name: 'Sample Plugin' };`,
+  );
+  return dir;
+}
+
+test('plugin enable/disable persists', async () => {
+  const dir = createTempPluginDir();
+  await loadPlugins(dir);
+  let plugin = getPlugins().find((p) => p.id === 'sample');
+  assert(plugin);
+  assert.strictEqual(plugin!.enabled, false);
+
+  await enablePlugin('sample');
+  await loadPlugins(dir);
+  plugin = getPlugins().find((p) => p.id === 'sample');
+  assert(plugin);
+  assert.strictEqual(plugin!.enabled, true);
+
+  await disablePlugin('sample');
+  await loadPlugins(dir);
+  plugin = getPlugins().find((p) => p.id === 'sample');
+  assert(plugin);
+  assert.strictEqual(plugin!.enabled, false);
+});
+
+test('plugin options persist', async () => {
+  const dir = createTempPluginDir();
+  await loadPlugins(dir);
+  await updatePluginOptions('sample', { greeting: 'hi' });
+  await loadPlugins(dir);
+  const plugin = getPlugins().find((p) => p.id === 'sample');
+  assert(plugin);
+  assert.deepStrictEqual(plugin!.options, { greeting: 'hi' });
+});
+

--- a/src/lib/plugin-system.ts
+++ b/src/lib/plugin-system.ts
@@ -5,22 +5,62 @@ import { pathToFileURL, fileURLToPath } from 'url';
 export interface Plugin {
   id: string;
   name: string;
-  onLoad?: () => void | Promise<void>;
-  onEnable?: () => void | Promise<void>;
+  onLoad?: (options?: Record<string, unknown>) => void | Promise<void>;
+  onEnable?: (options?: Record<string, unknown>) => void | Promise<void>;
   onDisable?: () => void | Promise<void>;
   enabled?: boolean;
+  options?: Record<string, unknown>;
+  warning?: string;
+  error?: string;
+}
+
+interface PluginState {
+  enabled: boolean;
+  options?: Record<string, unknown>;
 }
 
 const registry = new Map<string, Plugin>();
+let state: Record<string, PluginState> = {};
+let stateFilePath = path.join(process.cwd(), 'plugins', 'plugin-state.json');
 
-export function registerPlugin(plugin: Plugin): void {
+function loadState(): void {
+  if (fs.existsSync(stateFilePath)) {
+    try {
+      state = JSON.parse(fs.readFileSync(stateFilePath, 'utf8'));
+    } catch {
+      state = {};
+    }
+  } else {
+    state = {};
+  }
+}
+
+function saveState(): void {
+  fs.mkdirSync(path.dirname(stateFilePath), { recursive: true });
+  fs.writeFileSync(stateFilePath, JSON.stringify(state, null, 2));
+}
+
+export async function registerPlugin(plugin: Plugin): Promise<void> {
   if (registry.has(plugin.id)) {
     throw new Error(`Plugin with id "${plugin.id}" already registered`);
   }
 
-  const entry = { ...plugin, enabled: plugin.enabled ?? false };
+  const persisted = state[plugin.id];
+  const entry: Plugin = {
+    ...plugin,
+    enabled: persisted?.enabled ?? plugin.enabled ?? false,
+    options: { ...plugin.options, ...persisted?.options },
+  };
+
   registry.set(plugin.id, entry);
-  plugin.onLoad?.();
+  try {
+    await plugin.onLoad?.(entry.options);
+  } catch (err) {
+    entry.error = String(err);
+  }
+  if (entry.enabled) {
+    await plugin.onEnable?.(entry.options);
+  }
 }
 
 export function getPlugins(): Plugin[] {
@@ -31,7 +71,9 @@ export async function enablePlugin(id: string): Promise<void> {
   const plugin = registry.get(id);
   if (plugin && !plugin.enabled) {
     plugin.enabled = true;
-    await plugin.onEnable?.();
+    await plugin.onEnable?.(plugin.options);
+    state[id] = { ...state[id], enabled: true, options: plugin.options };
+    saveState();
   }
 }
 
@@ -40,21 +82,48 @@ export async function disablePlugin(id: string): Promise<void> {
   if (plugin && plugin.enabled) {
     plugin.enabled = false;
     await plugin.onDisable?.();
+    state[id] = { ...state[id], enabled: false, options: plugin.options };
+    saveState();
+  }
+}
+
+export async function updatePluginOptions(
+  id: string,
+  options: Record<string, unknown>,
+): Promise<void> {
+  const plugin = registry.get(id);
+  if (plugin) {
+    plugin.options = options;
+    state[id] = { ...state[id], enabled: plugin.enabled ?? false, options };
+    saveState();
   }
 }
 
 export async function loadPlugins(dir = path.join(process.cwd(), 'plugins')): Promise<void> {
+  registry.clear();
+  stateFilePath = path.join(dir, 'plugin-state.json');
+  loadState();
   if (!fs.existsSync(dir)) return;
   const files = fs
     .readdirSync(dir)
     .filter((f) => f.endsWith('.ts') || f.endsWith('.js') || f.endsWith('.mjs'));
 
   for (const file of files) {
-    const url = pathToFileURL(path.join(dir, file)).href;
-    const mod = await import(url);
-    const plugin: Plugin | undefined = mod.default;
-    if (plugin) {
-      registerPlugin(plugin);
+    const id = path.basename(file, path.extname(file));
+    try {
+      const url = pathToFileURL(path.join(dir, file)).href;
+      const mod = await import(url);
+      const plugin: Plugin | undefined = mod.default;
+      if (plugin) {
+        await registerPlugin(plugin);
+      }
+    } catch (err) {
+      registry.set(id, {
+        id,
+        name: id,
+        enabled: false,
+        error: String(err),
+      });
     }
   }
 }


### PR DESCRIPTION
## Summary
- add persistent plugin system with error handling
- configure plugins via settings dialog
- test plugin toggling and configuration

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b19ce5ddd88325a070e0691ea78036