### PR TITLE
feat: add API rate limiting and sanitize inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## API Rate Limiting
+
+All API routes are limited to 100 requests per minute per IP address. Clients exceeding this limit will receive a `429 Too Many Requests` response.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@radix-ui/react-toast": "^1.2.15",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "lru-cache": "^11.1.0",
         "lucide-react": "^0.542.0",
         "next": "15.5.2",
         "openai": "^5.16.0",
@@ -27,6 +28,7 @@
         "react-dnd-html5-backend": "^16.0.1",
         "react-dom": "19.1.0",
         "reactflow": "^11.11.4",
+        "sanitize-html": "^2.17.0",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7",
         "uuid": "^11.1.0"
@@ -4418,6 +4420,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -4494,6 +4505,61 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -4528,6 +4594,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -4753,7 +4831,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -5636,6 +5713,25 @@
         "react-is": "^16.7.0"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -5975,6 +6071,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-regex": {
@@ -6553,6 +6658,15 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
+      "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/lucide-react": {
       "version": "0.542.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.542.0.tgz",
@@ -7020,6 +7134,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -7080,7 +7200,6 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7493,6 +7612,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sanitize-html": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.0.tgz",
+      "integrity": "sha512-dLAADUSS8rBwhaevT12yCezvioCA+bmUTPH/u57xKPT8d++voeYE6HeluA/bPbQ15TwDBG2ii+QZIEmYx8VdxA==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^8.0.0",
+        "is-plain-object": "^5.0.0",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
       }
     },
     "node_modules/scheduler": {

--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
   "name": "agents-sandbox",
   "version": "0.1.0",
   "private": true,
-    "scripts": {
-      "dev": "next dev --turbopack",
-      "build": "next build --turbopack",
-      "start": "next start",
-      "lint": "eslint",
-      "plugins": "tsx src/lib/plugin-system.ts",
-      "scaffold:plugin": "tsx scripts/scaffold-plugin.ts"
-    },
+  "scripts": {
+    "dev": "next dev --turbopack",
+    "build": "next build --turbopack",
+    "start": "next start",
+    "lint": "eslint",
+    "plugins": "tsx src/lib/plugin-system.ts",
+    "scaffold:plugin": "tsx scripts/scaffold-plugin.ts"
+  },
   "dependencies": {
     "@azure/openai": "^2.0.0",
     "@dnd-kit/core": "^6.3.1",
@@ -22,6 +22,7 @@
     "@radix-ui/react-toast": "^1.2.15",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "lru-cache": "^11.1.0",
     "lucide-react": "^0.542.0",
     "next": "15.5.2",
     "openai": "^5.16.0",
@@ -30,6 +31,7 @@
     "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "19.1.0",
     "reactflow": "^11.11.4",
+    "sanitize-html": "^2.17.0",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
     "uuid": "^11.1.0"

--- a/src/app/api/_middleware.ts
+++ b/src/app/api/_middleware.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server';
+import LRU from 'lru-cache';
+
+const rateLimit = new LRU<string, number>({ max: 5000, ttl: 60 * 1000 });
+const LIMIT = 100;
+
+export function middleware(request: NextRequest) {
+  const ip = request.ip ?? '127.0.0.1';
+  const hits = rateLimit.get(ip) ?? 0;
+  if (hits >= LIMIT) {
+    return NextResponse.json({ error: 'Too Many Requests' }, { status: 429 });
+  }
+  rateLimit.set(ip, hits + 1);
+  return NextResponse.next();
+}

--- a/src/app/api/marketplace/agents/[id]/route.ts
+++ b/src/app/api/marketplace/agents/[id]/route.ts
@@ -1,12 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { marketplaceStore } from '@/lib/marketplace-store';
+import sanitizeHtml from 'sanitize-html';
 
 export async function GET(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id } = await params;
-  const agent = marketplaceStore.getAgent(id);
+  const agentId = sanitizeHtml(id);
+  const agent = marketplaceStore.getAgent(agentId);
   if (!agent) {
     return NextResponse.json({ error: 'Agent not found' }, { status: 404 });
   }

--- a/src/app/api/marketplace/agents/route.ts
+++ b/src/app/api/marketplace/agents/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { marketplaceStore } from '@/lib/marketplace-store';
 import { AgentConfig } from '@/types/agent';
+import sanitizeHtml from 'sanitize-html';
 
 export async function GET() {
   const agents = marketplaceStore.listAgents();
@@ -9,6 +10,14 @@ export async function GET() {
 
 export async function POST(request: Request) {
   const data: AgentConfig = await request.json();
-  const agent = marketplaceStore.publishAgent(data);
+  const sanitize = (value: string) => sanitizeHtml(value);
+  const cleaned: AgentConfig = {
+    ...data,
+    id: sanitize(data.id),
+    name: sanitize(data.name),
+    description: sanitize(data.description),
+    systemPrompt: sanitize(data.systemPrompt),
+  };
+  const agent = marketplaceStore.publishAgent(cleaned);
   return NextResponse.json(agent, { status: 201 });
 }

--- a/src/app/api/workflows/route.ts
+++ b/src/app/api/workflows/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server';
+import { workflowStore } from '@/lib/workflow-store';
+import { WorkflowTemplate } from '@/types/workflow';
+import sanitizeHtml from 'sanitize-html';
+
+const clean = (v: string) => sanitizeHtml(v);
+
+function sanitizeWorkflow(
+  data: Omit<WorkflowTemplate, 'id' | 'createdAt' | 'updatedAt'>,
+): Omit<WorkflowTemplate, 'id' | 'createdAt' | 'updatedAt'> {
+  return {
+    ...data,
+    name: clean(data.name),
+    nodes: data.nodes.map((n) => ({
+      ...n,
+      id: clean(n.id),
+      label: clean(n.label),
+    })),
+    edges: data.edges.map((e) => ({
+      ...e,
+      id: clean(e.id),
+      source: clean(e.source),
+      target: clean(e.target),
+      condition: e.condition ? clean(e.condition) : undefined,
+    })),
+  };
+}
+
+export async function GET() {
+  const workflows = workflowStore.getAllWorkflows();
+  return NextResponse.json(workflows);
+}
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  const data = sanitizeWorkflow(body);
+  const workflow = workflowStore.createWorkflow(data);
+  return NextResponse.json(workflow, { status: 201 });
+}


### PR DESCRIPTION
## Summary
- add LRU-based API rate limiter middleware returning 429 on excessive requests
- sanitize user input in marketplace and workflow API handlers
- document request limits in the README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b19ce0743c83258b00183b477e68c5