### PR TITLE
feat: broadcast analytics and session events

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
       "start": "next start",
       "lint": "eslint",
       "plugins": "tsx src/lib/plugin-system.ts",
-      "scaffold:plugin": "tsx scripts/scaffold-plugin.ts"
-    },
+    "scaffold:plugin": "tsx scripts/scaffold-plugin.ts",
+    "test": "node --test -r tsx tests/events.test.ts"
+  },
   "dependencies": {
     "@azure/openai": "^2.0.0",
     "@dnd-kit/core": "^6.3.1",

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest } from 'next/server';
+
+export const runtime = 'nodejs';
+
+const clients = new Set<ReadableStreamDefaultController<Uint8Array>>();
+const encoder = new TextEncoder();
+
+export function GET(req: NextRequest) {
+  let controller: ReadableStreamDefaultController<Uint8Array>;
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) {
+      controller = c;
+      clients.add(c);
+      c.enqueue(encoder.encode(': connected\n\n'));
+    },
+    cancel() {
+      clients.delete(controller);
+    },
+  });
+
+  req.signal.addEventListener('abort', () => {
+    clients.delete(controller);
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    },
+  });
+}
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const message = `event: ${body.type}\ndata: ${JSON.stringify(body.data)}\n\n`;
+  const payload = encoder.encode(message);
+  for (const client of clients) {
+    client.enqueue(payload);
+  }
+  return new Response(null, { status: 204 });
+}

--- a/tests/events.test.ts
+++ b/tests/events.test.ts
@@ -1,0 +1,40 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { GET, POST } from '../src/app/api/events/route';
+
+const decoder = new TextDecoder();
+
+async function openStream() {
+  const res = GET(new Request('http://localhost/api/events'));
+  const reader = res.body!.getReader();
+  await reader.read(); // discard initial comment
+  return reader;
+}
+
+test('broadcasts session events to clients', async () => {
+  const reader = await openStream();
+  await POST(new Request('http://localhost/api/events', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ type: 'session', data: [{ id: '1' }] }),
+  }));
+  const { value } = await reader.read();
+  const message = decoder.decode(value);
+  assert.ok(message.includes('event: session'));
+  assert.ok(message.includes('"id":"1"'));
+  await reader.cancel();
+});
+
+test('broadcasts analytics events to clients', async () => {
+  const reader = await openStream();
+  await POST(new Request('http://localhost/api/events', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ type: 'analytics', data: { a: { responseTimes: [1], errorCount: 0, tokensUsed: 0 } } }),
+  }));
+  const { value } = await reader.read();
+  const message = decoder.decode(value);
+  assert.ok(message.includes('event: analytics'));
+  assert.ok(message.includes('responseTimes'));
+  await reader.cancel();
+});


### PR DESCRIPTION
## Summary
- add Server-Sent Events endpoint at `/api/events`
- broadcast session updates and analytics metrics and sync stores via SSE
- test SSE broadcasting for sessions and analytics

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b19cfd2af483259a1efa0f2962c2c5