### PR TITLE
feat: add import/export for agents and workflows

### DIFF
--- a/docs/json-schema.md
+++ b/docs/json-schema.md
@@ -1,0 +1,65 @@
+# Import/Export JSON Schemas
+
+This project supports exchanging agent and workflow definitions using JSON files.
+
+## Agents
+
+Agent files should contain an object with an `agents` array. Each agent entry uses the following structure:
+
+```json
+{
+  "agents": [
+    {
+      "name": "My Agent",
+      "type": "chat",
+      "description": "What the agent does",
+      "systemPrompt": "You are helpful",
+      "modelConfig": {
+        "provider": "openai",
+        "apiKey": "sk-...",
+        "model": "gpt-4o",
+        "baseUrl": "https://api.openai.com",
+        "apiVersion": "v1"
+      },
+      "temperature": 0.7,
+      "maxTokens": 1024,
+      "voiceSettings": {
+        "voice": "alloy",
+        "speed": 1,
+        "pitch": 0
+      }
+    }
+  ]
+}
+```
+
+Identifiers and timestamps are generated on import and therefore omitted from the schema.
+
+## Workflows
+
+Workflow files describe a single workflow template:
+
+```json
+{
+  "name": "Sample Workflow",
+  "nodes": [
+    {
+      "id": "node-1",
+      "type": "task",
+      "label": "First task",
+      "data": {},
+      "position": { "x": 0, "y": 0 }
+    }
+  ],
+  "edges": [
+    {
+      "id": "edge-1",
+      "source": "node-1",
+      "target": "node-2",
+      "condition": "optional"
+    }
+  ]
+}
+```
+
+Each node `type` must be one of `task`, `condition`, `loop`, or `parallel`.

--- a/src/components/workflows/WorkflowBuilder.tsx
+++ b/src/components/workflows/WorkflowBuilder.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useState, useRef } from 'react';
 import ReactFlow, {
   Background,
   Controls,
@@ -14,9 +14,10 @@ import ReactFlow, {
 import 'reactflow/dist/style.css';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Download, Upload } from 'lucide-react';
 import { generateId } from '@/lib/utils';
 import { workflowStore } from '@/lib/workflow-store';
-import { WorkflowNodeType, WorkflowTemplate } from '@/types/workflow';
+import { WorkflowNodeType, WorkflowTemplate, WorkflowNode, WorkflowEdge } from '@/types/workflow';
 
 export function WorkflowBuilder() {
   const [nodes, setNodes, onNodesChange] = useNodesState([]);
@@ -81,6 +82,79 @@ export function WorkflowBuilder() {
     );
   };
 
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleExport = () => {
+    const data = {
+      name,
+      nodes: nodes.map((n) => ({
+        id: n.id,
+        type: n.data.nodeType as WorkflowNodeType,
+        label: n.data.label as string,
+        data: n.data,
+        position: n.position,
+      })),
+      edges: edges.map((e) => ({
+        id: e.id,
+        source: e.source,
+        target: e.target,
+        condition: e.data?.condition,
+      })),
+    };
+    const blob = new Blob([JSON.stringify(data, null, 2)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'workflow.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleImport = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      try {
+        const data = JSON.parse(event.target?.result as string);
+        if (
+          typeof data.name !== 'string' ||
+          !Array.isArray(data.nodes) ||
+          !Array.isArray(data.edges)
+        ) {
+          throw new Error('Invalid workflow file');
+        }
+        setName(data.name);
+        setNodes(
+          data.nodes.map((n: WorkflowNode) => ({
+            id: n.id,
+            position: n.position,
+            data: { ...n.data, label: n.label, nodeType: n.type },
+          })),
+        );
+        setEdges(
+          data.edges.map((e: WorkflowEdge) => ({
+            id: e.id,
+            source: e.source,
+            target: e.target,
+            data: { condition: e.condition },
+          })),
+        );
+        workflowStore.createWorkflow({
+          name: data.name,
+          nodes: data.nodes,
+          edges: data.edges,
+        });
+      } catch (err) {
+        console.error('Failed to import workflow:', err);
+      }
+    };
+    reader.readAsText(file);
+    e.target.value = '';
+  };
+
   return (
     <div className="space-y-4">
       <div className="flex items-center gap-2">
@@ -94,6 +168,22 @@ export function WorkflowBuilder() {
         <Button variant="outline" onClick={handleLoad}>
           Load
         </Button>
+        <Button variant="outline" onClick={handleExport}>
+          <Download className="mr-2 h-4 w-4" /> Export
+        </Button>
+        <Button
+          variant="outline"
+          onClick={() => fileInputRef.current?.click()}
+        >
+          <Upload className="mr-2 h-4 w-4" /> Import
+        </Button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="application/json"
+          onChange={handleImport}
+          className="hidden"
+        />
       </div>
       <div className="flex gap-2">
         <Button size="sm" onClick={() => addNode('task')}>


### PR DESCRIPTION
## Summary
- allow exporting and importing agent configs through dashboard
- support workflow JSON import/export in builder
- document JSON schemas for agents and workflows

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b19d0f66f883259cddba096feafc98