### PR TITLE
feat: persist agent sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Agents Sandbox exposes a lightweight API layer for interacting with plugins and 
 
 ## Persistence Layers
 
-The project ships with an in-memory store for rapid prototyping. Additional persistence strategies can be added by implementing the persistence interface described in [docs/persistence-layers.md](docs/persistence-layers.md).
+The project ships with an in-memory store for rapid prototyping. Agent chat sessions are persisted to `data/sessions.json` so conversations survive server restarts. Additional persistence strategies can be added by implementing the persistence interface described in [docs/persistence-layers.md](docs/persistence-layers.md).
 
 ## Developer Guidelines
 

--- a/docs/persistence-layers.md
+++ b/docs/persistence-layers.md
@@ -6,6 +6,10 @@ Agents Sandbox defaults to an in-memory store suited for development.
 
 Implement the persistence interface to back data with external stores such as databases or cloud storage. Each implementation should export `load` and `save` functions and declare required configuration.
 
+## Built-in File Persistence
+
+The project includes a simple file-based persistence layer. Agent sessions are serialized as JSON and stored in `data/sessions.json` using the `readSessions` and `writeSessions` helpers. This allows session data to survive process restarts without requiring an external database.
+
 ## Migration Strategy
 
 When introducing new persistence layers, provide migration scripts to move data from the in-memory store.

--- a/src/app/api/agents/[id]/sessions/[sessionId]/route.ts
+++ b/src/app/api/agents/[id]/sessions/[sessionId]/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import { persistence } from '@/lib/persistence/file';
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: { id: string; sessionId: string } }
+) {
+  const sessions = await persistence.readSessions();
+  const filtered = sessions.filter(
+    s => !(s.id === params.sessionId && s.agentId === params.id)
+  );
+  const deleted = filtered.length !== sessions.length;
+  if (deleted) {
+    await persistence.writeSessions(filtered);
+  }
+  return NextResponse.json({ success: deleted });
+}

--- a/src/app/api/agents/[id]/sessions/route.ts
+++ b/src/app/api/agents/[id]/sessions/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+import { persistence } from '@/lib/persistence/file';
+import { AgentSession } from '@/types/agent';
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const sessions = await persistence.readSessions();
+  const filtered: AgentSession[] = sessions.filter(s => s.agentId === params.id);
+  return NextResponse.json(filtered);
+}

--- a/src/lib/persistence/file.ts
+++ b/src/lib/persistence/file.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'fs';
 import path from 'path';
+import { AgentSession } from '@/types/agent';
 
 const dataDir = path.join(process.cwd(), 'data');
 
@@ -24,4 +25,25 @@ async function write<T>(name: string, data: T): Promise<void> {
   await fs.writeFile(filePath, JSON.stringify(data, null, 2));
 }
 
-export const persistence = { read, write };
+function parseSession(raw: AgentSession): AgentSession {
+  return {
+    ...raw,
+    createdAt: new Date(raw.createdAt),
+    updatedAt: new Date(raw.updatedAt),
+    messages: raw.messages.map(m => ({
+      ...m,
+      timestamp: new Date(m.timestamp),
+    })),
+  };
+}
+
+async function readSessions(): Promise<AgentSession[]> {
+  const sessions = await read<AgentSession[]>('sessions', []);
+  return sessions.map(parseSession);
+}
+
+async function writeSessions(sessions: AgentSession[]): Promise<void> {
+  await write('sessions', sessions);
+}
+
+export const persistence = { read, write, readSessions, writeSessions };

--- a/tests/agent-session-persistence.test.ts
+++ b/tests/agent-session-persistence.test.ts
@@ -1,0 +1,39 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const sessionsFile = path.join(process.cwd(), 'data', 'sessions.json');
+
+async function cleanSessions() {
+  try {
+    await fs.unlink(sessionsFile);
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+  }
+}
+
+describe('agent session persistence', () => {
+  beforeEach(async () => {
+    await cleanSessions();
+    vi.resetModules();
+  });
+
+  it('persists sessions across restarts', async () => {
+    const { agentStore } = await import('@/lib/agent-store');
+    await agentStore.ready;
+    const session = agentStore.createSession('agent-1');
+    agentStore.addMessageToSession(session.id, {
+      role: 'user',
+      content: 'hello',
+      agentId: 'agent-1',
+    });
+    await agentStore.waitForPersistence();
+
+    vi.resetModules();
+    const { agentStore: newStore } = await import('@/lib/agent-store');
+    await newStore.ready;
+    const loaded = newStore.getSession(session.id);
+    expect(loaded).not.toBeNull();
+    expect(loaded?.messages.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add file-based helpers for reading and writing session data
- persist sessions in agent store and expose REST endpoints for listing and deleting
- document session persistence and add tests ensuring sessions survive restarts

## Testing
- `npm test` *(fails: No test suite found in some files)*
- `npx vitest run tests/agent-session-persistence.test.ts`
- `npm run lint` *(fails: Unexpected any, triple-slash reference)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a2e85d008325956a7da8a9f90ba3