### PR TITLE
feat: sandboxed plugin execution with permission warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,9 @@
         "reactflow": "^11.11.4",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7",
-        "uuid": "^11.1.0"
+        "uuid": "^11.1.0",
+        "vm2": "^3.9.19",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -45,9 +47,7 @@
         "tailwindcss": "^4",
         "tsx": "^4.20.5",
         "typescript": "^5",
-        "vitest": "^3.2.4",
-        "zod": "^3.25.76"
-
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -4097,7 +4097,6 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -4114,6 +4113,18 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -9259,6 +9270,23 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vm2": {
+      "version": "3.9.19",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.19.tgz",
+      "integrity": "sha512-J637XF0DHDMV57R6JyVsTak7nIL8gy5KH4r1HiwWLf/4GBbb5MKL5y7LpmF4A8E2nR6XmzpmMFQ7V7ppPTmUQg==",
+      "deprecated": "The library contains critical security issues and should not be used for production! The maintenance of the project has been discontinued. Consider migrating your code to isolated-vm.",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.7.0",
+        "acorn-walk": "^8.2.0"
+      },
+      "bin": {
+        "vm2": "bin/vm2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -9418,7 +9446,6 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
     "uuid": "^11.1.0",
+    "vm2": "^3.9.19",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/scripts/scaffold-plugin.ts
+++ b/scripts/scaffold-plugin.ts
@@ -19,11 +19,12 @@ if (fs.existsSync(filePath)) {
   process.exit(1);
 }
 
-const content = `import { Plugin } from '@/lib/plugin-system';
+const content = `import type { Plugin } from '@/lib/plugin-system';
 
 const plugin: Plugin = {
   id: '${name}',
   name: '${name.replace(/[-_]/g, ' ')}',
+  // permissions: ['fs'],
   onEnable: () => {
     console.log('${name} enabled');
   },

--- a/src/app/plugins/page.tsx
+++ b/src/app/plugins/page.tsx
@@ -47,15 +47,20 @@ export default async function PluginsPage() {
               </span>
               <PluginSettings plugin={plugin} action={updatePlugin} />
             </div>
-            {plugin.error && (
-              <div className="text-xs text-red-600">{plugin.error}</div>
-            )}
-            {plugin.warning && (
-              <div className="text-xs text-yellow-600">{plugin.warning}</div>
-            )}
-          </li>
-        ))}
-      </ul>
+          {plugin.error && (
+            <div className="text-xs text-red-600">{plugin.error}</div>
+          )}
+          {plugin.permissions?.length ? (
+            <div className="text-xs text-yellow-600">
+              Requires permissions: {plugin.permissions.join(', ')}
+            </div>
+          ) : null}
+          {plugin.warning && (
+            <div className="text-xs text-yellow-600">{plugin.warning}</div>
+          )}
+        </li>
+      ))}
+    </ul>
     </div>
   );
 }

--- a/src/lib/plugin-system.sandbox.test.ts
+++ b/src/lib/plugin-system.sandbox.test.ts
@@ -1,0 +1,25 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { loadPlugins, getPlugins } from './plugin-system';
+
+function createSandboxPluginDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sandbox-'));
+  const pluginFile = path.join(dir, 'sandbox.js');
+  fs.writeFileSync(
+    pluginFile,
+    "const secret = process.env.SECRET;\nmodule.exports = { default: { id: 'sandbox', name: 'Sandbox' } };",
+  );
+  return dir;
+}
+
+test('plugin cannot access process.env', async () => {
+  const dir = createSandboxPluginDir();
+  await loadPlugins(dir);
+  const plugin = getPlugins().find((p) => p.id.startsWith('sandbox'));
+  assert(plugin);
+  assert(plugin!.error);
+  assert.match(plugin!.error!, /env/);
+});

--- a/src/lib/plugin-system.ts
+++ b/src/lib/plugin-system.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
-import { pathToFileURL, fileURLToPath } from 'url';
+import { fileURLToPath } from 'url';
+import { Worker } from 'worker_threads';
 
 export interface Plugin {
   id: string;
@@ -10,6 +11,9 @@ export interface Plugin {
   onDisable?: () => void | Promise<void>;
   enabled?: boolean;
   options?: Record<string, unknown>;
+  permissions?: string[];
+  logs?: string[];
+  errors?: string[];
   warning?: string;
   error?: string;
 }
@@ -20,6 +24,8 @@ interface PluginState {
 }
 
 const registry = new Map<string, Plugin>();
+const workers = new Map<string, Worker>();
+const PLUGIN_TIMEOUT = 1000;
 let state: Record<string, PluginState> = {};
 let stateFilePath = path.join(process.cwd(), 'plugins', 'plugin-state.json');
 
@@ -40,6 +46,79 @@ function saveState(): void {
   fs.writeFileSync(stateFilePath, JSON.stringify(state, null, 2));
 }
 
+function callWorker(worker: Worker, method: string, options?: Record<string, unknown>): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const listener = (msg: any) => {
+      if (msg.type === 'result' && msg.method === method) {
+        worker.off('message', listener);
+        resolve();
+      } else if (msg.type === 'error' && msg.method === method) {
+        worker.off('message', listener);
+        reject(new Error(msg.error));
+      }
+    };
+    worker.on('message', listener);
+    worker.postMessage({ method, options, timeout: PLUGIN_TIMEOUT });
+  });
+}
+
+async function createWorker(filePath: string): Promise<{ worker: Worker; meta: { id: string; name: string; permissions?: string[] }; error?: string }>
+{
+  const worker = new Worker(
+    `import { parentPort, workerData } from 'worker_threads';
+import fs from 'fs';
+import { NodeVM } from 'vm2';
+import { transpileModule } from 'typescript';
+const file = workerData.file;
+let code = fs.readFileSync(file, 'utf8');
+if (file.endsWith('.ts')) {
+  code = transpileModule(code, { compilerOptions: { module: 1 } }).outputText;
+}
+const vm = new NodeVM({
+  console: 'redirect',
+  sandbox: {},
+  require: { external: false, builtin: [] },
+});
+vm.freeze(undefined, 'process');
+vm.on('console.log', (...args) => parentPort.postMessage({ type: 'log', data: args.join(' ') }));
+vm.on('console.error', (...args) => parentPort.postMessage({ type: 'consoleError', data: args.join(' ') }));
+let plugin;
+try {
+  plugin = vm.run(code, file).default;
+} catch (err) {
+  parentPort.postMessage({ type: 'loaded', error: String(err) });
+}
+if (plugin) {
+  parentPort.postMessage({ type: 'loaded', plugin: { id: plugin.id, name: plugin.name, permissions: plugin.permissions } });
+  parentPort.on('message', async (msg) => {
+    const { method, options, timeout } = msg;
+    try {
+      await Promise.race([
+        plugin[method]?.(options),
+        new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), timeout)),
+      ]);
+      parentPort.postMessage({ type: 'result', method });
+    } catch (err) {
+      parentPort.postMessage({ type: 'error', method, error: String(err) });
+    }
+  });
+}
+`,
+    { eval: true, type: 'module', workerData: { file: filePath } },
+  );
+
+  return new Promise((resolve, reject) => {
+    const onMessage = (msg: any) => {
+      if (msg.type === 'loaded') {
+        worker.off('message', onMessage);
+        resolve({ worker, meta: msg.plugin ?? { id: path.basename(filePath), name: path.basename(filePath) }, error: msg.error });
+      }
+    };
+    worker.on('message', onMessage);
+    worker.on('error', reject);
+  });
+}
+
 export async function registerPlugin(plugin: Plugin): Promise<void> {
   if (registry.has(plugin.id)) {
     throw new Error(`Plugin with id "${plugin.id}" already registered`);
@@ -50,6 +129,9 @@ export async function registerPlugin(plugin: Plugin): Promise<void> {
     ...plugin,
     enabled: persisted?.enabled ?? plugin.enabled ?? false,
     options: { ...plugin.options, ...persisted?.options },
+    permissions: plugin.permissions ?? [],
+    logs: plugin.logs ?? [],
+    errors: plugin.errors ?? [],
   };
 
   registry.set(plugin.id, entry);
@@ -59,7 +141,14 @@ export async function registerPlugin(plugin: Plugin): Promise<void> {
     entry.error = String(err);
   }
   if (entry.enabled) {
-    await plugin.onEnable?.(entry.options);
+    try {
+      await plugin.onEnable?.(entry.options);
+    } catch (err) {
+      entry.error = String(err);
+    }
+  }
+  if (entry.permissions.length) {
+    entry.warning = `Requests permissions: ${entry.permissions.join(', ')}`;
   }
 }
 
@@ -71,7 +160,11 @@ export async function enablePlugin(id: string): Promise<void> {
   const plugin = registry.get(id);
   if (plugin && !plugin.enabled) {
     plugin.enabled = true;
-    await plugin.onEnable?.(plugin.options);
+    try {
+      await plugin.onEnable?.(plugin.options);
+    } catch (err) {
+      plugin.error = String(err);
+    }
     state[id] = { ...state[id], enabled: true, options: plugin.options };
     saveState();
   }
@@ -81,7 +174,11 @@ export async function disablePlugin(id: string): Promise<void> {
   const plugin = registry.get(id);
   if (plugin && plugin.enabled) {
     plugin.enabled = false;
-    await plugin.onDisable?.();
+    try {
+      await plugin.onDisable?.();
+    } catch (err) {
+      plugin.error = String(err);
+    }
     state[id] = { ...state[id], enabled: false, options: plugin.options };
     saveState();
   }
@@ -101,6 +198,8 @@ export async function updatePluginOptions(
 
 export async function loadPlugins(dir = path.join(process.cwd(), 'plugins')): Promise<void> {
   registry.clear();
+  workers.forEach((w) => w.terminate());
+  workers.clear();
   stateFilePath = path.join(dir, 'plugin-state.json');
   loadState();
   if (!fs.existsSync(dir)) return;
@@ -111,12 +210,33 @@ export async function loadPlugins(dir = path.join(process.cwd(), 'plugins')): Pr
   for (const file of files) {
     const id = path.basename(file, path.extname(file));
     try {
-      const url = pathToFileURL(path.join(dir, file)).href;
-      const mod = await import(url);
-      const plugin: Plugin | undefined = mod.default;
-      if (plugin) {
-        await registerPlugin(plugin);
+      const filePath = path.join(dir, file);
+      const { worker, meta, error } = await createWorker(filePath);
+      const entry: Plugin = {
+        id: meta.id || id,
+        name: meta.name || id,
+        permissions: meta.permissions || [],
+        logs: [],
+        errors: [],
+      };
+
+      if (error) {
+        registry.set(entry.id, { ...entry, enabled: false, error });
+        worker.terminate();
+        continue;
       }
+
+      workers.set(entry.id, worker);
+      worker.on('message', (msg: any) => {
+        if (msg.type === 'log') entry.logs!.push(String(msg.data));
+        if (msg.type === 'consoleError') entry.errors!.push(String(msg.data));
+      });
+
+      entry.onLoad = (opts) => callWorker(worker, 'onLoad', opts);
+      entry.onEnable = (opts) => callWorker(worker, 'onEnable', opts);
+      entry.onDisable = () => callWorker(worker, 'onDisable');
+
+      await registerPlugin(entry);
     } catch (err) {
       registry.set(id, {
         id,


### PR DESCRIPTION
## Summary
- load plugins in worker-thread vm2 sandboxes with timeout and log capture
- surface requested permissions and warnings in plugin settings page
- scaffold plugins with permissions stub and add sandbox isolation test

## Testing
- `npm test` *(fails: No test suite found)*
- `node --import tsx --test src/lib/plugin-system.test.ts src/lib/utils.test.ts src/lib/plugin-system.sandbox.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b1a2ebba68832599ade1f9f9ea313b