### PR TITLE
Persist analytics metrics and add dashboard page

### DIFF
--- a/docs/developer-guidelines.md
+++ b/docs/developer-guidelines.md
@@ -15,3 +15,10 @@
 ## Documentation
 
 Update both this `docs/` directory and the root `README.md` whenever APIs or behavior change to keep documentation synchronized.
+
+## Analytics
+
+Metrics collected by `src/lib/analytics.ts` are persisted to `data/analytics-metrics.json`.
+The module flushes metrics to disk after each update and reloads them on startup so
+counts survive server restarts. A real-time dashboard is available at `/analytics` and
+refreshes automatically on `analytics-updated` events.

--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import AnalyticsDashboard from '@/components/analytics/AnalyticsDashboard';
+
+export default function AnalyticsPage() {
+  const [, setTick] = useState(0);
+
+  useEffect(() => {
+    const handler = () => setTick(t => t + 1);
+    window.addEventListener('analytics-updated', handler);
+    return () => window.removeEventListener('analytics-updated', handler);
+  }, []);
+
+  return (
+    <div className="container mx-auto p-6">
+      <h1 className="text-3xl font-bold mb-4">Analytics</h1>
+      <AnalyticsDashboard />
+    </div>
+  );
+}

--- a/tests/analytics-persistence.test.ts
+++ b/tests/analytics-persistence.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const metricsFile = path.join(process.cwd(), 'data', 'analytics-metrics.json');
+
+beforeEach(async () => {
+  await fs.rm(metricsFile, { force: true });
+  vi.resetModules();
+});
+
+afterEach(async () => {
+  await fs.rm(metricsFile, { force: true });
+});
+
+describe('analytics persistence', () => {
+  it('restores metrics after reload', async () => {
+    const analytics1 = await import('../src/lib/analytics');
+    analytics1.recordResponseTime('agent', 100);
+    analytics1.incrementError('agent');
+    analytics1.recordTokens('agent', 20);
+    await analytics1.writeMetrics();
+
+    vi.resetModules();
+    const analytics2 = await import('../src/lib/analytics');
+    const restored = analytics2.getMetrics('agent');
+    expect(restored).toEqual({
+      responseTimes: [100],
+      errorCount: 1,
+      tokensUsed: 20,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- persist analytics metrics to `data/analytics-metrics.json` and reload on startup
- add `/analytics` page with auto-refreshing dashboard
- document analytics storage and add persistence test

## Testing
- `npx vitest run tests/analytics-persistence.test.ts`
- `npx vitest run` *(fails: No test suite found in plugin-system.test.ts)*
- `npm run lint` *(fails: Unexpected any in several API routes)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a2ee5c5483258a5fe380ab01b01c