### PR TITLE
refactor api client with provider strategies

### DIFF
--- a/src/lib/api-client.test.ts
+++ b/src/lib/api-client.test.ts
@@ -1,19 +1,24 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { APIClient } from './api-client';
-import { getMetrics } from './analytics';
+import * as apiUtils from './api/utils';
 
 describe('APIClient retry logic', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    vi.spyOn(apiUtils, 'sleep').mockResolvedValue(undefined);
   });
 
   it('retries on transient failure and succeeds', async () => {
+    const metrics = {
+      incrementError: vi.fn(),
+      recordResponseTime: vi.fn(),
+      recordTokens: vi.fn(),
+    };
     const client = new APIClient(
       { provider: 'openai', apiKey: 'x', model: 'gpt', maxRetries: 2, timeoutMs: 1000 },
-      'agent-success'
+      'agent-success',
+      metrics
     );
-    // Mock sleep to avoid delays
-    vi.spyOn(client as unknown as { sleep: (ms: number) => Promise<void> }, 'sleep').mockResolvedValue(undefined);
 
     const mockCreate = vi
       .fn()
@@ -21,31 +26,36 @@ describe('APIClient retry logic', () => {
       .mockRejectedValueOnce(new Error('fail2'))
       .mockResolvedValue({ choices: [{ message: { content: 'ok' } }], usage: { total_tokens: 1 } });
 
-    (client as unknown as { client: Record<string, unknown> }).client = {
-      chat: { completions: { create: mockCreate } }
+    (client as any).provider.client = {
+      chat: { completions: { create: mockCreate } },
     };
 
     const result = await client.sendMessage([], 'sys');
     expect(result).toBe('ok');
     expect(mockCreate).toHaveBeenCalledTimes(3);
-    expect(getMetrics('agent-success')?.errorCount).toBe(2);
+    expect(metrics.incrementError).toHaveBeenCalledTimes(2);
   });
 
   it('fails after exceeding max retries', async () => {
+    const metrics = {
+      incrementError: vi.fn(),
+      recordResponseTime: vi.fn(),
+      recordTokens: vi.fn(),
+    };
     const client = new APIClient(
       { provider: 'openai', apiKey: 'x', model: 'gpt', maxRetries: 2, timeoutMs: 1000 },
-      'agent-fail'
+      'agent-fail',
+      metrics
     );
-    vi.spyOn(client as unknown as { sleep: (ms: number) => Promise<void> }, 'sleep').mockResolvedValue(undefined);
 
     const mockCreate = vi.fn().mockRejectedValue(new Error('always fail'));
-    (client as unknown as { client: Record<string, unknown> }).client = {
-      chat: { completions: { create: mockCreate } }
+    (client as any).provider.client = {
+      chat: { completions: { create: mockCreate } },
     };
 
     await expect(client.sendMessage([], 'sys')).rejects.toThrow(/Failed to send message/);
     expect(mockCreate).toHaveBeenCalledTimes(3);
-    expect(getMetrics('agent-fail')?.errorCount).toBe(3);
+    expect(metrics.incrementError).toHaveBeenCalledTimes(3);
+    expect(metrics.recordResponseTime).not.toHaveBeenCalled();
   });
 });
-

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -1,107 +1,45 @@
-import OpenAI from 'openai';
 import type { AudioSpeechCreateParams } from 'openai/resources/audio/speech';
-import type { ChatCompletionChunk } from 'openai/resources/chat/completions';
-import { ModelConfig, ChatMessage } from '@/types/agent';
-import {
-  recordResponseTime,
-  recordTokens,
-  incrementError,
-} from './analytics';
+import type { ModelConfig, ChatMessage } from '@/types/agent';
+import type { ProviderClient } from './api/ProviderClient';
+import { OpenAIClient } from './api/providers/OpenAIClient';
+import { AzureOpenAIClient } from './api/providers/AzureOpenAIClient';
+import { OpenRouterClient } from './api/providers/OpenRouterClient';
+import { ProviderOptions } from './api/ProviderClient';
 
-interface ChatCompletionResponse {
-  choices: { message?: { content?: string } }[];
-  usage?: { total_tokens?: number };
-}
-
-interface SpeechResponse {
-  arrayBuffer: () => Promise<ArrayBuffer>;
-}
-
-interface TranscriptionResponse {
-  text: string;
+export interface MetricsCallbacks {
+  recordResponseTime?: (agentId: string, ms: number) => void;
+  recordTokens?: (agentId: string, tokens: string | number) => void;
+  incrementError?: (agentId: string) => void;
 }
 
 export class APIClient {
+  private provider: ProviderClient;
   private config: ModelConfig;
-  private client!: OpenAI;
   private agentId?: string;
+  private metrics?: MetricsCallbacks;
 
-  constructor(config: ModelConfig, agentId?: string) {
+  constructor(config: ModelConfig, agentId?: string, metrics?: MetricsCallbacks) {
     this.config = config;
     this.agentId = agentId;
-    this.initializeClient();
+    this.metrics = metrics;
+    this.provider = this.createProvider();
   }
 
-  private initializeClient() {
+  private createProvider(): ProviderClient {
+    const onError: ProviderOptions['onError'] | undefined =
+      this.agentId && this.metrics?.incrementError
+        ? () => this.metrics!.incrementError!(this.agentId!)
+        : undefined;
     switch (this.config.provider) {
       case 'openai':
-        this.client = new OpenAI({
-          apiKey: this.config.apiKey,
-          dangerouslyAllowBrowser: true,
-        });
-        break;
+        return new OpenAIClient(this.config, { onError });
       case 'azure-openai':
-        // Azure OpenAI using OpenAI-compatible interface
-        this.client = new OpenAI({
-          apiKey: this.config.apiKey,
-          baseURL: this.config.baseUrl,
-          defaultQuery: { 'api-version': this.config.apiVersion || '2023-12-01-preview' },
-          dangerouslyAllowBrowser: true,
-        });
-        break;
+        return new AzureOpenAIClient(this.config, { onError });
       case 'openrouter':
-        this.client = new OpenAI({
-          apiKey: this.config.apiKey,
-          baseURL: this.config.baseUrl || 'https://openrouter.ai/api/v1',
-          dangerouslyAllowBrowser: true,
-        });
-        break;
+        return new OpenRouterClient(this.config, { onError });
       default:
         throw new Error(`Unsupported provider: ${this.config.provider}`);
     }
-  }
-
-  private async sleep(ms: number) {
-    return new Promise(resolve => setTimeout(resolve, ms));
-  }
-
-  private async withTimeout<T>(promise: Promise<T>, timeoutMs: number) {
-    if (!timeoutMs) return promise;
-    return new Promise<T>((resolve, reject) => {
-      const timer = setTimeout(() => {
-        reject(new Error(`Request timed out after ${timeoutMs}ms`));
-      }, timeoutMs);
-      promise
-        .then(res => {
-          clearTimeout(timer);
-          resolve(res);
-        })
-        .catch(err => {
-          clearTimeout(timer);
-          reject(err);
-        });
-    });
-  }
-
-  private async retryWithBackoff<T>(operation: (attempt: number) => Promise<T>) {
-    const maxRetries = this.config.maxRetries ?? 3;
-    const baseDelay = 500;
-    let attempt = 0;
-    let lastError: unknown;
-    while (attempt <= maxRetries) {
-      try {
-        return await operation(attempt);
-      } catch (err) {
-        lastError = err;
-        if (this.agentId) incrementError(this.agentId);
-        if (attempt === maxRetries) break;
-        const delay = baseDelay * 2 ** attempt;
-        await this.sleep(delay);
-      }
-      attempt++;
-    }
-    const message = lastError instanceof Error ? lastError.message : String(lastError);
-    throw new Error(`Operation failed after ${maxRetries + 1} attempts: ${message}`);
   }
 
   async sendMessage(
@@ -111,33 +49,20 @@ export class APIClient {
     maxTokens: number = 1000
   ): Promise<string> {
     const start = Date.now();
-    const formattedMessages = [
-      { role: 'system', content: systemPrompt },
-      ...messages.map(msg => ({
-        role: msg.role,
-        content: msg.content
-      }))
-    ];
-
-    const makeRequest = () =>
-      this.withTimeout<ChatCompletionResponse>(
-        this.client.chat.completions.create({
-          model: this.config.model,
-          messages: formattedMessages,
-          temperature,
-          max_tokens: maxTokens,
-        }) as Promise<ChatCompletionResponse>,
-        this.config.timeoutMs ?? 30000
-      );
-
     try {
-      const response = await this.retryWithBackoff<ChatCompletionResponse>(makeRequest);
+      const response = await this.provider.sendMessage(
+        messages,
+        systemPrompt,
+        temperature,
+        maxTokens
+      );
       if (this.agentId) {
-        recordResponseTime(this.agentId, Date.now() - start);
-        const tokens = response.usage?.total_tokens;
-        if (tokens) recordTokens(this.agentId, tokens);
+        this.metrics?.recordResponseTime?.(this.agentId, Date.now() - start);
+        if (response.tokens !== undefined) {
+          this.metrics?.recordTokens?.(this.agentId, response.tokens);
+        }
       }
-      return response.choices[0]?.message?.content || '';
+      return response.content;
     } catch (error) {
       console.error('API Error:', error);
       const message = error instanceof Error ? error.message : String(error);
@@ -151,44 +76,21 @@ export class APIClient {
     temperature: number = 0.7,
     maxTokens: number = 1000
   ): AsyncGenerator<string> {
-    if (!['openai', 'openrouter'].includes(this.config.provider)) {
-      yield await this.sendMessage(messages, systemPrompt, temperature, maxTokens);
-      return;
-    }
-
     const start = Date.now();
-    const formattedMessages = [
-      { role: 'system', content: systemPrompt },
-      ...messages.map(m => ({ role: m.role, content: m.content }))
-    ];
-
-    const makeRequest = () =>
-      this.withTimeout<AsyncIterable<ChatCompletionChunk>>(
-        this.client.chat.completions.create({
-          model: this.config.model,
-          messages: formattedMessages,
-          temperature,
-          max_tokens: maxTokens,
-          stream: true,
-        }) as AsyncIterable<ChatCompletionChunk>,
-        this.config.timeoutMs ?? 30000
-      );
-
     try {
-      const stream = await this.retryWithBackoff<AsyncIterable<ChatCompletionChunk>>(
-        () => makeRequest()
-      );
       let full = '';
-      for await (const part of stream) {
-        const token = part.choices?.[0]?.delta?.content;
-        if (token) {
-          full += token;
-          yield token;
-        }
+      for await (const token of this.provider.streamMessage(
+        messages,
+        systemPrompt,
+        temperature,
+        maxTokens
+      )) {
+        full += token;
+        yield token;
       }
       if (this.agentId) {
-        recordResponseTime(this.agentId, Date.now() - start);
-        recordTokens(this.agentId, full);
+        this.metrics?.recordResponseTime?.(this.agentId, Date.now() - start);
+        this.metrics?.recordTokens?.(this.agentId, full);
       }
     } catch (error) {
       console.error('Streaming API error:', error);
@@ -201,27 +103,16 @@ export class APIClient {
     text: string,
     voice: AudioSpeechCreateParams['voice'] = 'alloy'
   ): Promise<ArrayBuffer> {
-    if (this.config.provider !== 'openai') {
-      throw new Error('Speech generation only supported with OpenAI');
+    if (!this.provider.generateSpeech) {
+      throw new Error('Speech generation not supported by this provider');
     }
-
     const start = Date.now();
-    const makeRequest = () =>
-      this.withTimeout<SpeechResponse>(
-        this.client.audio.speech.create({
-          model: 'tts-1',
-          voice,
-          input: text,
-        }) as Promise<SpeechResponse>,
-        this.config.timeoutMs ?? 30000
-      );
-
     try {
-      const response = await this.retryWithBackoff<SpeechResponse>(makeRequest);
+      const buffer = await this.provider.generateSpeech(text, voice);
       if (this.agentId) {
-        recordResponseTime(this.agentId, Date.now() - start);
+        this.metrics?.recordResponseTime?.(this.agentId, Date.now() - start);
       }
-      return await response.arrayBuffer();
+      return buffer;
     } catch (error) {
       console.error('Speech generation error:', error);
       const message = error instanceof Error ? error.message : String(error);
@@ -230,26 +121,16 @@ export class APIClient {
   }
 
   async transcribeAudio(audioFile: File): Promise<string> {
-    if (this.config.provider !== 'openai') {
-      throw new Error('Audio transcription only supported with OpenAI');
+    if (!this.provider.transcribeAudio) {
+      throw new Error('Audio transcription not supported by this provider');
     }
-
     const start = Date.now();
-    const makeRequest = () =>
-      this.withTimeout<TranscriptionResponse>(
-        this.client.audio.transcriptions.create({
-          file: audioFile,
-          model: 'whisper-1',
-        }) as Promise<TranscriptionResponse>,
-        this.config.timeoutMs ?? 30000
-      );
-
     try {
-      const response = await this.retryWithBackoff<TranscriptionResponse>(makeRequest);
+      const text = await this.provider.transcribeAudio(audioFile);
       if (this.agentId) {
-        recordResponseTime(this.agentId, Date.now() - start);
+        this.metrics?.recordResponseTime?.(this.agentId, Date.now() - start);
       }
-      return response.text;
+      return text;
     } catch (error) {
       console.error('Transcription error:', error);
       const message = error instanceof Error ? error.message : String(error);

--- a/src/lib/api/ProviderClient.ts
+++ b/src/lib/api/ProviderClient.ts
@@ -1,0 +1,34 @@
+import type { AudioSpeechCreateParams } from 'openai/resources/audio/speech';
+import type { ChatMessage } from '@/types/agent';
+
+export interface MessageResponse {
+  content: string;
+  tokens?: number;
+}
+
+export interface ProviderClient {
+  sendMessage(
+    messages: ChatMessage[],
+    systemPrompt: string,
+    temperature?: number,
+    maxTokens?: number
+  ): Promise<MessageResponse>;
+
+  streamMessage(
+    messages: ChatMessage[],
+    systemPrompt: string,
+    temperature?: number,
+    maxTokens?: number
+  ): AsyncGenerator<string>;
+
+  generateSpeech?(
+    text: string,
+    voice?: AudioSpeechCreateParams['voice']
+  ): Promise<ArrayBuffer>;
+
+  transcribeAudio?(audioFile: File): Promise<string>;
+}
+
+export interface ProviderOptions {
+  onError?: (err: unknown, attempt: number) => void;
+}

--- a/src/lib/api/providers/AzureOpenAIClient.ts
+++ b/src/lib/api/providers/AzureOpenAIClient.ts
@@ -1,0 +1,71 @@
+import OpenAI from 'openai';
+import type { ModelConfig, ChatMessage } from '@/types/agent';
+import { ProviderClient, MessageResponse, ProviderOptions } from '../ProviderClient';
+import { withTimeout, retryWithBackoff } from '../utils';
+
+export class AzureOpenAIClient implements ProviderClient {
+  private client: OpenAI;
+  private config: ModelConfig;
+  private onError?: ProviderOptions['onError'];
+
+  constructor(config: ModelConfig, options: ProviderOptions = {}) {
+    this.config = config;
+    this.client = new OpenAI({
+      apiKey: config.apiKey,
+      baseURL: config.baseUrl,
+      defaultQuery: { 'api-version': config.apiVersion || '2023-12-01-preview' },
+      dangerouslyAllowBrowser: true,
+    });
+    this.onError = options.onError;
+  }
+
+  async sendMessage(
+    messages: ChatMessage[],
+    systemPrompt: string,
+    temperature: number = 0.7,
+    maxTokens: number = 1000
+  ): Promise<MessageResponse> {
+    const formattedMessages = [
+      { role: 'system', content: systemPrompt },
+      ...messages.map(m => ({ role: m.role, content: m.content })),
+    ];
+
+    const makeRequest = () =>
+      withTimeout(
+        this.client.chat.completions.create({
+          model: this.config.model,
+          messages: formattedMessages,
+          temperature,
+          max_tokens: maxTokens,
+        }) as Promise<any>,
+        this.config.timeoutMs ?? 30000
+      );
+
+    const response = await retryWithBackoff(makeRequest, {
+      maxRetries: this.config.maxRetries,
+      onError: this.onError,
+    });
+
+    return {
+      content: response.choices[0]?.message?.content || '',
+      tokens: response.usage?.total_tokens,
+    };
+  }
+
+  async *streamMessage(
+    messages: ChatMessage[],
+    systemPrompt: string,
+    temperature: number = 0.7,
+    maxTokens: number = 1000
+  ): AsyncGenerator<string> {
+    // Azure OpenAI doesn't support streaming in this simplified client,
+    // so fall back to non-streaming response.
+    const response = await this.sendMessage(
+      messages,
+      systemPrompt,
+      temperature,
+      maxTokens
+    );
+    yield response.content;
+  }
+}

--- a/src/lib/api/providers/OpenAIClient.ts
+++ b/src/lib/api/providers/OpenAIClient.ts
@@ -1,0 +1,126 @@
+import OpenAI from 'openai';
+import type { ChatCompletionChunk } from 'openai/resources/chat/completions';
+import type { AudioSpeechCreateParams } from 'openai/resources/audio/speech';
+import type { ModelConfig, ChatMessage } from '@/types/agent';
+import { ProviderClient, MessageResponse, ProviderOptions } from '../ProviderClient';
+import { withTimeout, retryWithBackoff } from '../utils';
+
+export class OpenAIClient implements ProviderClient {
+  private client: OpenAI;
+  private config: ModelConfig;
+  private onError?: ProviderOptions['onError'];
+
+  constructor(config: ModelConfig, options: ProviderOptions = {}) {
+    this.config = config;
+    this.client = new OpenAI({
+      apiKey: config.apiKey,
+      dangerouslyAllowBrowser: true,
+    });
+    this.onError = options.onError;
+  }
+
+  async sendMessage(
+    messages: ChatMessage[],
+    systemPrompt: string,
+    temperature: number = 0.7,
+    maxTokens: number = 1000
+  ): Promise<MessageResponse> {
+    const formattedMessages = [
+      { role: 'system', content: systemPrompt },
+      ...messages.map(m => ({ role: m.role, content: m.content })),
+    ];
+
+    const makeRequest = () =>
+      withTimeout(
+        this.client.chat.completions.create({
+          model: this.config.model,
+          messages: formattedMessages,
+          temperature,
+          max_tokens: maxTokens,
+        }) as Promise<any>,
+        this.config.timeoutMs ?? 30000
+      );
+
+    const response = await retryWithBackoff(makeRequest, {
+      maxRetries: this.config.maxRetries,
+      onError: this.onError,
+    });
+
+    return {
+      content: response.choices[0]?.message?.content || '',
+      tokens: response.usage?.total_tokens,
+    };
+  }
+
+  async *streamMessage(
+    messages: ChatMessage[],
+    systemPrompt: string,
+    temperature: number = 0.7,
+    maxTokens: number = 1000
+  ): AsyncGenerator<string> {
+    const formattedMessages = [
+      { role: 'system', content: systemPrompt },
+      ...messages.map(m => ({ role: m.role, content: m.content })),
+    ];
+
+    const makeRequest = () =>
+      withTimeout(
+        this.client.chat.completions.create({
+          model: this.config.model,
+          messages: formattedMessages,
+          temperature,
+          max_tokens: maxTokens,
+          stream: true,
+        }) as AsyncIterable<ChatCompletionChunk>,
+        this.config.timeoutMs ?? 30000
+      );
+
+    const stream = await retryWithBackoff(() => makeRequest(), {
+      maxRetries: this.config.maxRetries,
+      onError: this.onError,
+    });
+
+    for await (const part of stream) {
+      const token = part.choices?.[0]?.delta?.content;
+      if (token) yield token;
+    }
+  }
+
+  async generateSpeech(
+    text: string,
+    voice: AudioSpeechCreateParams['voice'] = 'alloy'
+  ): Promise<ArrayBuffer> {
+    const makeRequest = () =>
+      withTimeout(
+        this.client.audio.speech.create({
+          model: 'tts-1',
+          voice,
+          input: text,
+        }) as Promise<{ arrayBuffer: () => Promise<ArrayBuffer> }>,
+        this.config.timeoutMs ?? 30000
+      );
+
+    const res = await retryWithBackoff(makeRequest, {
+      maxRetries: this.config.maxRetries,
+      onError: this.onError,
+    });
+    return res.arrayBuffer();
+  }
+
+  async transcribeAudio(audioFile: File): Promise<string> {
+    const makeRequest = () =>
+      withTimeout(
+        this.client.audio.transcriptions.create({
+          file: audioFile,
+          model: 'whisper-1',
+        }) as Promise<{ text: string }>,
+        this.config.timeoutMs ?? 30000
+      );
+
+    const res = await retryWithBackoff(makeRequest, {
+      maxRetries: this.config.maxRetries,
+      onError: this.onError,
+    });
+    return res.text;
+  }
+}

--- a/src/lib/api/providers/OpenRouterClient.ts
+++ b/src/lib/api/providers/OpenRouterClient.ts
@@ -1,0 +1,88 @@
+import OpenAI from 'openai';
+import type { ChatCompletionChunk } from 'openai/resources/chat/completions';
+import type { ModelConfig, ChatMessage } from '@/types/agent';
+import { ProviderClient, MessageResponse, ProviderOptions } from '../ProviderClient';
+import { withTimeout, retryWithBackoff } from '../utils';
+
+export class OpenRouterClient implements ProviderClient {
+  private client: OpenAI;
+  private config: ModelConfig;
+  private onError?: ProviderOptions['onError'];
+
+  constructor(config: ModelConfig, options: ProviderOptions = {}) {
+    this.config = config;
+    this.client = new OpenAI({
+      apiKey: config.apiKey,
+      baseURL: config.baseUrl || 'https://openrouter.ai/api/v1',
+      dangerouslyAllowBrowser: true,
+    });
+    this.onError = options.onError;
+  }
+
+  async sendMessage(
+    messages: ChatMessage[],
+    systemPrompt: string,
+    temperature: number = 0.7,
+    maxTokens: number = 1000
+  ): Promise<MessageResponse> {
+    const formattedMessages = [
+      { role: 'system', content: systemPrompt },
+      ...messages.map(m => ({ role: m.role, content: m.content })),
+    ];
+
+    const makeRequest = () =>
+      withTimeout(
+        this.client.chat.completions.create({
+          model: this.config.model,
+          messages: formattedMessages,
+          temperature,
+          max_tokens: maxTokens,
+        }) as Promise<any>,
+        this.config.timeoutMs ?? 30000
+      );
+
+    const response = await retryWithBackoff(makeRequest, {
+      maxRetries: this.config.maxRetries,
+      onError: this.onError,
+    });
+
+    return {
+      content: response.choices[0]?.message?.content || '',
+      tokens: response.usage?.total_tokens,
+    };
+  }
+
+  async *streamMessage(
+    messages: ChatMessage[],
+    systemPrompt: string,
+    temperature: number = 0.7,
+    maxTokens: number = 1000
+  ): AsyncGenerator<string> {
+    const formattedMessages = [
+      { role: 'system', content: systemPrompt },
+      ...messages.map(m => ({ role: m.role, content: m.content })),
+    ];
+
+    const makeRequest = () =>
+      withTimeout(
+        this.client.chat.completions.create({
+          model: this.config.model,
+          messages: formattedMessages,
+          temperature,
+          max_tokens: maxTokens,
+          stream: true,
+        }) as AsyncIterable<ChatCompletionChunk>,
+        this.config.timeoutMs ?? 30000
+      );
+
+    const stream = await retryWithBackoff(() => makeRequest(), {
+      maxRetries: this.config.maxRetries,
+      onError: this.onError,
+    });
+
+    for await (const part of stream) {
+      const token = part.choices?.[0]?.delta?.content;
+      if (token) yield token;
+    }
+  }
+}

--- a/src/lib/api/utils.ts
+++ b/src/lib/api/utils.ts
@@ -1,0 +1,50 @@
+export async function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export async function withTimeout<T>(promise: Promise<T>, timeoutMs?: number): Promise<T> {
+  if (!timeoutMs) return promise;
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`Request timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    promise
+      .then(res => {
+        clearTimeout(timer);
+        resolve(res);
+      })
+      .catch(err => {
+        clearTimeout(timer);
+        reject(err);
+      });
+  });
+}
+
+interface RetryOptions {
+  maxRetries?: number;
+  baseDelayMs?: number;
+  onError?: (err: unknown, attempt: number) => void;
+}
+
+export async function retryWithBackoff<T>(
+  operation: (attempt: number) => Promise<T>,
+  options: RetryOptions = {}
+): Promise<T> {
+  const { maxRetries = 3, baseDelayMs = 500, onError } = options;
+  let attempt = 0;
+  let lastError: unknown;
+  while (attempt <= maxRetries) {
+    try {
+      return await operation(attempt);
+    } catch (err) {
+      lastError = err;
+      onError?.(err, attempt);
+      if (attempt === maxRetries) break;
+      const delay = baseDelayMs * 2 ** attempt;
+      await sleep(delay);
+    }
+    attempt++;
+  }
+  const message = lastError instanceof Error ? lastError.message : String(lastError);
+  throw new Error(`Operation failed after ${maxRetries + 1} attempts: ${message}`);
+}


### PR DESCRIPTION
## Summary
- add ProviderClient interface and provider-specific clients (OpenAI, Azure OpenAI, OpenRouter)
- move retry/timeout helpers to dedicated api utils
- inject optional metrics callbacks and use strategy classes in APIClient
- update APIClient tests for new architecture

## Testing
- `npm test` *(fails: plugin-system tests)*
- `npx vitest run src/lib/api-client.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b1a714bf008325b61f40bc7278c93e