### PR TITLE
Refactor analytics alerts into modular handlers

### DIFF
--- a/docs/developer-guidelines.md
+++ b/docs/developer-guidelines.md
@@ -18,7 +18,7 @@ Update both this `docs/` directory and the root `README.md` whenever APIs or beh
 
 ## Analytics
 
-Metrics collected by `src/lib/analytics.ts` are persisted to `data/analytics-metrics.json`.
+ Metrics collected by `src/lib/analytics/index.ts` are persisted to `data/analytics-metrics.json`.
 The module flushes metrics to disk after each update and reloads them on startup so
 counts survive server restarts. A real-time dashboard is available at `/analytics` and
 refreshes automatically on `analytics-updated` events.

--- a/src/lib/analytics/alerts/email.ts
+++ b/src/lib/analytics/alerts/email.ts
@@ -1,0 +1,23 @@
+import { registerAlertHandler, Thresholds } from '..';
+
+export async function sendEmailAlert(
+  agentId: string,
+  metric: keyof Thresholds,
+  value: number
+) {
+  if (!process.env.EMAIL_WEBHOOK_URL) return;
+  try {
+    await fetch(process.env.EMAIL_WEBHOOK_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agentId, metric, value }),
+    });
+  } catch (err) {
+    console.error('Failed to send email alert', err);
+  }
+}
+
+registerAlertHandler((agentId, metric, value) => {
+  sendEmailAlert(agentId, metric, value);
+});
+

--- a/src/lib/analytics/alerts/slack.ts
+++ b/src/lib/analytics/alerts/slack.ts
@@ -1,0 +1,25 @@
+import { registerAlertHandler, Thresholds } from '..';
+
+export async function sendSlackAlert(
+  agentId: string,
+  metric: keyof Thresholds,
+  value: number
+) {
+  if (!process.env.SLACK_WEBHOOK_URL) return;
+  try {
+    await fetch(process.env.SLACK_WEBHOOK_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        text: `Agent ${agentId} exceeded ${metric}: ${value}`,
+      }),
+    });
+  } catch (err) {
+    console.error('Failed to send Slack alert', err);
+  }
+}
+
+registerAlertHandler((agentId, metric, value) => {
+  sendSlackAlert(agentId, metric, value);
+});
+

--- a/src/lib/analytics/setup.ts
+++ b/src/lib/analytics/setup.ts
@@ -1,0 +1,8 @@
+if (process.env.SLACK_WEBHOOK_URL) {
+  await import('./alerts/slack');
+}
+
+if (process.env.EMAIL_WEBHOOK_URL) {
+  await import('./alerts/email');
+}
+


### PR DESCRIPTION
## Summary
- Move Slack and email alert transports into dedicated modules
- Add registerAlertHandler hook and conditional setup for default alerts
- Update developer guidelines for new analytics path

## Testing
- `npm run lint` *(fails: Unexpected any in plugin-system.ts)*
- `npm test` *(fails: plugin system tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a715cc748325a75a46246ea8390e