### PR TITLE
refactor: modularize plugin system

### DIFF
--- a/src/lib/plugin-system.sandbox.test.ts
+++ b/src/lib/plugin-system.sandbox.test.ts
@@ -1,5 +1,4 @@
-import { test } from 'node:test';
-import assert from 'node:assert';
+import { it, expect } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -15,11 +14,11 @@ function createSandboxPluginDir(): string {
   return dir;
 }
 
-test('plugin cannot access process.env', async () => {
+it('plugin cannot access process.env', async () => {
   const dir = createSandboxPluginDir();
   await loadPlugins(dir);
   const plugin = getPlugins().find((p) => p.id.startsWith('sandbox'));
-  assert(plugin);
-  assert(plugin!.error);
-  assert.match(plugin!.error!, /env/);
+  expect(plugin).toBeDefined();
+  expect(plugin!.error).toBeDefined();
+  expect(plugin!.error).toMatch(/env/);
 });

--- a/src/lib/plugin/registry.ts
+++ b/src/lib/plugin/registry.ts
@@ -1,0 +1,97 @@
+import type { PluginState } from './state';
+import { state, saveState } from './state';
+
+export interface Plugin {
+  id: string;
+  name: string;
+  onLoad?: (options?: Record<string, unknown>) => void | Promise<void>;
+  onEnable?: (options?: Record<string, unknown>) => void | Promise<void>;
+  onDisable?: () => void | Promise<void>;
+  enabled?: boolean;
+  options?: Record<string, unknown>;
+  permissions?: string[];
+  logs?: string[];
+  errors?: string[];
+  warning?: string;
+  error?: string;
+}
+
+export const registry = new Map<string, Plugin>();
+
+export async function registerPlugin(plugin: Plugin): Promise<void> {
+  if (registry.has(plugin.id)) {
+    throw new Error(`Plugin with id "${plugin.id}" already registered`);
+  }
+
+  const persisted: PluginState | undefined = state[plugin.id];
+  const entry: Plugin = {
+    ...plugin,
+    enabled: persisted?.enabled ?? plugin.enabled ?? false,
+    options: { ...plugin.options, ...persisted?.options },
+    permissions: plugin.permissions ?? [],
+    logs: plugin.logs ?? [],
+    errors: plugin.errors ?? [],
+  };
+
+  registry.set(plugin.id, entry);
+  try {
+    await plugin.onLoad?.(entry.options);
+  } catch (err) {
+    entry.error = String(err);
+  }
+  if (entry.enabled) {
+    try {
+      await plugin.onEnable?.(entry.options);
+    } catch (err) {
+      entry.error = String(err);
+    }
+  }
+  if (entry.permissions.length) {
+    entry.warning = `Requests permissions: ${entry.permissions.join(', ')}`;
+  }
+}
+
+export function getPlugins(): Plugin[] {
+  return Array.from(registry.values());
+}
+
+export async function enablePlugin(id: string): Promise<void> {
+  const plugin = registry.get(id);
+  if (plugin && !plugin.enabled) {
+    plugin.enabled = true;
+    try {
+      await plugin.onEnable?.(plugin.options);
+    } catch (err) {
+      plugin.error = String(err);
+    }
+    state[id] = { ...state[id], enabled: true, options: plugin.options };
+    saveState();
+  }
+}
+
+export async function disablePlugin(id: string): Promise<void> {
+  const plugin = registry.get(id);
+  if (plugin && plugin.enabled) {
+    plugin.enabled = false;
+    try {
+      await plugin.onDisable?.();
+    } catch (err) {
+      plugin.error = String(err);
+    }
+    state[id] = { ...state[id], enabled: false, options: plugin.options };
+    saveState();
+  }
+}
+
+export async function updatePluginOptions(
+  id: string,
+  options: Record<string, unknown>,
+): Promise<void> {
+  const plugin = registry.get(id);
+  if (plugin) {
+    plugin.options = options;
+    state[id] = { ...state[id], enabled: plugin.enabled ?? false, options };
+    saveState();
+  }
+}
+

--- a/src/lib/plugin/state.ts
+++ b/src/lib/plugin/state.ts
@@ -1,0 +1,32 @@
+import fs from 'fs';
+import path from 'path';
+
+export interface PluginState {
+  enabled: boolean;
+  options?: Record<string, unknown>;
+}
+
+export let state: Record<string, PluginState> = {};
+let stateFilePath = path.join(process.cwd(), 'plugins', 'plugin-state.json');
+
+export function setStateFilePath(filePath: string): void {
+  stateFilePath = filePath;
+}
+
+export function loadState(): void {
+  if (fs.existsSync(stateFilePath)) {
+    try {
+      state = JSON.parse(fs.readFileSync(stateFilePath, 'utf8'));
+    } catch {
+      state = {};
+    }
+  } else {
+    state = {};
+  }
+}
+
+export function saveState(): void {
+  fs.mkdirSync(path.dirname(stateFilePath), { recursive: true });
+  fs.writeFileSync(stateFilePath, JSON.stringify(state, null, 2));
+}
+

--- a/src/lib/plugin/worker.ts
+++ b/src/lib/plugin/worker.ts
@@ -1,0 +1,41 @@
+const workerScript = `import { parentPort, workerData } from 'worker_threads';
+import fs from 'fs';
+import { NodeVM } from 'vm2';
+import { transpileModule } from 'typescript';
+const file = workerData.file;
+let code = fs.readFileSync(file, 'utf8');
+if (file.endsWith('.ts')) {
+  code = transpileModule(code, { compilerOptions: { module: 1 } }).outputText;
+}
+const vm = new NodeVM({
+  console: 'redirect',
+  sandbox: {},
+  require: { external: false, builtin: [] },
+});
+vm.freeze(undefined, 'process');
+vm.on('console.log', (...args) => parentPort.postMessage({ type: 'log', data: args.join(' ') }));
+vm.on('console.error', (...args) => parentPort.postMessage({ type: 'consoleError', data: args.join(' ') }));
+let plugin;
+try {
+  plugin = vm.run(code, file).default;
+} catch (err) {
+  parentPort.postMessage({ type: 'loaded', error: String(err) });
+}
+if (plugin) {
+  parentPort.postMessage({ type: 'loaded', plugin: { id: plugin.id, name: plugin.name, permissions: plugin.permissions } });
+  parentPort.on('message', async (msg) => {
+    const { method, options, timeout } = msg;
+    try {
+      await Promise.race([
+        plugin[method]?.(options),
+        new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), timeout)),
+      ]);
+      parentPort.postMessage({ type: 'result', method });
+    } catch (err) {
+      parentPort.postMessage({ type: 'error', method, error: String(err) });
+    }
+  });
+}`;
+
+export default workerScript;
+

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -8,7 +8,7 @@ describe('utils', () => {
   });
 
   it('recordTokens counts tokens from text', () => {
-    const agentId = 'test-agent';
+    const agentId = `test-agent-${Math.random()}`;
     recordTokens(agentId, 'Hello world from tests');
     const metrics = getMetrics(agentId);
     expect(metrics?.tokensUsed).toBe(countTokens('Hello world from tests'));


### PR DESCRIPTION
## Summary
- split plugin registry into dedicated module for plugin lifecycle management
- move persistent plugin state handling into its own module
- extract worker thread script to standalone module and orchestrate loading via plugin-system
- convert sandbox plugin test to Vitest and isolate analytics token test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1a7145c1883258b484d24f7546990