### PR TITLE
chore: add pre-commit hook for linting and tests

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+npm run lint
+npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "@types/uuid": "^10.0.0",
         "eslint": "^9",
         "eslint-config-next": "15.5.2",
+        "husky": "^9.1.7",
         "tailwindcss": "^4",
         "tsx": "^4.20.5",
         "typescript": "^5",
@@ -6200,6 +6201,22 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/ignore": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint",
     "plugins": "tsx src/lib/plugin-system.ts",
     "scaffold:plugin": "tsx scripts/scaffold-plugin.ts",
-    "test": "vitest run"
+    "test": "vitest run",
+    "prepare": "husky"
   },
   "dependencies": {
     "@azure/openai": "^2.0.0",
@@ -48,6 +49,7 @@
     "@types/uuid": "^10.0.0",
     "eslint": "^9",
     "eslint-config-next": "15.5.2",
+    "husky": "^9.1.7",
     "tailwindcss": "^4",
     "tsx": "^4.20.5",
     "typescript": "^5",


### PR DESCRIPTION
## Summary
- add Husky pre-commit hook that runs lint and tests
- include Husky dev dependency and prepare script

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot set properties of undefined; Test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ac8830648325973c4ee05bea3d76