### PR TITLE
feat: centralize agent config defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,5 +46,9 @@ The project ships with an in-memory store for rapid prototyping. Agent chat sess
 - **Testing:** run `npm test` (when available) and `npm run lint` before committing.
 - **Documentation:** update both the README and `docs/` directory whenever behavior or APIs change.
 
+### Default Agent Config Builder
+
+Use `createDefaultAgentConfig` from `src/lib/agents/agent-builder` to scaffold new agent definitions. It returns an `AgentConfig` without id or timestamps pre-populated with common defaults, which helps keep forms and tests consistent.
+
 For extended guidelines, consult [docs/developer-guidelines.md](docs/developer-guidelines.md).
 

--- a/src/components/agents/AgentForm.tsx
+++ b/src/components/agents/AgentForm.tsx
@@ -8,6 +8,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { AgentConfig, AgentType, ModelProvider } from '@/types/agent';
 import { validateApiKey, getModelsByProvider } from '@/lib/utils';
 import { MessageCircle, Mic, Save, X } from 'lucide-react';
+import { createDefaultAgentConfig } from '@/lib/agents/agent-builder';
 
 interface AgentFormProps {
   agent?: AgentConfig;
@@ -16,22 +17,23 @@ interface AgentFormProps {
 }
 
 export function AgentForm({ agent, onSave, onCancel }: AgentFormProps) {
+  const defaults = createDefaultAgentConfig();
   const [formData, setFormData] = useState({
-    name: agent?.name || '',
-    description: agent?.description || '',
-    category: agent?.category || 'general',
-    type: agent?.type || 'chat' as AgentType,
-    systemPrompt: agent?.systemPrompt || 'You are a helpful AI assistant.',
-    provider: agent?.modelConfig.provider || 'openai' as ModelProvider,
-    apiKey: agent?.modelConfig.apiKey || '',
-    model: agent?.modelConfig.model || 'gpt-3.5-turbo',
-    baseUrl: agent?.modelConfig.baseUrl || '',
-    apiVersion: agent?.modelConfig.apiVersion || '',
-    temperature: agent?.temperature || 0.7,
-    maxTokens: agent?.maxTokens || 1000,
-    voice: agent?.voiceSettings?.voice || 'alloy',
-    speed: agent?.voiceSettings?.speed || 1.0,
-    pitch: agent?.voiceSettings?.pitch || 1.0,
+    name: agent?.name ?? defaults.name,
+    description: agent?.description ?? defaults.description,
+    category: agent?.category ?? defaults.category,
+    type: (agent?.type ?? defaults.type) as AgentType,
+    systemPrompt: agent?.systemPrompt ?? defaults.systemPrompt,
+    provider: (agent?.modelConfig.provider ?? defaults.modelConfig.provider) as ModelProvider,
+    apiKey: agent?.modelConfig.apiKey ?? defaults.modelConfig.apiKey,
+    model: agent?.modelConfig.model ?? defaults.modelConfig.model,
+    baseUrl: agent?.modelConfig.baseUrl ?? defaults.modelConfig.baseUrl,
+    apiVersion: agent?.modelConfig.apiVersion ?? defaults.modelConfig.apiVersion,
+    temperature: agent?.temperature ?? defaults.temperature,
+    maxTokens: agent?.maxTokens ?? defaults.maxTokens,
+    voice: agent?.voiceSettings?.voice ?? defaults.voiceSettings?.voice ?? 'alloy',
+    speed: agent?.voiceSettings?.speed ?? defaults.voiceSettings?.speed ?? 1.0,
+    pitch: agent?.voiceSettings?.pitch ?? defaults.voiceSettings?.pitch ?? 1.0,
   });
 
   const [errors, setErrors] = useState<Record<string, string>>({});

--- a/src/lib/agents/agent-builder.ts
+++ b/src/lib/agents/agent-builder.ts
@@ -1,0 +1,27 @@
+import { AgentConfig } from '@/types/agent';
+
+export function createDefaultAgentConfig(): Omit<AgentConfig, 'id' | 'createdAt' | 'updatedAt'> {
+  return {
+    name: '',
+    type: 'chat',
+    description: '',
+    category: 'general',
+    systemPrompt: 'You are a helpful AI assistant.',
+    modelConfig: {
+      provider: 'openai',
+      apiKey: '',
+      model: 'gpt-3.5-turbo',
+      baseUrl: '',
+      apiVersion: '',
+    },
+    temperature: 0.7,
+    maxTokens: 1000,
+    voiceSettings: {
+      voice: 'alloy',
+      speed: 1.0,
+      pitch: 1.0,
+    },
+  };
+}
+
+export default createDefaultAgentConfig;

--- a/tests/chat-streaming.test.ts
+++ b/tests/chat-streaming.test.ts
@@ -2,20 +2,24 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { promises as fs } from 'fs';
 import path from 'path';
 import os from 'os';
+import { createDefaultAgentConfig } from '@/lib/agents/agent-builder';
 
 let tempDir: string;
 let originalCwd: string;
 let streamRoute: typeof import('../src/app/api/agents/[id]/stream/route');
 
+const defaultConfig = createDefaultAgentConfig();
 const agent = {
   id: 'a1',
+  ...defaultConfig,
   name: 'Test',
-  type: 'chat',
   description: 'desc',
   systemPrompt: 'system',
-  modelConfig: { provider: 'openai', apiKey: 'key', model: 'gpt-4' },
-  temperature: 0.7,
-  maxTokens: 1000,
+  modelConfig: {
+    ...defaultConfig.modelConfig,
+    apiKey: 'key',
+    model: 'gpt-4',
+  },
   createdAt: new Date().toISOString(),
   updatedAt: new Date().toISOString(),
 };

--- a/tests/marketplace-api.test.ts
+++ b/tests/marketplace-api.test.ts
@@ -2,20 +2,21 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { promises as fs } from 'fs';
 import path from 'path';
 import os from 'os';
+import { createDefaultAgentConfig } from '@/lib/agents/agent-builder';
 
+const baseAgent = createDefaultAgentConfig();
 const validAgent = {
+  ...baseAgent,
   name: 'Test Agent',
-  type: 'chat',
   description: 'desc',
   category: 'utilities',
   systemPrompt: 'prompt',
   modelConfig: {
-    provider: 'openai',
+    ...baseAgent.modelConfig,
     apiKey: 'key',
     model: 'gpt-4',
   },
   temperature: 0.5,
-  maxTokens: 1000,
 };
 
 let tempFile: string;


### PR DESCRIPTION
## Summary
- add `createDefaultAgentConfig` for reusable agent defaults
- use builder in `AgentForm` and tests to remove duplicate literals
- document default config helper in README

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot set properties of undefined in src/lib/api-client.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ae86e3d483259d755c225e4f6704