### PR TITLE
feat: centralize provider configs with runtime registration

### DIFF
--- a/src/lib/api-client.test.ts
+++ b/src/lib/api-client.test.ts
@@ -1,19 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { APIClient } from './api-client';
 import * as apiUtils from './api/utils';
+import * as analytics from './analytics';
 
 describe('APIClient retry logic', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     vi.spyOn(apiUtils, 'sleep').mockResolvedValue(undefined);
+    vi.spyOn(analytics, 'incrementError').mockImplementation(() => {});
+    vi.spyOn(analytics, 'recordResponseTime').mockImplementation(() => {});
+    vi.spyOn(analytics, 'recordTokens').mockImplementation(() => {});
   });
 
   it('retries on transient failure and succeeds', async () => {
-    const metrics = {
-      incrementError: vi.fn(),
-      recordResponseTime: vi.fn(),
-      recordTokens: vi.fn(),
-    };
     const client = new APIClient(
       { provider: 'openai', apiKey: 'x', model: 'gpt', maxRetries: 2, timeoutMs: 1000 },
       'agent-success'
@@ -26,22 +25,17 @@ describe('APIClient retry logic', () => {
       .mockResolvedValue({ choices: [{ message: { content: 'ok' } }], usage: { total_tokens: 1 } });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (client as any).provider.client = {
+    (client as any).client = {
       chat: { completions: { create: mockCreate } },
     };
 
     const result = await client.sendMessage([], 'sys');
     expect(result).toBe('ok');
     expect(mockCreate).toHaveBeenCalledTimes(3);
-    expect(metrics.incrementError).toHaveBeenCalledTimes(2);
+    expect(analytics.incrementError).toHaveBeenCalledTimes(2);
   });
 
   it('fails after exceeding max retries', async () => {
-    const metrics = {
-      incrementError: vi.fn(),
-      recordResponseTime: vi.fn(),
-      recordTokens: vi.fn(),
-    };
     const client = new APIClient(
       { provider: 'openai', apiKey: 'x', model: 'gpt', maxRetries: 2, timeoutMs: 1000 },
       'agent-fail'
@@ -49,13 +43,13 @@ describe('APIClient retry logic', () => {
 
     const mockCreate = vi.fn().mockRejectedValue(new Error('always fail'));
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (client as any).provider.client = {
+    (client as any).client = {
       chat: { completions: { create: mockCreate } },
     };
 
     await expect(client.sendMessage([], 'sys')).rejects.toThrow(/Failed to send message/);
     expect(mockCreate).toHaveBeenCalledTimes(3);
-    expect(metrics.incrementError).toHaveBeenCalledTimes(3);
-    expect(metrics.recordResponseTime).not.toHaveBeenCalled();
+    expect(analytics.incrementError).toHaveBeenCalledTimes(3);
+    expect(analytics.recordResponseTime).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/providers/index.ts
+++ b/src/lib/providers/index.ts
@@ -1,0 +1,27 @@
+export interface ProviderConfig {
+  models: string[];
+  apiKeyPattern?: RegExp;
+}
+
+export const providerConfigs: Record<string, ProviderConfig> = {
+  openai: {
+    models: ["gpt-4", "gpt-4-turbo", "gpt-3.5-turbo"],
+    apiKeyPattern: /^sk-/,
+  },
+  "azure-openai": {
+    models: ["gpt-4", "gpt-35-turbo"],
+    apiKeyPattern: /^.{11,}$/,
+  },
+  openrouter: {
+    models: [
+      "openai/gpt-4",
+      "anthropic/claude-3-opus",
+      "meta-llama/llama-2-70b-chat",
+    ],
+    apiKeyPattern: /^sk-or-/,
+  },
+};
+
+export function registerProvider(id: string, config: ProviderConfig) {
+  providerConfigs[id] = config;
+}

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { countTokens } from './utils';
+import { countTokens, validateApiKey, getModelsByProvider } from './utils';
 import { recordTokens, getMetrics } from './analytics';
+import { registerProvider } from './providers';
 
 describe('utils', () => {
   it('countTokens counts tokens using tiktoken', () => {
@@ -12,5 +13,17 @@ describe('utils', () => {
     recordTokens(agentId, 'Hello world from tests');
     const metrics = getMetrics(agentId);
     expect(metrics?.tokensUsed).toBe(countTokens('Hello world from tests'));
+  });
+
+  it('validates API keys using provider configs', () => {
+    expect(validateApiKey('openai', 'sk-valid')).toBe(true);
+    expect(validateApiKey('openai', 'invalid')).toBe(false);
+  });
+
+  it('supports registering providers at runtime', () => {
+    const id = `test-${Math.random()}`;
+    registerProvider(id, { models: ['test-model'], apiKeyPattern: /^test-/ });
+    expect(getModelsByProvider(id)).toEqual(['test-model']);
+    expect(validateApiKey(id, 'test-123')).toBe(true);
   });
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,7 @@
 import { type ClassValue, clsx } from "clsx";
 import { encodingForModel, type TiktokenModel } from "js-tiktoken";
 import { twMerge } from "tailwind-merge";
+import { providerConfigs } from "./providers";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -22,30 +23,14 @@ export function formatDate(date: Date): string {
 
 export function validateApiKey(provider: string, apiKey: string): boolean {
   if (!apiKey || apiKey.trim().length === 0) return false;
-  
-  switch (provider) {
-    case 'openai':
-      return apiKey.startsWith('sk-');
-    case 'azure-openai':
-      return apiKey.length > 10; // Basic validation
-    case 'openrouter':
-      return apiKey.startsWith('sk-or-');
-    default:
-      return false;
-  }
+  const config = providerConfigs[provider];
+  if (!config) return false;
+  const { apiKeyPattern } = config;
+  return apiKeyPattern ? apiKeyPattern.test(apiKey) : true;
 }
 
 export function getModelsByProvider(provider: string): string[] {
-  switch (provider) {
-    case 'openai':
-      return ['gpt-4', 'gpt-4-turbo', 'gpt-3.5-turbo'];
-    case 'azure-openai':
-      return ['gpt-4', 'gpt-35-turbo'];
-    case 'openrouter':
-      return ['openai/gpt-4', 'anthropic/claude-3-opus', 'meta-llama/llama-2-70b-chat'];
-    default:
-      return [];
-  }
+  return providerConfigs[provider]?.models ?? [];
 }
 
 const encoders: Record<string, ReturnType<typeof encodingForModel>> = {};


### PR DESCRIPTION
## Summary
- add provider configuration registry with default OpenAI, Azure OpenAI, and OpenRouter entries
- reference provider registry in `validateApiKey` and `getModelsByProvider`
- allow plugins to register providers at runtime
- fix API client tests to mock internal client directly

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1ae882dec8325a6eeb15b3225b862