### PR TITLE
ci: refine Supabase workflow

### DIFF
--- a/.github/workflows/supabase.yml
+++ b/.github/workflows/supabase.yml
@@ -1,0 +1,43 @@
+name: Apply Supabase migrations
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'supabase/migrations/**'
+      - 'supabase/functions/**'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+      SITE_URL: https://sync-date-magic.vercel.app
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Link to Supabase project
+        run: supabase link --project-ref ${{ secrets.SUPABASE_PROJECT_ID }}
+        working-directory: ./supabase
+
+      - name: Apply database migrations
+        run: supabase db push --include-all
+        working-directory: ./supabase
+
+      - name: Deploy Edge Functions
+        run: |
+          for dir in $(find functions -maxdepth 1 -mindepth 1 -type d \
+            ! -name '_*' ! -name 'lib'); do
+            supabase functions deploy $(basename "$dir") --no-verify-jwt
+          done
+        working-directory: ./supabase

--- a/supabase/migrations/20240101000000_initial_schema.sql
+++ b/supabase/migrations/20240101000000_initial_schema.sql
@@ -1,0 +1,30 @@
+-- Initial schema for Arcane Dominion
+create table if not exists game_state (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default now(),
+  cycle int not null default 1,
+  resources jsonb not null default '{"grain": 1000, "coin": 500, "mana": 200, "favor": 10, "unrest": 0, "threat": 0}',
+  notes text
+);
+
+create table if not exists proposals (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default now(),
+  state_id uuid references game_state(id) on delete cascade,
+  guild text not null check (guild in ('Wardens','Alchemists','Scribes','Stewards')),
+  title text not null,
+  description text not null,
+  predicted_delta jsonb not null default '{}',
+  status text not null default 'pending' check (status in ('pending','accepted','rejected','applied'))
+);
+
+create table if not exists decisions (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default now(),
+  proposal_id uuid references proposals(id) on delete cascade,
+  decision text not null check (decision in ('accept','reject')),
+  scry_delta jsonb,
+  comment text
+);
+
+create index if not exists proposals_state_status_idx on proposals(state_id, status);

--- a/supabase/migrations/20240102000000_add_game_state_updated_at.sql
+++ b/supabase/migrations/20240102000000_add_game_state_updated_at.sql
@@ -1,0 +1,3 @@
+-- Add updated_at column to game_state
+alter table if exists game_state
+  add column if not exists updated_at timestamptz not null default now();


### PR DESCRIPTION
## Summary
- apply Supabase migrations and deploy Edge Functions in CI
- move Supabase migrations to a top-level directory for path-based triggers

## Testing
- `npm run lint` *(fails: Unexpected any in src/app/play/page.tsx)*
- `npx supabase --version`


------
https://chatgpt.com/codex/tasks/task_e_68b4531934208325a58e7e264b3ee06c