### PR TITLE
docs: add root agent guide and update Arcane Dominion instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# Repository Agents Guide
+
+This root guide defines norms for collaborating in this repository.
+
+## Branching Strategy
+- Create a dedicated feature branch for each change and open a pull request into `main`.
+- Keep `main` in a deployable state.
+
+## Testing
+- Run `npm test` or other relevant test commands in any affected project directories.
+- Include test results in pull requests.
+
+## Sub-Guides
+- [Arcane Dominion](./arcane-dominion/AGENTS.md)
+

--- a/arcane-dominion/AGENTS.md
+++ b/arcane-dominion/AGENTS.md
@@ -1,5 +1,7 @@
 # Arcane Dominion Agents Guide
 
+> See [root AGENTS.md](../AGENTS.md) for repository-wide norms.
+
 This guide aligns agents with the Arcane Dominion Tycoon design. It explains setup, architecture, and conventions to extend the AI-driven council.
 
 ## Setup


### PR DESCRIPTION
## Summary
- add repository-wide AGENTS guide outlining branching and testing norms
- rename Arcane Dominion's AGENTS.MD to AGENTS.md and link to root guidelines

## Testing
- `npm test` (fails: Could not read package.json)
- `cd arcane-dominion && npm test` (fails: Missing script: "test")


------
https://chatgpt.com/codex/tasks/task_e_68b45a9644e88325a440f2d23e5cd999