### PR TITLE
Update tick route to refresh updated_at timestamp

### DIFF
--- a/arcane-dominion/src/app/api/state/tick/route.ts
+++ b/arcane-dominion/src/app/api/state/tick/route.ts
@@ -41,7 +41,7 @@ export async function POST() {
   // Increment cycle and persist
   const { data: updated, error: upErr } = await supabase
     .from('game_state')
-    .update({ cycle: state.cycle + 1, resources })
+    .update({ cycle: state.cycle + 1, resources, updated_at: new Date().toISOString() })
     .eq('id', state.id)
     .select('*')
     .single()


### PR DESCRIPTION
## Summary
- refresh `updated_at` whenever game state advances a cycle

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_68b45a96f1448325b3b097306b2f4de5