### PR TITLE
Validate proposal routes with Zod

### DIFF
--- a/arcane-dominion/src/app/api/proposals/[id]/scry/route.ts
+++ b/arcane-dominion/src/app/api/proposals/[id]/scry/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase/server'
 import { generateText } from 'ai'
 import { createOpenAI } from '@ai-sdk/openai'
+import { z } from 'zod'
 
 const openai = createOpenAI({ apiKey: process.env.OPENAI_API_KEY })
 
@@ -9,10 +10,25 @@ interface RouteContext {
   params: Promise<{ id: string }>
 }
 
-export async function POST(_req: NextRequest, context: RouteContext) {
+const BodySchema = z.object({})
+
+const AIResponseSchema = z.object({
+  predicted_delta: z.record(z.number()),
+  risk_note: z.string(),
+})
+
+export async function POST(req: NextRequest, context: RouteContext) {
   const params = await context.params
   const supabase = createSupabaseServerClient()
   const { id } = params
+  const body = await req.json().catch(() => ({}))
+  const bodyResult = BodySchema.safeParse(body)
+  if (!bodyResult.success) {
+    return NextResponse.json(
+      { error: bodyResult.error.message },
+      { status: 400 },
+    )
+  }
 
   const { data: proposal, error } = await supabase
     .from('proposals')
@@ -28,15 +44,25 @@ Return JSON: { predicted_delta: {resource:number,...}, risk_note: string }`
   const user = `Resources: ${JSON.stringify(proposal.game_state.resources)}\nProposal: ${proposal.title} - ${proposal.description}`
   const { text } = await generateText({ model: openai('gpt-4o-mini'), system, prompt: user })
 
+  let parsedJson: unknown
   try {
     const start = text.indexOf('{')
     const end = text.lastIndexOf('}') + 1
-    const parsed = JSON.parse(text.slice(start, end))
-
-    // Update proposal predicted delta
-    await supabase.from('proposals').update({ predicted_delta: parsed.predicted_delta }).eq('id', id)
-    return NextResponse.json(parsed)
-  } catch (e) {
-    return NextResponse.json({ error: 'Scry parse failed', raw: text }, { status: 500 })
+    parsedJson = JSON.parse(text.slice(start, end))
+  } catch {
+    return NextResponse.json(
+      { error: 'Scry parse failed', raw: text },
+      { status: 400 },
+    )
   }
+  const parsed = AIResponseSchema.safeParse(parsedJson)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.message },
+      { status: 400 },
+    )
+  }
+
+  await supabase.from('proposals').update({ predicted_delta: parsed.data.predicted_delta }).eq('id', id)
+  return NextResponse.json(parsed.data)
 }


### PR DESCRIPTION
## Summary
- add request/response Zod schemas for proposal generation
- validate decision inputs with Zod
- guard scry results with Zod schemas

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 27 problems (7 errors, 20 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68b45a95e2108325a5a0cb7c7f7b22b5