### PR TITLE
Fix zod record schemas and add workspace build config

### DIFF
--- a/arcane-dominion/src/app/api/proposals/[id]/scry/route.ts
+++ b/arcane-dominion/src/app/api/proposals/[id]/scry/route.ts
@@ -13,7 +13,7 @@ interface RouteContext {
 const BodySchema = z.object({})
 
 const AIResponseSchema = z.object({
-  predicted_delta: z.record(z.number()),
+  predicted_delta: z.record(z.string(), z.number()),
   risk_note: z.string(),
 })
 

--- a/arcane-dominion/src/app/api/proposals/generate/route.ts
+++ b/arcane-dominion/src/app/api/proposals/generate/route.ts
@@ -13,7 +13,7 @@ const BodySchema = z.object({
 const ProposalSchema = z.object({
   title: z.string(),
   description: z.string(),
-  predicted_delta: z.record(z.number()),
+  predicted_delta: z.record(z.string(), z.number()),
 })
 
 const AIResponseSchema = z.array(ProposalSchema)

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "agents-sandbox",
+  "private": true,
+  "workspaces": ["arcane-dominion"],
+  "scripts": {
+    "vercel-build": "npm --workspace arcane-dominion run vercel-build"
+  }
+}


### PR DESCRIPTION
## Summary
- specify string key type in AI response record schemas
- add repository root package.json that delegates vercel-build to arcane-dominion workspace

## Testing
- `npm test` (fails: Missing script: "test")
- `npm test` (root; fails: Missing script: "test")
- `npm run vercel-build`


------
https://chatgpt.com/codex/tasks/task_e_68b45d486f648325b064d2c923938de6