### PR TITLE
Add collapsible goal banner

### DIFF
--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -13,6 +13,7 @@ import { createSupabaseBrowserClient } from '@/lib/supabase/browser'
 import EffectsLayer from '@/components/game/EffectsLayer';
 import HeatLayer from '@/components/game/HeatLayer';
 import MarkersLayer from '@/components/game/MarkersLayer';
+import GoalBanner from '@/components/game/GoalBanner';
 
 interface GameState {
   id: string;
@@ -487,6 +488,7 @@ export default function PlayPage() {
 
   return (
     <div className="h-screen bg-neutral-50 overflow-hidden relative flex flex-col">
+      <GoalBanner />
 
       <div className="flex-1 relative min-h-0">
 

--- a/src/components/game/GoalBanner.tsx
+++ b/src/components/game/GoalBanner.tsx
@@ -1,0 +1,60 @@
+import { useState, useEffect } from 'react';
+
+const DISMISSED_KEY = 'ad_goal_banner_dismissed';
+const COLLAPSED_KEY = 'ad_goal_banner_collapsed';
+
+export default function GoalBanner() {
+  const [dismissed, setDismissed] = useState(false);
+  const [collapsed, setCollapsed] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      setDismissed(localStorage.getItem(DISMISSED_KEY) === '1');
+      setCollapsed(localStorage.getItem(COLLAPSED_KEY) === '1');
+    } catch {}
+  }, []);
+
+  const handleDismiss = () => {
+    setDismissed(true);
+    try { localStorage.setItem(DISMISSED_KEY, '1'); } catch {}
+  };
+
+  const toggleCollapse = () => {
+    setCollapsed(prev => {
+      const next = !prev;
+      try { localStorage.setItem(COLLAPSED_KEY, next ? '1' : '0'); } catch {}
+      return next;
+    });
+  };
+
+  if (dismissed) return null;
+
+  return (
+    <div className="w-full bg-indigo-700 text-white text-sm px-4 py-2 flex items-center justify-between">
+      <div className="flex-1">
+        {collapsed ? (
+          <span className="cursor-pointer" onClick={toggleCollapse}>Dominion goal</span>
+        ) : (
+          <span>Hold the Dominion as long as you can—keep Unrest &lt;80 and Threat &lt;70.</span>
+        )}
+      </div>
+      <div className="flex items-center gap-3 ml-4">
+        <button
+          onClick={toggleCollapse}
+          className="text-white hover:text-indigo-200 text-xs underline"
+        >
+          {collapsed ? 'Show' : 'Hide'}
+        </button>
+        <button
+          onClick={handleDismiss}
+          className="text-white hover:text-indigo-200"
+          aria-label="Dismiss goal banner"
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add dismissible GoalBanner with Dominion objective and localStorage persistence
- show goal banner at top of active play screen

## Testing
- `npm test`
- `npm run lint` *(fails: React Hook missing dependencies and unused vars in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e3ced36c832580e0960fae35f364