### PR TITLE
feat: add survival tracker overlay

### DIFF
--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -13,6 +13,7 @@ import { createSupabaseBrowserClient } from '@/lib/supabase/browser'
 import EffectsLayer from '@/components/game/EffectsLayer';
 import HeatLayer from '@/components/game/HeatLayer';
 import MarkersLayer from '@/components/game/MarkersLayer';
+import SurvivalTracker from '@/components/game/SurvivalTracker';
 
 interface GameState {
   id: string;
@@ -684,31 +685,43 @@ export default function PlayPage() {
         </div>
       )}
 
-      {/* Objective Tracker */}
-      {!dismissedGuide && !showOnboarding && (
-        <div className="absolute top-4 right-4 z-40 max-w-sm w-[280px]">
-          <div className="bg-white/95 backdrop-blur-sm border border-slate-200 rounded-lg shadow-lg p-4">
-            <div className="flex items-center justify-between mb-2">
-              <h3 className="text-slate-900 font-semibold">Objectives</h3>
-              <button onClick={skipGuide} className="text-xs text-slate-500 hover:text-slate-900">Skip</button>
+      {/* Guide Objectives or Survival Tracker */}
+      {!showOnboarding && (
+        dismissedGuide ? (
+          state && (
+            <div className="absolute top-4 right-4 z-40 max-w-sm w-[280px]">
+              <SurvivalTracker
+                cycle={state.cycle}
+                unrest={state.resources.unrest || 0}
+                threat={state.resources.threat || 0}
+              />
             </div>
-            <ul className="text-sm text-slate-700 space-y-1">
-              <li className="flex items-center gap-2"><span className={`inline-block h-2.5 w-2.5 rounded-full ${guideProgress.selectedTile ? 'bg-emerald-500' : 'bg-slate-300'}`}></span>Select any tile</li>
-              <li className="flex items-center gap-2"><span className={`inline-block h-2.5 w-2.5 rounded-full ${guideProgress.openedCouncil ? 'bg-emerald-500' : 'bg-slate-300'}`}></span>Open the Council</li>
-              <li className="flex items-center gap-2"><span className={`inline-block h-2.5 w-2.5 rounded-full ${guideProgress.generated ? 'bg-emerald-500' : 'bg-slate-300'}`}></span>Summon proposals</li>
-              <li className="flex items-center gap-2"><span className={`inline-block h-2.5 w-2.5 rounded-full ${guideProgress.accepted ? 'bg-emerald-500' : 'bg-slate-300'}`}></span>Accept one proposal</li>
-              <li className="flex items-center gap-2"><span className={`inline-block h-2.5 w-2.5 rounded-full ${guideProgress.advanced ? 'bg-emerald-500' : 'bg-slate-300'}`}></span>Advance the cycle</li>
-            </ul>
-            {!guideProgress.advanced && (
-              <div className="mt-3 text-xs text-slate-500">Complete these steps to finish the intro.</div>
-            )}
-            {guideProgress.advanced && (
-              <div className="mt-3 flex justify-end">
-                <button onClick={skipGuide} className="px-3 py-1.5 rounded bg-emerald-600 hover:bg-emerald-700 text-white text-sm">Finish</button>
+          )
+        ) : (
+          <div className="absolute top-4 right-4 z-40 max-w-sm w-[280px]">
+            <div className="bg-white/95 backdrop-blur-sm border border-slate-200 rounded-lg shadow-lg p-4">
+              <div className="flex items-center justify-between mb-2">
+                <h3 className="text-slate-900 font-semibold">Objectives</h3>
+                <button onClick={skipGuide} className="text-xs text-slate-500 hover:text-slate-900">Skip</button>
               </div>
-            )}
+              <ul className="text-sm text-slate-700 space-y-1">
+                <li className="flex items-center gap-2"><span className={`inline-block h-2.5 w-2.5 rounded-full ${guideProgress.selectedTile ? 'bg-emerald-500' : 'bg-slate-300'}`}></span>Select any tile</li>
+                <li className="flex items-center gap-2"><span className={`inline-block h-2.5 w-2.5 rounded-full ${guideProgress.openedCouncil ? 'bg-emerald-500' : 'bg-slate-300'}`}></span>Open the Council</li>
+                <li className="flex items-center gap-2"><span className={`inline-block h-2.5 w-2.5 rounded-full ${guideProgress.generated ? 'bg-emerald-500' : 'bg-slate-300'}`}></span>Summon proposals</li>
+                <li className="flex items-center gap-2"><span className={`inline-block h-2.5 w-2.5 rounded-full ${guideProgress.accepted ? 'bg-emerald-500' : 'bg-slate-300'}`}></span>Accept one proposal</li>
+                <li className="flex items-center gap-2"><span className={`inline-block h-2.5 w-2.5 rounded-full ${guideProgress.advanced ? 'bg-emerald-500' : 'bg-slate-300'}`}></span>Advance the cycle</li>
+              </ul>
+              {!guideProgress.advanced && (
+                <div className="mt-3 text-xs text-slate-500">Complete these steps to finish the intro.</div>
+              )}
+              {guideProgress.advanced && (
+                <div className="mt-3 flex justify-end">
+                  <button onClick={skipGuide} className="px-3 py-1.5 rounded bg-emerald-600 hover:bg-emerald-700 text-white text-sm">Finish</button>
+                </div>
+              )}
+            </div>
           </div>
-        </div>
+        )
       )}
 
       {/* Onboarding Modal */}

--- a/src/components/game/SurvivalTracker.tsx
+++ b/src/components/game/SurvivalTracker.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { createSupabaseBrowserClient } from '@/lib/supabase/browser';
+
+interface SurvivalTrackerProps {
+  cycle: number;
+  unrest: number;
+  threat: number;
+}
+
+export default function SurvivalTracker({ cycle, unrest, threat }: SurvivalTrackerProps) {
+  const [bestCycle, setBestCycle] = useState<number>(cycle);
+
+  useEffect(() => {
+    let isMounted = true;
+    const loadBest = async () => {
+      let localBest = cycle;
+      try {
+        const stored = localStorage.getItem('ad_best_cycle');
+        if (stored) localBest = Math.max(localBest, parseInt(stored, 10));
+      } catch {}
+
+      let remoteBest = 0;
+      try {
+        const supabase = createSupabaseBrowserClient();
+        const { data } = await supabase
+          .from('game_state')
+          .select('cycle')
+          .order('cycle', { ascending: false })
+          .limit(1);
+        if (data && data.length > 0) remoteBest = data[0].cycle as number;
+      } catch {}
+
+      const best = Math.max(localBest, remoteBest);
+      if (isMounted) {
+        setBestCycle(best);
+      }
+      try { localStorage.setItem('ad_best_cycle', String(best)); } catch {}
+    };
+    loadBest();
+    return () => { isMounted = false; };
+  }, [cycle]);
+
+  useEffect(() => {
+    if (cycle > bestCycle) {
+      setBestCycle(cycle);
+      try { localStorage.setItem('ad_best_cycle', String(cycle)); } catch {}
+    }
+  }, [cycle, bestCycle]);
+
+  const bar = (label: string, value: number) => {
+    const pct = Math.max(0, Math.min(100, value));
+    const level = value >= 90 ? 'danger' : value >= 70 ? 'warn' : 'safe';
+    const base = 'h-2 rounded transition-all duration-300';
+    const color =
+      level === 'danger'
+        ? 'bg-red-600 animate-pulse'
+        : level === 'warn'
+        ? 'bg-amber-500 animate-pulse'
+        : 'bg-emerald-500';
+    return (
+      <div key={label}>
+        <div className="flex justify-between text-xs text-slate-600 mb-1">
+          <span>{label}</span>
+          <span>{pct}</span>
+        </div>
+        <div className="w-full h-2 bg-slate-200 rounded">
+          <div className={`${base} ${color}`} style={{ width: `${pct}%` }} />
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="bg-white/95 backdrop-blur-sm border border-slate-200 rounded-lg shadow-lg p-4">
+      <div className="flex items-center justify-between mb-2">
+        <h3 className="text-slate-900 font-semibold">Survival</h3>
+        <div className="text-sm text-slate-700 font-medium">Cycle {cycle}</div>
+      </div>
+      <div className="text-xs text-slate-500 mb-3">Best: {bestCycle}</div>
+      <div className="space-y-3">
+        {bar('Unrest', unrest)}
+        {bar('Threat', threat)}
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/game/SurvivalTracker.tsx
+++ b/src/components/game/SurvivalTracker.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { createSupabaseBrowserClient } from '@/lib/supabase/browser';
+import { useBestCycle } from '@/hooks/useBestCycle';
 
 interface SurvivalTrackerProps {
   cycle: number;
@@ -10,44 +9,7 @@ interface SurvivalTrackerProps {
 }
 
 export default function SurvivalTracker({ cycle, unrest, threat }: SurvivalTrackerProps) {
-  const [bestCycle, setBestCycle] = useState<number>(cycle);
-
-  useEffect(() => {
-    let isMounted = true;
-    const loadBest = async () => {
-      let localBest = cycle;
-      try {
-        const stored = localStorage.getItem('ad_best_cycle');
-        if (stored) localBest = Math.max(localBest, parseInt(stored, 10));
-      } catch {}
-
-      let remoteBest = 0;
-      try {
-        const supabase = createSupabaseBrowserClient();
-        const { data } = await supabase
-          .from('game_state')
-          .select('cycle')
-          .order('cycle', { ascending: false })
-          .limit(1);
-        if (data && data.length > 0) remoteBest = data[0].cycle as number;
-      } catch {}
-
-      const best = Math.max(localBest, remoteBest);
-      if (isMounted) {
-        setBestCycle(best);
-      }
-      try { localStorage.setItem('ad_best_cycle', String(best)); } catch {}
-    };
-    loadBest();
-    return () => { isMounted = false; };
-  }, [cycle]);
-
-  useEffect(() => {
-    if (cycle > bestCycle) {
-      setBestCycle(cycle);
-      try { localStorage.setItem('ad_best_cycle', String(cycle)); } catch {}
-    }
-  }, [cycle, bestCycle]);
+  const bestCycle = useBestCycle(cycle);
 
   const bar = (label: string, value: number) => {
     const pct = Math.max(0, Math.min(100, value));

--- a/src/hooks/useBestCycle.ts
+++ b/src/hooks/useBestCycle.ts
@@ -1,0 +1,50 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { createSupabaseBrowserClient } from '@/lib/supabase/browser';
+
+interface GameStateRow {
+  cycle: number;
+}
+
+export function useBestCycle(cycle: number) {
+  const [bestCycle, setBestCycle] = useState<number>(cycle);
+
+  useEffect(() => {
+    let isMounted = true;
+    const loadBest = async () => {
+      let localBest = cycle;
+      try {
+        const stored = localStorage.getItem('ad_best_cycle');
+        if (stored) localBest = Math.max(localBest, parseInt(stored, 10));
+      } catch {}
+
+      let remoteBest = 0;
+      try {
+        const supabase = createSupabaseBrowserClient();
+        const { data } = await supabase
+          .from<GameStateRow>('game_state')
+          .select('cycle')
+          .order('cycle', { ascending: false })
+          .limit(1);
+        if (data && data.length > 0) remoteBest = data[0].cycle;
+      } catch {}
+
+      const best = Math.max(localBest, remoteBest);
+      if (isMounted) setBestCycle(best);
+      try { localStorage.setItem('ad_best_cycle', String(best)); } catch {}
+    };
+    loadBest();
+    return () => { isMounted = false; };
+  }, [cycle]);
+
+  useEffect(() => {
+    if (cycle > bestCycle) {
+      setBestCycle(cycle);
+      try { localStorage.setItem('ad_best_cycle', String(cycle)); } catch {}
+    }
+  }, [cycle, bestCycle]);
+
+  return bestCycle;
+}
+


### PR DESCRIPTION
## Summary
- add SurvivalTracker component that tracks current and best cycle and displays unrest/threat bars with warning animations
- show SurvivalTracker after onboarding instead of objectives block

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any...)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e3cf66488325bcf2c3d7991dd2b1