### PR TITLE
feat: track max cycle in game state

### DIFF
--- a/supabase/migrations/20250831000000_reconcile_schema.sql
+++ b/supabase/migrations/20250831000000_reconcile_schema.sql
@@ -8,6 +8,10 @@ create extension if not exists pgcrypto;
 alter table if exists game_state
   add column if not exists updated_at timestamptz not null default now();
 
+-- Ensure max_cycle column exists on game_state
+alter table if exists game_state
+  add column if not exists max_cycle int not null default 0;
+
 -- Ensure proposals index exists
 create index if not exists proposals_state_status_idx on proposals(state_id, status);
 

--- a/supabase/migrations/20250831001000_ensure_core_tables.sql
+++ b/supabase/migrations/20250831001000_ensure_core_tables.sql
@@ -8,6 +8,7 @@ create table if not exists game_state (
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),
   cycle int not null default 1,
+  max_cycle int not null default 0,
   resources jsonb not null default '{"grain": 1000, "coin": 500, "mana": 200, "favor": 10, "unrest": 0, "threat": 0}',
   notes text
 );

--- a/supabase/migrations/20250902000000_add_game_state_max_cycle.sql
+++ b/supabase/migrations/20250902000000_add_game_state_max_cycle.sql
@@ -1,0 +1,6 @@
+-- Add max_cycle column to game_state
+alter table if exists game_state
+  add column if not exists max_cycle int not null default 0;
+
+-- Initialize max_cycle to current cycle where applicable
+update game_state set max_cycle = greatest(max_cycle, cycle);


### PR DESCRIPTION
## Summary
- add `max_cycle` to `game_state` with migrations and schema updates
- scale unrest and threat decay based on current cycle
- track highest cycle reached and include `max_cycle` in tick response

## Testing
- `npm test`
- `npm run lint` *(fails: react-hooks/exhaustive-deps, no-unused-vars, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b5e3d121dc8325b74dc9eb0a7f5a48