### PR TITLE
feat: add crisis handling for unrest and threat

### DIFF
--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -13,6 +13,7 @@ import { createSupabaseBrowserClient } from '@/lib/supabase/browser'
 import EffectsLayer from '@/components/game/EffectsLayer';
 import HeatLayer from '@/components/game/HeatLayer';
 import MarkersLayer from '@/components/game/MarkersLayer';
+import CrisisModal, { CrisisData } from '@/components/game/CrisisModal';
 
 interface GameState {
   id: string;
@@ -49,6 +50,7 @@ export default function PlayPage() {
   const [error, setError] = useState<string | null>(null);
   const [isPaused, setIsPaused] = useState(true);
   const [timeRemaining, setTimeRemaining] = useState(120); // 2 minutes per cycle
+  const [crisis, setCrisis] = useState<CrisisData | null>(null);
   
   // Panel states
   const [isCouncilOpen, setIsCouncilOpen] = useState(false);
@@ -137,8 +139,12 @@ export default function PlayPage() {
       const res = await fetch(`/api/state/tick`, { method: "POST" });
       const json = await res.json();
       if (!res.ok) throw new Error(json.error || "Failed to tick");
-      setState(json);
+      setState(json.state);
       setTimeRemaining(120); // Reset timer
+      if (json.crisis) {
+        setIsPaused(true);
+        setCrisis(json.crisis);
+      }
       await fetchProposals();
     } catch (e: any) {
       setError(e.message);
@@ -767,6 +773,16 @@ export default function PlayPage() {
             </div>
           </div>
         </div>
+      )}
+
+      {crisis && (
+        <CrisisModal
+          crisis={crisis}
+          onResolve={() => {
+            setCrisis(null);
+            setIsPaused(false);
+          }}
+        />
       )}
 
       {error && (

--- a/src/components/game/CrisisModal.tsx
+++ b/src/components/game/CrisisModal.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { ActionButton, ResourceIcon } from '../ui';
+import type { ResourceType } from '../ui/ResourceIcon';
+
+export interface CrisisData {
+  type: 'unrest' | 'threat';
+  message: string;
+  penalty: Record<string, number>;
+}
+
+interface CrisisModalProps {
+  crisis: CrisisData;
+  onResolve: () => void;
+}
+
+const CrisisModal: React.FC<CrisisModalProps> = ({ crisis, onResolve }) => (
+  <Dialog.Root open>
+    <Dialog.Overlay className="fixed inset-0 bg-black/50 z-50" />
+    <Dialog.Content className="fixed z-50 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-white rounded-lg shadow-xl p-6 w-full max-w-md">
+      <Dialog.Title className="text-xl font-bold mb-2">
+        {crisis.type === 'unrest' ? 'Unrest Boils Over' : 'Threat Escalates'}
+      </Dialog.Title>
+      <Dialog.Description className="text-slate-700 mb-4">
+        {crisis.message}
+      </Dialog.Description>
+      <div className="mb-4">
+        <h3 className="font-semibold text-slate-800 mb-2">Temporary Penalty</h3>
+        <ul className="space-y-1">
+          {Object.entries(crisis.penalty).map(([key, val]) => (
+            <li key={key} className="flex items-center gap-2 text-sm text-slate-700">
+              <ResourceIcon type={key as ResourceType} value={val} />
+              <span>-{Math.abs(val)} {key}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="text-right">
+        <Dialog.Close asChild>
+          <ActionButton onClick={onResolve} variant="primary">Endure</ActionButton>
+        </Dialog.Close>
+      </div>
+    </Dialog.Content>
+  </Dialog.Root>
+);
+
+export default CrisisModal;


### PR DESCRIPTION
## Summary
- add `CrisisModal` to narrate unrest or threat emergencies and display penalties
- extend state tick API to flag crises and apply temporary resource losses
- pause play and show crisis modal when returned from tick

## Testing
- `npm test`
- `npm run lint` *(fails: 56 problems (26 errors, 30 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68b5e3d40500832581265889d2bd616a