### PR TITLE
feat: add random flavor events

### DIFF
--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -13,6 +13,8 @@ import { createSupabaseBrowserClient } from '@/lib/supabase/browser'
 import EffectsLayer from '@/components/game/EffectsLayer';
 import HeatLayer from '@/components/game/HeatLayer';
 import MarkersLayer from '@/components/game/MarkersLayer';
+import FlavorEvent from '@/components/game/FlavorEvent';
+import { FlavorEventDef, getRandomFlavorEvent } from '@/components/game/flavorEvents';
 
 interface GameState {
   id: string;
@@ -57,6 +59,7 @@ export default function PlayPage() {
   const [dismissedGuide, setDismissedGuide] = useState(false);
   const [acceptedNotice, setAcceptedNotice] = useState<{ title: string; delta: Record<string, number> } | null>(null);
   const [markers, setMarkers] = useState<{ id: string; x: number; y: number; label?: string }[]>([]);
+  const [flavorEvent, setFlavorEvent] = useState<FlavorEventDef | null>(null);
   // onboarding & guidance
   const [gameMode, setGameMode] = useState<'casual' | 'advanced'>('casual');
   const [showOnboarding, setShowOnboarding] = useState(false);
@@ -140,6 +143,20 @@ export default function PlayPage() {
       setState(json);
       setTimeRemaining(120); // Reset timer
       await fetchProposals();
+      if (Math.random() < 0.2) {
+        const ev = getRandomFlavorEvent();
+        setFlavorEvent(ev);
+        if (ev.delta) {
+          setState(prev => {
+            if (!prev) return prev;
+            const resources = { ...prev.resources };
+            for (const [k, v] of Object.entries(ev.delta!)) {
+              resources[k] = (resources[k] || 0) + v;
+            }
+            return { ...prev, resources };
+          });
+        }
+      }
     } catch (e: any) {
       setError(e.message);
     } finally {
@@ -765,8 +782,13 @@ export default function PlayPage() {
               <button onClick={() => { setAcceptedNotice(null); tick(); }} className="px-3 py-1.5 rounded bg-emerald-600 hover:bg-emerald-700 text-white text-sm">Advance Cycle</button>
               <button onClick={() => setAcceptedNotice(null)} className="px-3 py-1.5 rounded bg-slate-100 hover:bg-slate-200 text-slate-700 text-sm">Later</button>
             </div>
-          </div>
         </div>
+      </div>
+      )}
+
+      {/* Flavor event dialog */}
+      {flavorEvent && (
+        <FlavorEvent event={flavorEvent} onClose={() => setFlavorEvent(null)} />
       )}
 
       {error && (

--- a/src/components/game/FlavorEvent.tsx
+++ b/src/components/game/FlavorEvent.tsx
@@ -1,0 +1,38 @@
+import { FlavorEventDef } from './flavorEvents';
+import { getResourceColor, getResourceIcon, ResourceType } from './resourceUtils';
+
+interface Props {
+  event: FlavorEventDef;
+  onClose: () => void;
+}
+
+export default function FlavorEvent({ event, onClose }: Props) {
+  return (
+    <div className="absolute top-24 left-1/2 -translate-x-1/2 z-50 pointer-events-auto">
+      <div className="bg-white/95 backdrop-blur-sm border border-slate-200 rounded-lg shadow-lg p-4 max-w-sm w-[90vw] sm:w-auto">
+        <div className="flex items-start justify-between gap-4">
+          <div className="text-sm text-slate-800">
+            {event.message}
+          </div>
+          <button
+            onClick={onClose}
+            className="text-slate-500 hover:text-slate-900 rounded p-1 hover:bg-slate-100"
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
+        {event.delta && Object.keys(event.delta).length > 0 && (
+          <div className="mt-3 grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
+            {Object.entries(event.delta).map(([key, value]) => (
+              <div key={key} className="flex items-center gap-1">
+                <span className={getResourceColor(key as ResourceType)}>{getResourceIcon(key as ResourceType)}</span>
+                <span className="font-mono">{value! >= 0 ? '+' : ''}{value}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/game/flavorEvents.ts
+++ b/src/components/game/flavorEvents.ts
@@ -1,0 +1,32 @@
+import { ResourceType } from './resourceUtils';
+
+export interface FlavorEventDef {
+  message: string;
+  delta?: Partial<Record<ResourceType, number>>;
+}
+
+export const FLAVOR_EVENTS: FlavorEventDef[] = [
+  {
+    message: 'A traveling bard sings of your realm, bolstering morale.',
+    delta: { favor: 1 },
+  },
+  {
+    message: 'A stray pixie leaves a trail of glittering mana in its wake.',
+    delta: { mana: 2 },
+  },
+  {
+    message: 'A mischievous urchin filches a few coins from the treasury.',
+    delta: { coin: -3 },
+  },
+  {
+    message: 'A bumper crop of grain sprouted overnight after a warm rain.',
+    delta: { grain: 4 },
+  },
+  {
+    message: 'A quiet day passes with nothing of note.'
+  },
+];
+
+export function getRandomFlavorEvent(): FlavorEventDef {
+  return FLAVOR_EVENTS[Math.floor(Math.random() * FLAVOR_EVENTS.length)];
+}


### PR DESCRIPTION
## Summary
- show whimsical flavor events in a small dialog
- roll 20% chance after each cycle tick and tweak resources
- keep timer running when flavor events pop up

## Testing
- `npm test`
- `npx tsc --noEmit` *(fails: Variable 'supabase' implicitly has type 'any', argument type errors in EffectsLayer and MarkersLayer)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e4095110832598f3b3e66bcf5c77