### PR TITLE
feat: centralize logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@supabase/supabase-js": "^2.56.1",
         "ai": "^5.0.28",
         "autoprefixer": "^10.4.21",
+        "loglevel": "^1.9.2",
         "next": "15.5.2",
         "pixi-viewport": "^6.0.3",
         "pixi.js": "^8.12.0",
@@ -6554,6 +6555,19 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@supabase/supabase-js": "^2.56.1",
     "ai": "^5.0.28",
     "autoprefixer": "^10.4.21",
+    "loglevel": "^1.9.2",
     "next": "15.5.2",
     "pixi-viewport": "^6.0.3",
     "pixi.js": "^8.12.0",

--- a/src/app/api/proposals/route.ts
+++ b/src/app/api/proposals/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase/server'
+import logger from '@/lib/logger'
 
 export async function GET(_req: NextRequest) {
   try {
@@ -13,7 +14,7 @@ export async function GET(_req: NextRequest) {
       .limit(1)
       .maybeSingle()
     if (stateErr) {
-      console.error('Supabase error in proposals route:', stateErr.message)
+      logger.error('Supabase error in proposals route:', stateErr.message)
       return NextResponse.json(
         { error: 'Database connection failed' },
         { status: 503 }
@@ -28,7 +29,7 @@ export async function GET(_req: NextRequest) {
       .in('status', ['pending', 'accepted', 'rejected'])
       .order('created_at', { ascending: false })
     if (propErr) {
-      console.error('Supabase error fetching proposals:', propErr.message)
+      logger.error('Supabase error fetching proposals:', propErr.message)
       return NextResponse.json(
         { error: 'Failed to fetch proposals' },
         { status: 503 }
@@ -37,7 +38,7 @@ export async function GET(_req: NextRequest) {
 
     return NextResponse.json({ proposals })
   } catch (error) {
-    console.error('Supabase connection error in proposals route:', error)
+    logger.error('Supabase connection error in proposals route:', error)
     return NextResponse.json(
       { error: 'Service unavailable - database not configured' },
       { status: 503 }

--- a/src/app/api/state/route.ts
+++ b/src/app/api/state/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase/server'
+import logger from '@/lib/logger'
 
 export async function GET() {
   try {
@@ -13,7 +14,7 @@ export async function GET() {
       .maybeSingle()
 
     if (error) {
-      console.error('Supabase error:', error.message)
+      logger.error('Supabase error:', error.message)
       return NextResponse.json(
         { error: `Database error: ${error.message}` },
         { status: 503 }
@@ -28,7 +29,7 @@ export async function GET() {
         .select('*')
         .single()
       if (createErr) {
-        console.error('Supabase create error:', createErr.message)
+        logger.error('Supabase create error:', createErr.message)
         return NextResponse.json(
           { error: 'Failed to create game state' },
           { status: 503 }
@@ -39,7 +40,7 @@ export async function GET() {
 
     return NextResponse.json(state)
   } catch (error) {
-    console.error('Supabase connection error:', error)
+    logger.error('Supabase connection error:', error)
     return NextResponse.json(
       { error: 'Service unavailable - database not configured' },
       { status: 503 }

--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import GameRenderer from '@/components/game/GameRenderer';
+import logger from '@/lib/logger';
 
 import { GameHUD, GameResources, GameTime } from '@/components/game/GameHUD';
 import { CouncilPanel, CouncilProposal } from '@/components/game/CouncilPanel';
@@ -18,6 +19,7 @@ import FlavorEvent from '@/components/game/FlavorEvent';
 import { FlavorEventDef, getRandomFlavorEvent } from '@/components/game/flavorEvents';
 import CrisisModal, { CrisisData } from '@/components/game/CrisisModal';
 import GoalBanner from '@/components/game/GoalBanner';
+
 
 interface GameState {
   id: string;
@@ -121,11 +123,11 @@ export default function PlayPage() {
     }
   }, [state]);
   const fetchState = useCallback(async () => {
-    console.log('Fetching state from /api/state');
+    logger.debug('Fetching state from /api/state');
     const res = await fetch("/api/state");
-    console.log('Response status:', res.status, res.ok);
+    logger.debug('Response status:', res.status, res.ok);
     const json = await res.json();
-    console.log('Response JSON:', json);
+    logger.debug('Response JSON:', json);
     if (!res.ok) throw new Error(json.error || "Failed to fetch state");
     setState(json);
   }, []);
@@ -178,7 +180,7 @@ export default function PlayPage() {
         await fetchState();
         await fetchProposals();
       } catch (e: any) {
-        console.error('Failed to connect to database:', e.message);
+        logger.error('Failed to connect to database:', e.message);
         setError(e.message);
       }
     })();
@@ -209,7 +211,7 @@ export default function PlayPage() {
     try {
       client = createSupabaseBrowserClient();
     } catch (e: any) {
-      console.warn('Realtime disabled:', e?.message || String(e));
+      logger.debug('Realtime disabled:', e?.message || String(e));
       return; // Early exit: supabase not configured in browser env
     }
 

--- a/src/components/game/GameCanvas.tsx
+++ b/src/components/game/GameCanvas.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import * as PIXI from "pixi.js";
 import { Viewport } from "pixi-viewport";
 import { useGameContext } from "./GameContext";
+import logger from "@/lib/logger";
 
 interface GameCanvasProps {
   width?: number;
@@ -18,7 +19,7 @@ export default function GameCanvas({
   onTileHover,
   onTileClick,
 }: GameCanvasProps) {
-  console.log('GameCanvas component mounted with props:', { width, height });
+  logger.debug("GameCanvas component mounted with props:", { width, height });
   
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const appRef = useRef<PIXI.Application | null>(null);
@@ -30,23 +31,23 @@ export default function GameCanvas({
   const { setApp, setViewport } = useGameContext();
 
   useEffect(() => {
-    console.log('GameCanvas useEffect triggered with width:', width, 'height:', height);
-    console.log('Canvas ref available:', !!canvasRef.current);
-    console.log('Is initialized:', isInitialized);
+    logger.debug("GameCanvas useEffect triggered with width:", width, "height:", height);
+    logger.debug("Canvas ref available:", !!canvasRef.current);
+    logger.debug("Is initialized:", isInitialized);
     
     if (!canvasRef.current) {
-      console.error('Canvas ref is not available!');
+      logger.error("Canvas ref is not available!");
       return;
     }
     
     if (isInitialized) {
-      console.log('Canvas already initialized, skipping');
+      logger.debug("Canvas already initialized, skipping");
       return;
     }
 
     const initPixi = async () => {
         const initializeCanvas = async () => {
-          console.log('Starting PIXI initialization...');
+          logger.debug("Starting PIXI initialization...");
         // Create PIXI Application with enhanced fallback options
         const app = new PIXI.Application();
         
@@ -73,13 +74,13 @@ export default function GameCanvas({
         const canvas = app.canvas as HTMLCanvasElement;
         
         contextLostHandlerRef.current = (event: Event) => {
-          console.warn('WebGL context lost, preventing default behavior');
+          logger.warn("WebGL context lost, preventing default behavior");
           event.preventDefault();
           setInitError('WebGL context lost. The game will attempt to restore automatically.');
         };
         
         contextRestoredHandlerRef.current = () => {
-          console.log('WebGL context restored, reinitializing...');
+          logger.debug("WebGL context restored, reinitializing...");
           setInitError(null);
           setIsInitialized(false);
           // Trigger reinitialization
@@ -160,15 +161,15 @@ export default function GameCanvas({
         setViewport(viewport);
 
         setIsInitialized(true);
-        console.log('PIXI Application initialized successfully');
-        console.log('App canvas dimensions:', app.canvas.width, 'x', app.canvas.height);
-        console.log('Viewport world size:', viewport.worldWidth, 'x', viewport.worldHeight);
-        console.log('Viewport position:', viewport.x, viewport.y);
-        console.log('Viewport scale:', viewport.scale.x, viewport.scale.y);
+        logger.debug("PIXI Application initialized successfully");
+        logger.debug("App canvas dimensions:", app.canvas.width, "x", app.canvas.height);
+        logger.debug("Viewport world size:", viewport.worldWidth, "x", viewport.worldHeight);
+        logger.debug("Viewport position:", viewport.x, viewport.y);
+        logger.debug("Viewport scale:", viewport.scale.x, viewport.scale.y);
       };
 
       const initializeFallbackCanvas = async () => {
-        console.log('Initializing fallback canvas with reduced settings...');
+        logger.debug("Initializing fallback canvas with reduced settings...");
         
         const app = new PIXI.Application();
         
@@ -217,30 +218,30 @@ export default function GameCanvas({
         setApp(app);
         setViewport(viewport);
         setIsInitialized(true);
-        console.log('Fallback canvas initialized successfully');
+        logger.debug("Fallback canvas initialized successfully");
       };
 
       try {
         await initializeCanvas();
       } catch (error) {
-        console.error('Failed to initialize game canvas:', error);
+        logger.error("Failed to initialize game canvas:", error);
         
         // Try fallback initialization with reduced settings
         try {
-          console.log('Attempting fallback canvas initialization...');
+          logger.debug("Attempting fallback canvas initialization...");
           await initializeFallbackCanvas();
         } catch (fallbackError) {
-          console.error('Fallback initialization also failed:', fallbackError);
+          logger.error("Fallback initialization also failed:", fallbackError);
           const errorMessage = fallbackError instanceof Error ? fallbackError.message : 'Unknown WebGL error';
           setInitError('Failed to initialize game canvas. Your browser may not support WebGL.');
           setIsInitialized(true); // Set to true to stop loading state
           
           // Provide helpful error messages based on common issues
           if (errorMessage.includes('WebGL')) {
-            console.warn('WebGL initialization failed. This may be due to:');
-            console.warn('- Hardware acceleration disabled');
-            console.warn('- Outdated graphics drivers');
-            console.warn('- Browser security settings');
+            logger.warn("WebGL initialization failed. This may be due to:");
+            logger.warn("- Hardware acceleration disabled");
+            logger.warn("- Outdated graphics drivers");
+            logger.warn("- Browser security settings");
           }
         }
       }

--- a/src/components/game/GameContext.tsx
+++ b/src/components/game/GameContext.tsx
@@ -3,6 +3,7 @@
 import { createContext, useContext, ReactNode } from "react";
 import { Viewport } from "pixi-viewport";
 import * as PIXI from "pixi.js";
+import logger from "@/lib/logger";
 
 interface GameContextType {
   app: PIXI.Application | null;
@@ -36,7 +37,7 @@ export function GameProvider({
   setApp,
   setViewport,
 }: GameProviderProps) {
-  console.log('GameProvider rendering with:', { app: !!app, viewport: !!viewport });
+  logger.debug("GameProvider rendering with:", { app: !!app, viewport: !!viewport });
   
   return (
     <GameContext.Provider value={{ app, viewport, setApp, setViewport }}>

--- a/src/components/game/GameRenderer.tsx
+++ b/src/components/game/GameRenderer.tsx
@@ -8,6 +8,7 @@ import { GameProvider } from "./GameContext";
 import { Viewport } from "pixi-viewport";
 import * as PIXI from "pixi.js";
 import MiniMap from "./MiniMap";
+import logger from "@/lib/logger";
 
 interface GameRendererProps {
   width?: number;
@@ -25,7 +26,7 @@ function GameRendererContent({
   onTileHover,
   onTileClick,
 }: GameRendererProps) {
-  console.log('GameRendererContent rendering with:', { width, height, gridSize });
+  logger.debug("GameRendererContent rendering with:", { width, height, gridSize });
   const [showHelp, setShowHelp] = useState(true);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [dims, setDims] = useState<{ w: number; h: number }>({ w: width, h: height });
@@ -108,7 +109,7 @@ function GameRendererContent({
 }
 
 export default function GameRenderer({ children, ...props }: GameRendererProps) {
-  console.log('GameRenderer component rendering with props:', props);
+  logger.debug("GameRenderer component rendering with props:", props);
   
   const [app, setApp] = useState<PIXI.Application | null>(null);
   const [viewport, setViewport] = useState<Viewport | null>(null);

--- a/src/components/game/IsometricGrid.tsx
+++ b/src/components/game/IsometricGrid.tsx
@@ -2,8 +2,8 @@
 
 import { useEffect, useRef } from "react";
 import * as PIXI from "pixi.js";
-import { Viewport } from "pixi-viewport";
 import { useGameContext } from "./GameContext";
+import logger from "@/lib/logger";
 
 interface GridTile {
   x: number;
@@ -110,9 +110,9 @@ export default function IsometricGrid({
 
   // Initialize grid
   useEffect(() => {
-    console.log('IsometricGrid useEffect triggered, viewport:', viewport);
+    logger.debug('IsometricGrid useEffect triggered, viewport:', viewport);
     if (!viewport) {
-      console.warn('IsometricGrid: No viewport available');
+      logger.warn('IsometricGrid: No viewport available');
       return;
     }
     if (initializedRef.current) {
@@ -121,7 +121,7 @@ export default function IsometricGrid({
     }
     initializedRef.current = true;
 
-    console.log('Creating grid container and tiles...');
+    logger.debug('Creating grid container and tiles...');
     const gridContainer = new PIXI.Container();
     gridContainer.name = 'isometric-grid';
     viewport.addChild(gridContainer);
@@ -139,8 +139,8 @@ export default function IsometricGrid({
       }
     }
     
-    console.log(`Created ${tiles.size} tiles for ${gridSize}x${gridSize} grid`);
-    console.log('Grid container children count:', gridContainer.children.length);
+    logger.debug(`Created ${tiles.size} tiles for ${gridSize}x${gridSize} grid`);
+    logger.debug('Grid container children count:', gridContainer.children.length);
     tilesRef.current = tiles;
 
     // Compute world bounds for clamping based on isometric grid extents
@@ -163,7 +163,7 @@ export default function IsometricGrid({
       viewport.setZoom(1.5);
       viewport.moveCenter(gridCenterX, gridCenterY);
       centeredRef.current = true;
-      console.log(`Centered viewport on geometric center at (${gridCenterX}, ${gridCenterY})`);
+      logger.debug(`Centered viewport on geometric center at (${gridCenterX}, ${gridCenterY})`);
     }
 
     const halfW = tileWidth / 2;

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,10 @@
+import log from 'loglevel';
+
+const logger = log.getLogger('arcane-dominion');
+
+const level = (process.env.NEXT_PUBLIC_LOG_LEVEL as log.LogLevelDesc) ||
+  (process.env.NODE_ENV === 'development' ? 'debug' : 'error');
+
+logger.setLevel(level);
+
+export default logger;

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js'
+import logger from '@/lib/logger'
 
 // Server-side Supabase client using the service role key (never sent to the browser)
 // Ensure these env vars are set in your environment (e.g., .env.local)
@@ -9,7 +10,7 @@ export function createSupabaseServerClient() {
   const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
 
   if (!url || !serviceKey || url.includes('placeholder') || serviceKey.includes('placeholder')) {
-    console.error('Supabase configuration missing:', {
+    logger.error('Supabase configuration missing:', {
       hasUrl: !!url,
       hasServiceKey: !!serviceKey,
       urlContainsPlaceholder: url?.includes('placeholder'),


### PR DESCRIPTION
## Summary
- add loglevel-based logger to control client and server verbosity
- replace scattered console statements with centralized logger across game components and API routes
- wire supabase client to logger for clearer configuration errors

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any and other existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e7641f648325bdbc5e9e125e8472