### PR TITLE
feat: add district hover tooltip

### DIFF
--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useRef } from 'react';
+import * as PIXI from 'pixi.js';
 import GameRenderer from '@/components/game/GameRenderer';
 
 import { GameHUD, GameResources, GameTime } from '@/components/game/GameHUD';
@@ -84,6 +85,10 @@ export default function PlayPage() {
   const [selectedLeyline, setSelectedLeyline] = useState<Leyline | null>(null);
   const [isDrawingMode, setIsDrawingMode] = useState(false);
   const hasAutoOpenedCouncilRef = useRef(false);
+
+  // Tooltip state
+  const [cursorPos, setCursorPos] = useState({ x: 0, y: 0 });
+  const [tooltip, setTooltip] = useState<{ x: number; y: number; district: District } | null>(null);
   
   // Panels data (empty until backend features are implemented)
   const [edicts, setEdicts] = useState<EdictSetting[]>([]);
@@ -333,6 +338,22 @@ export default function PlayPage() {
   }, [placedBuildings, selectedTile]);
   const handleTileHover = (x: number, y: number) => {
     setSelectedTile({ x, y });
+    const district = districts.find(d => d.gridX === x && d.gridY === y);
+    if (district) {
+      setTooltip({ x: cursorPos.x, y: cursorPos.y, district });
+    } else {
+      setTooltip(null);
+    }
+  };
+
+  const handleDistrictHover = (district: District | null, e?: PIXI.FederatedPointerEvent) => {
+    if (district) {
+      const x = e?.clientX ?? cursorPos.x;
+      const y = e?.clientY ?? cursorPos.y;
+      setTooltip({ x, y, district });
+    } else {
+      setTooltip(null);
+    }
   };
 
   const handleTileClick = (x: number, y: number) => {
@@ -514,7 +535,11 @@ export default function PlayPage() {
     <div className="h-screen bg-neutral-50 overflow-hidden relative flex flex-col">
       <GoalBanner />
 
-      <div className="flex-1 relative min-h-0">
+      <div
+        className="flex-1 relative min-h-0"
+        onMouseMove={e => setCursorPos({ x: e.clientX, y: e.clientY })}
+        onMouseLeave={() => setTooltip(null)}
+      >
 
         {/* Sim Mode overlays */}
         <div className="absolute top-4 right-4 z-40 flex gap-2">
@@ -567,7 +592,7 @@ export default function PlayPage() {
         )}
 
         <GameRenderer onTileHover={handleTileHover} onTileClick={handleTileClick}>
-          <DistrictSprites districts={districts} />
+          <DistrictSprites districts={districts} onDistrictHover={handleDistrictHover} />
           <LeylineSystem
             leylines={leylines}
             onLeylineCreate={handleLeylineCreate}
@@ -594,6 +619,15 @@ export default function PlayPage() {
             ...placedBuildings.map(b => ({ id: `b-${b.id}`, x: b.x, y: b.y, label: SIM_BUILDINGS[b.typeId].name }))
           ].map(m => ({ id: m.id, gridX: m.x, gridY: m.y, label: m.label }))} />
         </GameRenderer>
+        {tooltip && (
+          <div
+            className="pointer-events-none fixed bg-white rounded shadow px-2 py-1 text-xs"
+            style={{ left: tooltip.x + 12, top: tooltip.y + 12 }}
+          >
+            <div className="font-semibold capitalize">{tooltip.district.type}</div>
+            <div className="text-[10px] text-slate-500">Tier {tooltip.district.tier}</div>
+          </div>
+        )}
       </div>
 
       <GameHUD

--- a/src/components/game/DistrictSprites.tsx
+++ b/src/components/game/DistrictSprites.tsx
@@ -50,7 +50,7 @@ interface DistrictSpritesProps {
   tileWidth?: number;
   tileHeight?: number;
   onDistrictClick?: (district: District) => void;
-  onDistrictHover?: (district: District | null) => void;
+  onDistrictHover?: (district: District | null, event?: PIXI.FederatedPointerEvent) => void;
 }
 
 export default function DistrictSprites({
@@ -219,14 +219,14 @@ export default function DistrictSprites({
     container.addChild(stateOverlay);
     
     // Interaction events
-    container.on('pointerover', () => {
+    container.on('pointerover', (event: PIXI.FederatedPointerEvent) => {
       container.scale.set(1.1);
-      onDistrictHover?.(district);
+      onDistrictHover?.(district, event);
     });
-    
-    container.on('pointerout', () => {
+
+    container.on('pointerout', (event: PIXI.FederatedPointerEvent) => {
       container.scale.set(1.0);
-      onDistrictHover?.(null);
+      onDistrictHover?.(null, event);
     });
     
     container.on('pointerdown', () => {


### PR DESCRIPTION
## Summary
- pass district data through onDistrictHover in DistrictSprites
- show a cursor-following tooltip with district details in play page

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any and unused vars in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ea4d65108325b0fdf50347dcc4c7