### PR TITLE
refactor: centralize category definitions

### DIFF
--- a/src/components/game/CouncilPanel.tsx
+++ b/src/components/game/CouncilPanel.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import { GameResources } from './GameHUD';
 import { getResourceIcon, getResourceColor } from './resourceUtils';
+import { CategoryIcon } from '../ui';
+import { CategoryType } from '@/lib/categories';
 
 export interface ProposalDelta {
   grain?: number;
@@ -16,7 +18,7 @@ export interface CouncilProposal {
   id: string;
   title: string;
   description: string;
-  type: 'economic' | 'military' | 'diplomatic' | 'mystical' | 'infrastructure';
+  type: CategoryType;
   cost: ProposalDelta;
   benefit: ProposalDelta;
   risk: number; // 0-100 percentage
@@ -68,25 +70,15 @@ const ProposalCard: React.FC<{
   onReject: () => void;
   onScry: () => void;
 }> = ({ proposal, currentResources, onAccept, onReject, onScry }) => {
-  const getTypeColor = (type: CouncilProposal['type']) => {
+  const getTypeColor = (type: CategoryType) => {
     switch (type) {
       case 'economic': return 'bg-yellow-100 text-yellow-800 border border-yellow-200';
       case 'military': return 'bg-red-100 text-red-800 border border-red-200';
       case 'diplomatic': return 'bg-blue-100 text-blue-800 border border-blue-200';
       case 'mystical': return 'bg-purple-100 text-purple-800 border border-purple-200';
       case 'infrastructure': return 'bg-green-100 text-green-800 border border-green-200';
+      case 'social': return 'bg-pink-100 text-pink-800 border border-pink-200';
       default: return 'bg-gray-100 text-gray-800 border border-gray-200';
-    }
-  };
-
-  const getTypeIcon = (type: CouncilProposal['type']) => {
-    switch (type) {
-      case 'economic': return '💰';
-      case 'military': return '⚔️';
-      case 'diplomatic': return '🤝';
-      case 'mystical': return '🔮';
-      case 'infrastructure': return '🏗️';
-      default: return '📋';
     }
   };
 
@@ -111,7 +103,7 @@ const ProposalCard: React.FC<{
       <div className="flex items-start justify-between mb-3">
         <div className="flex items-center gap-2">
           <span className={`px-2 py-1 rounded text-xs font-medium ${getTypeColor(proposal.type)}`}>
-            {getTypeIcon(proposal.type)} {proposal.type.toUpperCase()}
+            <CategoryIcon category={proposal.type} className="text-xs" /> {proposal.type.toUpperCase()}
           </span>
           <div className="flex items-center gap-1">
             <span className="text-xs text-muted">Risk:</span>

--- a/src/components/game/EdictsPanel.tsx
+++ b/src/components/game/EdictsPanel.tsx
@@ -6,13 +6,14 @@ import * as Tooltip from '@radix-ui/react-tooltip';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCrown, faScroll, faXmark, faLock } from '@/lib/icons';
 import { CategoryIcon } from '../ui';
+import { CategoryType, CATEGORY_TYPES } from '@/lib/categories';
 
 export interface EdictSetting {
   id: string;
   name: string;
   description: string;
   type: 'slider' | 'toggle';
-  category: 'economic' | 'military' | 'social' | 'mystical';
+  category: CategoryType;
   currentValue: number; // 0-100 for sliders, 0/1 for toggles
   defaultValue: number;
   cost?: number; // Favor cost to change
@@ -159,11 +160,13 @@ const CategorySection: React.FC<{
   
   if (categoryEdicts.length === 0) return null;
 
-  const categoryNames = {
+  const categoryNames: Record<CategoryType, string> = {
     economic: 'Economic Policy',
     military: 'Military Doctrine',
     social: 'Social Order',
-    mystical: 'Mystical Arts'
+    mystical: 'Mystical Arts',
+    diplomatic: 'Diplomacy',
+    infrastructure: 'Infrastructure',
   };
 
   return (
@@ -250,7 +253,7 @@ export const EdictsPanel: React.FC<EdictsPanelProps> = ({
           <div className="flex flex-col h-[calc(90vh-120px)]">
             <div className="flex-1 p-6 overflow-y-auto">
               <div className="space-y-8">
-                {(['economic', 'military', 'social', 'mystical'] as const).map(category => (
+                {CATEGORY_TYPES.filter(category => edicts.some(e => e.category === category)).map(category => (
                   <CategorySection
                     key={category}
                     category={category}

--- a/src/components/ui/CategoryIcon.tsx
+++ b/src/components/ui/CategoryIcon.tsx
@@ -1,29 +1,14 @@
 import React from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
-import {
-  faSackDollar,
-  faShieldHalved,
-  faUsers,
-  faHatWizard
-} from '@/lib/icons';
-
-export type CategoryType = 'economic' | 'military' | 'social' | 'mystical';
+import { CATEGORY_ICONS, CategoryType } from '@/lib/categories';
 
 export interface CategoryIconProps {
   category: CategoryType;
   className?: string;
 }
 
-const ICONS: Record<CategoryType, IconDefinition> = {
-  economic: faSackDollar,
-  military: faShieldHalved,
-  social: faUsers,
-  mystical: faHatWizard,
-};
-
 export const CategoryIcon: React.FC<CategoryIconProps> = ({ category, className = 'text-lg' }) => (
-  <FontAwesomeIcon icon={ICONS[category]} className={className} />
+  <FontAwesomeIcon icon={CATEGORY_ICONS[category]} className={className} />
 );
 
 export default CategoryIcon;

--- a/src/lib/categories.ts
+++ b/src/lib/categories.ts
@@ -1,0 +1,35 @@
+import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
+import {
+  faSackDollar,
+  faShieldHalved,
+  faUsers,
+  faHatWizard,
+  faHandshake,
+  faLandmark
+} from '@/lib/icons';
+
+export type CategoryType =
+  | 'economic'
+  | 'military'
+  | 'social'
+  | 'mystical'
+  | 'diplomatic'
+  | 'infrastructure';
+
+export const CATEGORY_TYPES: CategoryType[] = [
+  'economic',
+  'military',
+  'social',
+  'mystical',
+  'diplomatic',
+  'infrastructure',
+];
+
+export const CATEGORY_ICONS: Record<CategoryType, IconDefinition> = {
+  economic: faSackDollar,
+  military: faShieldHalved,
+  social: faUsers,
+  mystical: faHatWizard,
+  diplomatic: faHandshake,
+  infrastructure: faLandmark,
+};

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -21,7 +21,8 @@ import {
   faSackDollar,
   faShieldHalved,
   faUsers,
-  faHatWizard
+  faHatWizard,
+  faHandshake
 } from '@fortawesome/free-solid-svg-icons';
 
 // Add icons to the library for tree-shaking optimization
@@ -46,7 +47,8 @@ library.add(
   faSackDollar,
   faShieldHalved,
   faUsers,
-  faHatWizard
+  faHatWizard,
+  faHandshake
 );
 
 // Export icons for direct use
@@ -71,5 +73,6 @@ export {
   faSackDollar,
   faShieldHalved,
   faUsers,
-  faHatWizard
+  faHatWizard,
+  faHandshake
 };


### PR DESCRIPTION
## Summary
- add shared `CategoryType` and icon map
- refactor `CategoryIcon`, `EdictsPanel`, and `CouncilPanel` to use common categories
- include icons for diplomatic and infrastructure categories

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ef85bd048325972cc959a4606ebb