### PR TITLE
feat: centralize game state fetch

### DIFF
--- a/src/app/api/state/tick/route.ts
+++ b/src/app/api/state/tick/route.ts
@@ -1,18 +1,13 @@
 import { NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase/server'
+import { getLatestGameState } from '@/lib/server/gameState'
 
 // Advance one cycle: apply accepted proposals to resources with simple rules and clear applied
 export async function POST() {
   const supabase = createSupabaseServerClient()
 
-  // Get latest state
-  const { data: state, error: stateErr } = await supabase
-    .from('game_state')
-    .select('*')
-    .order('created_at', { ascending: false })
-    .limit(1)
-    .maybeSingle()
-  if (stateErr) return NextResponse.json({ error: stateErr.message }, { status: 500 })
+  const { state, error } = await getLatestGameState(supabase)
+  if (error) return error
   if (!state) return NextResponse.json({ error: 'No game state' }, { status: 400 })
 
   // Fetch accepted proposals

--- a/src/lib/server/gameState.ts
+++ b/src/lib/server/gameState.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server'
+import logger from '@/lib/logger'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export async function getLatestGameState(supabase: SupabaseClient) {
+  try {
+    const { data: state, error } = await supabase
+      .from('game_state')
+      .select('*')
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle()
+
+    if (error) {
+      logger.error('Supabase error fetching game state:', error.message)
+      return {
+        state: null,
+        error: NextResponse.json(
+          { error: 'Database connection failed' },
+          { status: 503 },
+        ),
+      }
+    }
+
+    return { state, error: null }
+  } catch (err) {
+    logger.error('Supabase connection error fetching game state:', err)
+    return {
+      state: null,
+      error: NextResponse.json(
+        { error: 'Service unavailable - database not configured' },
+        { status: 503 },
+      ),
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add getLatestGameState helper to handle Supabase fetch errors
- refactor state and proposal routes to use shared helper
- unify error responses when retrieving latest game state

## Testing
- `npm run lint` *(fails: 47 problems)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5ef9278348325a930a71a0f4cc1d2