### PR TITLE
refactor: unify panel buttons with ActionButton

### DIFF
--- a/src/components/game/CouncilPanel.tsx
+++ b/src/components/game/CouncilPanel.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import { GameResources } from './GameHUD';
 import { getResourceIcon, getResourceColor } from './resourceUtils';
+import { ActionButton } from '../ui';
 
 export interface ProposalDelta {
   grain?: number;
@@ -184,33 +185,26 @@ const ProposalCard: React.FC<{
       {/* Actions */}
       <div className="flex gap-2">
         {proposal.canScry && !proposal.scryResult && (proposal.status ?? 'pending') === 'pending' && (
-          <button
-            onClick={onScry}
-            className="px-3 py-1 bg-accent hover:opacity-80 text-inverse text-xs rounded transition-colors"
-          >
+          <ActionButton onClick={onScry} variant="accent" className="px-3 py-1 text-xs">
             🔮 Scry
-          </button>
+          </ActionButton>
         )}
-        <button
+        <ActionButton
           onClick={onAccept}
           disabled={!isActionable}
-          className={`px-3 py-1 text-xs rounded transition-colors ${
-            isActionable
-              ? 'bg-success hover:opacity-80 text-inverse'
-              : 'bg-muted text-muted cursor-not-allowed'
-          }`}
+          variant="success"
+          className="px-3 py-1 text-xs"
         >
           ✓ Accept
-        </button>
-        <button
+        </ActionButton>
+        <ActionButton
           onClick={onReject}
           disabled={(proposal.status ?? 'pending') !== 'pending'}
-          className={`px-3 py-1 text-inverse text-xs rounded transition-colors ${
-            (proposal.status ?? 'pending') === 'pending' ? 'bg-danger hover:opacity-80' : 'bg-muted text-muted cursor-not-allowed'
-          }`}
+          variant="danger"
+          className="px-3 py-1 text-xs"
         >
           ✗ Reject
-        </button>
+        </ActionButton>
       </div>
 
       {/* Affordability Warning */}
@@ -257,17 +251,14 @@ export const CouncilPanel: React.FC<CouncilPanelProps> = ({
               </div>
             </div>
             <div className="flex items-center gap-2">
-              <button
+              <ActionButton
                 onClick={onGenerateProposals}
                 disabled={!canGenerateProposals}
-                className={`px-4 py-2 rounded text-sm font-medium transition-colors ${
-                  canGenerateProposals
-                    ? 'bg-primary hover:bg-secondary text-inverse'
-                    : 'bg-muted text-muted cursor-not-allowed'
-                }`}
+                variant="primary"
+                className="px-4 py-2 text-sm font-medium"
               >
                 📜 Summon Proposals
-              </button>
+              </ActionButton>
               <Dialog.Close asChild>
                 <button className="p-2 hover:bg-muted rounded text-muted hover:text-foreground transition-colors">
                   ✕
@@ -285,17 +276,14 @@ export const CouncilPanel: React.FC<CouncilPanelProps> = ({
                 <p className="text-muted mb-4">
                   The council chamber is quiet. Summon your advisors to generate new proposals.
                 </p>
-                <button
+                <ActionButton
                   onClick={onGenerateProposals}
                   disabled={!canGenerateProposals}
-                  className={`px-6 py-3 rounded font-medium transition-colors ${
-                    canGenerateProposals
-                      ? 'bg-primary hover:bg-secondary text-inverse'
-                      : 'bg-muted text-muted cursor-not-allowed'
-                  }`}
-              >
-                📜 Summon Proposals
-              </button>
+                  variant="primary"
+                  className="px-6 py-3 font-medium"
+                >
+                  📜 Summon Proposals
+                </ActionButton>
               </div>
             ) : (
               <div className="grid gap-4">

--- a/src/components/game/EdictsPanel.tsx
+++ b/src/components/game/EdictsPanel.tsx
@@ -5,7 +5,7 @@ import * as Toggle from '@radix-ui/react-toggle';
 import * as Tooltip from '@radix-ui/react-tooltip';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCrown, faScroll, faXmark, faLock } from '@/lib/icons';
-import { CategoryIcon } from '../ui';
+import { CategoryIcon, ActionButton } from '../ui';
 
 export interface EdictSetting {
   id: string;
@@ -270,26 +270,24 @@ export const EdictsPanel: React.FC<EdictsPanelProps> = ({
                     Changes will take effect at the start of the next cycle
                   </div>
                   <div className="flex gap-2">
-                    <button
+                    <ActionButton
                       onClick={onResetChanges}
-                      className="px-4 py-2 bg-slate-100 hover:bg-slate-200 text-slate-700 text-sm rounded transition-colors"
+                      variant="muted"
+                      className="px-4 py-2 text-sm"
                     >
                       Reset
-                    </button>
+                    </ActionButton>
                     <Tooltip.Provider>
                       <Tooltip.Root>
                         <Tooltip.Trigger asChild>
-                          <button
+                          <ActionButton
                             onClick={onApplyChanges}
                             disabled={!canAfford}
-                            className={`px-4 py-2 text-sm rounded font-medium transition-colors ${
-                              canAfford
-                                ? 'bg-green-600 hover:bg-green-700 text-white'
-                                : 'bg-slate-100 text-slate-400 cursor-not-allowed'
-                            }`}
+                            variant="success"
+                            className="px-4 py-2 text-sm font-medium"
                           >
                             Apply Changes
-                          </button>
+                          </ActionButton>
                         </Tooltip.Trigger>
                         {!canAfford && (
                           <Tooltip.Portal>

--- a/src/components/game/OmenPanel.tsx
+++ b/src/components/game/OmenPanel.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import * as Tooltip from '@radix-ui/react-tooltip';
+import { ActionButton } from '../ui';
 
 export interface SeasonalEvent {
   id: string;
@@ -287,17 +288,14 @@ export const OmenPanel: React.FC<OmenPanelProps> = ({
                 <Tooltip.Provider>
                   <Tooltip.Root>
                     <Tooltip.Trigger asChild>
-                      <button
+                      <ActionButton
                         onClick={onRequestReading}
                         disabled={!canRequestReading || !canAffordReading}
-                        className={`btn-primary text-sm ${
-                          canRequestReading && canAffordReading
-                            ? ''
-                            : 'opacity-50 cursor-not-allowed'
-                        }`}
+                        variant="primary"
+                        className="text-sm"
                       >
                         🔮 Divine Reading (✨ {readingCost})
-                      </button>
+                      </ActionButton>
                     </Tooltip.Trigger>
                     {(!canRequestReading || !canAffordReading) && (
                       <Tooltip.Portal>

--- a/src/components/ui/ActionButton.tsx
+++ b/src/components/ui/ActionButton.tsx
@@ -3,15 +3,24 @@ import React from 'react';
 export interface ActionButtonProps {
   onClick?: () => void;
   children: React.ReactNode;
-  variant?: 'primary' | 'secondary' | 'danger';
+  variant?:
+    | 'primary'
+    | 'secondary'
+    | 'danger'
+    | 'accent'
+    | 'success'
+    | 'muted';
   disabled?: boolean;
   className?: string;
 }
 
 const VARIANT_CLASSES: Record<NonNullable<ActionButtonProps['variant']>, string> = {
-  primary: 'bg-blue-600 hover:bg-blue-700 text-white hover:transform hover:scale-105 hover:shadow-lg active:scale-95',
-  secondary: 'bg-gray-600 hover:bg-gray-700 text-white hover:transform hover:scale-105 hover:shadow-lg active:scale-95',
-  danger: 'bg-red-600 hover:bg-red-700 text-white hover:transform hover:scale-105 hover:shadow-lg active:scale-95',
+  primary: 'bg-primary hover:bg-secondary text-inverse',
+  secondary: 'bg-secondary hover:bg-primary text-inverse',
+  danger: 'bg-danger hover:opacity-80 text-inverse',
+  accent: 'bg-accent hover:opacity-80 text-inverse',
+  success: 'bg-success hover:opacity-80 text-inverse',
+  muted: 'bg-panel hover:bg-border text-foreground',
 };
 
 export const ActionButton: React.FC<ActionButtonProps> = ({
@@ -24,7 +33,7 @@ export const ActionButton: React.FC<ActionButtonProps> = ({
   <button
     onClick={onClick}
     disabled={disabled}
-    className={`inline-flex items-center gap-1 px-3 py-2 rounded-md text-sm font-medium transition-transform duration-200 ease-out will-change-transform ${VARIANT_CLASSES[variant]} ${disabled ? 'opacity-50 cursor-not-allowed hover:scale-100 hover:shadow-none' : 'cursor-pointer'} ${className}`}
+    className={`inline-flex items-center gap-1 px-3 py-2 rounded-md text-sm font-medium transition-transform duration-200 ease-out will-change-transform hover:transform hover:scale-105 hover:shadow-lg active:scale-95 ${VARIANT_CLASSES[variant]} ${disabled ? 'opacity-50 cursor-not-allowed hover:scale-100 hover:shadow-none' : 'cursor-pointer'} ${className}`}
   >
     {children}
   </button>


### PR DESCRIPTION
## Summary
- extend ActionButton with accent, success, and muted variants
- refactor CouncilPanel, EdictsPanel, and OmenPanel to use ActionButton instead of plain buttons
- remove ad-hoc styling from buttons now covered by ActionButton variants

## Testing
- `npm test`
- `npm run lint` *(fails: 48 problems, 22 errors, 26 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ef8d22fc832582fe7c4a72a9cd87