### PR TITLE
refactor: centralize game types

### DIFF
--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -5,8 +5,9 @@ import * as PIXI from 'pixi.js';
 import GameRenderer from '@/components/game/GameRenderer';
 import logger from '@/lib/logger';
 
-import { GameHUD, GameResources, GameTime } from '@/components/game/GameHUD';
-import { CouncilPanel, CouncilProposal } from '@/components/game/CouncilPanel';
+import { GameHUD } from '@/components/game/GameHUD';
+import { CouncilPanel } from '@/components/game/CouncilPanel';
+import { GameResources, GameTime, CouncilProposal } from '@/types/game';
 import { EdictsPanel, EdictSetting } from '@/components/game/EdictsPanel';
 import { OmenPanel, SeasonalEvent, OmenReading } from '@/components/game/OmenPanel';
 import DistrictSprites, { District } from '@/components/game/DistrictSprites';

--- a/src/components/game/CouncilPanel.tsx
+++ b/src/components/game/CouncilPanel.tsx
@@ -1,34 +1,7 @@
 import React from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
-import { GameResources } from './GameHUD';
+import { GameResources, CouncilProposal, ProposalDelta } from '@/types/game';
 import { getResourceIcon, getResourceColor } from './resourceUtils';
-
-export interface ProposalDelta {
-  grain?: number;
-  coin?: number;
-  mana?: number;
-  favor?: number;
-  unrest?: number;
-  threat?: number;
-}
-
-export interface CouncilProposal {
-  id: string;
-  title: string;
-  description: string;
-  type: 'economic' | 'military' | 'diplomatic' | 'mystical' | 'infrastructure';
-  cost: ProposalDelta;
-  benefit: ProposalDelta;
-  risk: number; // 0-100 percentage
-  duration: number; // cycles to complete
-  requirements?: string[];
-  canScry: boolean;
-  scryResult?: {
-    successChance: number;
-    hiddenEffects?: string[];
-  };
-  status?: 'pending' | 'accepted' | 'rejected' | 'applied';
-}
 
 export interface CouncilPanelProps {
   isOpen: boolean;

--- a/src/components/game/GameHUD.tsx
+++ b/src/components/game/GameHUD.tsx
@@ -14,21 +14,7 @@ import {
 import { ActionButton, ResourceIcon } from '../ui';
 import '../../styles/design-tokens.css';
 import '../../styles/animations.css';
-
-export interface GameResources {
-  grain: number;
-  coin: number;
-  mana: number;
-  favor: number;
-  unrest: number;
-  threat: number;
-}
-
-export interface GameTime {
-  cycle: number;
-  season: string;
-  timeRemaining: number; // seconds until next cycle
-}
+import { GameResources, GameTime } from '@/types/game';
 
 export interface GameHUDProps {
   resources: GameResources;

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -1,0 +1,41 @@
+export interface GameResources {
+  grain: number;
+  coin: number;
+  mana: number;
+  favor: number;
+  unrest: number;
+  threat: number;
+}
+
+export interface GameTime {
+  cycle: number;
+  season: string;
+  timeRemaining: number; // seconds until next cycle
+}
+
+export interface ProposalDelta {
+  grain?: number;
+  coin?: number;
+  mana?: number;
+  favor?: number;
+  unrest?: number;
+  threat?: number;
+}
+
+export interface CouncilProposal {
+  id: string;
+  title: string;
+  description: string;
+  type: 'economic' | 'military' | 'diplomatic' | 'mystical' | 'infrastructure';
+  cost: ProposalDelta;
+  benefit: ProposalDelta;
+  risk: number; // 0-100 percentage
+  duration: number; // cycles to complete
+  requirements?: string[];
+  canScry: boolean;
+  scryResult?: {
+    successChance: number;
+    hiddenEffects?: string[];
+  };
+  status?: 'pending' | 'accepted' | 'rejected' | 'applied';
+}


### PR DESCRIPTION
## Summary
- centralize game domain interfaces in new `src/types/game.ts`
- adjust `GameHUD` and `CouncilPanel` to import shared types
- update `PlayPage` to consume shared game types

## Testing
- `npm run lint` *(fails: 22 errors, 26 warnings)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5ef989d2c8325ace74f6aadda4a85