### PR TITLE
feat: centralize modal handling with reusable component

### DIFF
--- a/src/components/game/CouncilPanel.tsx
+++ b/src/components/game/CouncilPanel.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
+import { Modal } from '../ui';
 import { GameResources } from './GameHUD';
 import { getResourceIcon, getResourceColor } from './resourceUtils';
 
@@ -235,16 +236,16 @@ export const CouncilPanel: React.FC<CouncilPanelProps> = ({
   canGenerateProposals
 }) => {
   return (
-    <Dialog.Root open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>
-      <Dialog.Portal>
-        <Dialog.Overlay
-          className="fixed inset-0 bg-black/50 backdrop-blur-sm z-40 data-[state=open]:opacity-100 data-[state=closed]:opacity-0 motion-safe:transition-opacity motion-safe:duration-200 motion-safe:data-[state=open]:animate-fade-in"
-        />
-        <Dialog.Content
-          className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-panel rounded-lg shadow-xl z-50 w-full max-w-4xl max-h-[90vh] overflow-hidden border border-border data-[state=open]:opacity-100 data-[state=closed]:opacity-0 data-[state=closed]:scale-95 motion-safe:transition-[opacity,transform] motion-safe:duration-200 motion-safe:data-[state=open]:animate-scale-in"
-        >
-          {/* Header */}
-          <div className="flex items-center justify-between p-6 border-b border-border">
+    <Modal
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+      size="lg"
+      className="bg-panel border border-border"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between p-6 border-b border-border">
             <div className="flex items-center gap-3">
               <span className="text-2xl">🏛️</span>
               <div>
@@ -274,10 +275,10 @@ export const CouncilPanel: React.FC<CouncilPanelProps> = ({
                 </button>
               </Dialog.Close>
             </div>
-          </div>
+      </div>
 
-          {/* Content */}
-          <div className="p-6 overflow-y-auto max-h-[calc(90vh-120px)] bg-panel">
+      {/* Content */}
+      <div className="p-6 overflow-y-auto max-h-[calc(90vh-120px)] bg-panel">
             {proposals.length === 0 ? (
               <div className="text-center py-12">
                 <div className="text-6xl mb-4">📜</div>
@@ -311,10 +312,8 @@ export const CouncilPanel: React.FC<CouncilPanelProps> = ({
                 ))}
               </div>
             )}
-          </div>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
+      </div>
+    </Modal>
   );
 };
 

--- a/src/components/game/CrisisModal.tsx
+++ b/src/components/game/CrisisModal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
-import { ActionButton, ResourceIcon } from '../ui';
+import { ActionButton, ResourceIcon, Modal } from '../ui';
 import type { ResourceType } from '../ui/ResourceIcon';
 
 export interface CrisisData {
@@ -15,33 +15,30 @@ interface CrisisModalProps {
 }
 
 const CrisisModal: React.FC<CrisisModalProps> = ({ crisis, onResolve }) => (
-  <Dialog.Root open>
-    <Dialog.Overlay className="fixed inset-0 bg-black/50 z-50" />
-    <Dialog.Content className="fixed z-50 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-white rounded-lg shadow-xl p-6 w-full max-w-md">
-      <Dialog.Title className="text-xl font-bold mb-2">
-        {crisis.type === 'unrest' ? 'Unrest Boils Over' : 'Threat Escalates'}
-      </Dialog.Title>
-      <Dialog.Description className="text-slate-700 mb-4">
-        {crisis.message}
-      </Dialog.Description>
-      <div className="mb-4">
-        <h3 className="font-semibold text-slate-800 mb-2">Temporary Penalty</h3>
-        <ul className="space-y-1">
-          {Object.entries(crisis.penalty).map(([key, val]) => (
-            <li key={key} className="flex items-center gap-2 text-sm text-slate-700">
-              <ResourceIcon type={key as ResourceType} value={val} />
-              <span>-{Math.abs(val)} {key}</span>
-            </li>
-          ))}
-        </ul>
-      </div>
-      <div className="text-right">
-        <Dialog.Close asChild>
-          <ActionButton onClick={onResolve} variant="primary">Endure</ActionButton>
-        </Dialog.Close>
-      </div>
-    </Dialog.Content>
-  </Dialog.Root>
+  <Modal open overlayClassName="fixed inset-0 bg-black/50 z-50" className="bg-white p-6">
+    <Dialog.Title className="text-xl font-bold mb-2">
+      {crisis.type === 'unrest' ? 'Unrest Boils Over' : 'Threat Escalates'}
+    </Dialog.Title>
+    <Dialog.Description className="text-slate-700 mb-4">
+      {crisis.message}
+    </Dialog.Description>
+    <div className="mb-4">
+      <h3 className="font-semibold text-slate-800 mb-2">Temporary Penalty</h3>
+      <ul className="space-y-1">
+        {Object.entries(crisis.penalty).map(([key, val]) => (
+          <li key={key} className="flex items-center gap-2 text-sm text-slate-700">
+            <ResourceIcon type={key as ResourceType} value={val} />
+            <span>-{Math.abs(val)} {key}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+    <div className="text-right">
+      <Dialog.Close asChild>
+        <ActionButton onClick={onResolve} variant="primary">Endure</ActionButton>
+      </Dialog.Close>
+    </div>
+  </Modal>
 );
 
 export default CrisisModal;

--- a/src/components/game/EdictsPanel.tsx
+++ b/src/components/game/EdictsPanel.tsx
@@ -5,7 +5,8 @@ import * as Toggle from '@radix-ui/react-toggle';
 import * as Tooltip from '@radix-ui/react-tooltip';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCrown, faScroll, faXmark, faLock } from '@/lib/icons';
-import { CategoryIcon } from '../ui';
+import { Modal } from '../ui';
+import { CategoryIcon } from '../ui/CategoryIcon';
 
 export interface EdictSetting {
   id: string;
@@ -203,16 +204,16 @@ export const EdictsPanel: React.FC<EdictsPanelProps> = ({
   const canAfford = currentFavor >= totalCost;
 
   return (
-    <Dialog.Root open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>
-      <Dialog.Portal>
-        <Dialog.Overlay
-          className="fixed inset-0 bg-black/50 backdrop-blur-sm z-40 data-[state=open]:opacity-100 data-[state=closed]:opacity-0 motion-safe:transition-opacity motion-safe:duration-200 motion-safe:data-[state=open]:animate-fade-in"
-        />
-        <Dialog.Content
-          className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-white rounded-lg shadow-xl z-50 w-full max-w-6xl max-h-[90vh] overflow-hidden border border-slate-200 data-[state=open]:opacity-100 data-[state=closed]:opacity-0 data-[state=closed]:scale-95 motion-safe:transition-[opacity,transform] motion-safe:duration-200 motion-safe:data-[state=open]:animate-scale-in"
-        >
-          {/* Header */}
-          <div className="flex items-center justify-between p-6 border-b border-slate-200">
+    <Modal
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+      size="xl"
+      className="bg-white border border-slate-200"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between p-6 border-b border-slate-200">
             <div className="flex items-center gap-3">
               <FontAwesomeIcon icon={faScroll} className="text-2xl" />
               <div>
@@ -244,10 +245,10 @@ export const EdictsPanel: React.FC<EdictsPanelProps> = ({
                 </button>
               </Dialog.Close>
             </div>
-          </div>
+      </div>
 
-          {/* Content */}
-          <div className="flex flex-col h-[calc(90vh-120px)]">
+      {/* Content */}
+      <div className="flex flex-col h-[calc(90vh-120px)]">
             <div className="flex-1 p-6 overflow-y-auto">
               <div className="space-y-8">
                 {(['economic', 'military', 'social', 'mystical'] as const).map(category => (
@@ -305,10 +306,8 @@ export const EdictsPanel: React.FC<EdictsPanelProps> = ({
                 </div>
               </div>
             )}
-          </div>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
+      </div>
+    </Modal>
   );
 };
 

--- a/src/components/game/OmenPanel.tsx
+++ b/src/components/game/OmenPanel.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import * as Tooltip from '@radix-ui/react-tooltip';
+import { Modal } from '../ui';
 
 export interface SeasonalEvent {
   id: string;
@@ -261,16 +262,16 @@ export const OmenPanel: React.FC<OmenPanelProps> = ({
   const canAffordReading = currentMana >= readingCost;
 
   return (
-    <Dialog.Root open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>
-      <Dialog.Portal>
-        <Dialog.Overlay
-          className="fixed inset-0 bg-black/50 backdrop-blur-sm z-40 data-[state=open]:opacity-100 data-[state=closed]:opacity-0 motion-safe:transition-opacity motion-safe:duration-200 motion-safe:data-[state=open]:animate-fade-in"
-        />
-        <Dialog.Content
-          className="card-elevated fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-white/95 backdrop-blur-sm z-50 w-full max-w-6xl max-h-[90vh] overflow-hidden data-[state=open]:opacity-100 data-[state=closed]:opacity-0 data-[state=closed]:scale-95 motion-safe:transition-[opacity,transform] motion-safe:duration-200 motion-safe:data-[state=open]:animate-scale-in"
-        >
-          {/* Header */}
-          <div className="flex items-center justify-between p-6 border-b border-neutral-200">
+    <Modal
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+      size="xl"
+      className="card-elevated bg-white/95 backdrop-blur-sm"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between p-6 border-b border-neutral-200">
             <div className="flex items-center gap-3">
               <span className="text-2xl">🔮</span>
               <div>
@@ -318,10 +319,10 @@ export const OmenPanel: React.FC<OmenPanelProps> = ({
                 </button>
               </Dialog.Close>
             </div>
-          </div>
+      </div>
 
-          {/* Content */}
-          <div className="p-6 overflow-y-auto max-h-[calc(90vh-120px)]">
+      {/* Content */}
+      <div className="p-6 overflow-y-auto max-h-[calc(90vh-120px)]">
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
               {/* Timeline */}
               <div className="lg:col-span-1">
@@ -398,10 +399,8 @@ export const OmenPanel: React.FC<OmenPanelProps> = ({
                 )}
               </div>
             </div>
-          </div>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
+      </div>
+    </Modal>
   );
 };
 

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+
+export interface ModalProps {
+  open: boolean;
+  onOpenChange?: (open: boolean) => void;
+  children: React.ReactNode;
+  header?: React.ReactNode;
+  footer?: React.ReactNode;
+  /**
+   * Controls maximum width of the dialog content. Defaults to small.
+   */
+  size?: 'sm' | 'md' | 'lg' | 'xl';
+  /** Additional classes for the dialog content */
+  className?: string;
+  /** Override classes for the overlay */
+  overlayClassName?: string;
+}
+
+const OVERLAY_CLASSES =
+  'fixed inset-0 bg-black/50 backdrop-blur-sm z-40 data-[state=open]:opacity-100 data-[state=closed]:opacity-0 motion-safe:transition-opacity motion-safe:duration-200 motion-safe:data-[state=open]:animate-fade-in';
+
+const CONTENT_CLASSES =
+  'fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-lg shadow-xl z-50 w-full max-h-[90vh] overflow-hidden focus:outline-none data-[state=open]:opacity-100 data-[state=closed]:opacity-0 data-[state=closed]:scale-95 motion-safe:transition-[opacity,transform] motion-safe:duration-200 motion-safe:data-[state=open]:animate-scale-in';
+
+const SIZE_CLASSES: Record<NonNullable<ModalProps['size']>, string> = {
+  sm: 'max-w-md',
+  md: 'max-w-2xl',
+  lg: 'max-w-4xl',
+  xl: 'max-w-6xl',
+};
+
+export const Modal: React.FC<ModalProps> = ({
+  open,
+  onOpenChange,
+  children,
+  header,
+  footer,
+  size = 'sm',
+  className = '',
+  overlayClassName = OVERLAY_CLASSES,
+}) => (
+  <Dialog.Root open={open} onOpenChange={onOpenChange}>
+    <Dialog.Portal>
+      <Dialog.Overlay className={overlayClassName} />
+      <Dialog.Content
+        className={`${CONTENT_CLASSES} ${SIZE_CLASSES[size]} ${className}`}
+      >
+        {header}
+        {children}
+        {footer}
+      </Dialog.Content>
+    </Dialog.Portal>
+  </Dialog.Root>
+);
+
+export default Modal;
+

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,3 +1,4 @@
 export { ResourceIcon } from './ResourceIcon';
 export { ActionButton } from './ActionButton';
 export { CategoryIcon } from './CategoryIcon';
+export { Modal } from './Modal';


### PR DESCRIPTION
## Summary
- add generic `Modal` wrapper around Radix Dialog
- refactor crisis, edicts, omen, and council panels to render within `Modal`
- export `Modal` from UI index
- fix duplicate `CategoryIcon` import in `EdictsPanel`

## Testing
- `npm test`
- `npm run lint` *(fails: 22 errors, 26 warnings)*
- `npm run vercel-build`


------
https://chatgpt.com/codex/tasks/task_e_68b5ef8af2f8832590e224216825e860