### PR TITLE
refactor: centralize game types

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -74,7 +74,7 @@ export default function Home() {
                   </div>
                   <h3 className="text-heading-3 text-neutral-900 mb-2">Strategic Building</h3>
                   <p className="text-body-small text-neutral-600">
-                    Construct and optimize your empire's infrastructure
+                    Construct and optimize your empire&apos;s infrastructure
                   </p>
                 </div>
                 

--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -5,8 +5,9 @@ import * as PIXI from 'pixi.js';
 import GameRenderer from '@/components/game/GameRenderer';
 import logger from '@/lib/logger';
 
-import { GameHUD, GameResources, GameTime } from '@/components/game/GameHUD';
-import { CouncilPanel, CouncilProposal } from '@/components/game/CouncilPanel';
+import { GameHUD } from '@/components/game/GameHUD';
+import { CouncilPanel } from '@/components/game/CouncilPanel';
+import { GameResources, GameTime, CouncilProposal } from '@/types/game';
 import { EdictsPanel, EdictSetting } from '@/components/game/EdictsPanel';
 import { OmenPanel, SeasonalEvent, OmenReading } from '@/components/game/OmenPanel';
 import DistrictSprites, { District } from '@/components/game/DistrictSprites';
@@ -172,8 +173,8 @@ export default function PlayPage() {
           });
         }
       }
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
     } finally {
       setLoading(false);
     }
@@ -184,9 +185,10 @@ export default function PlayPage() {
       try {
         await fetchState();
         await fetchProposals();
-      } catch (e: any) {
-        logger.error('Failed to connect to database:', e.message);
-        setError(e.message);
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : String(e);
+        logger.error('Failed to connect to database:', msg);
+        setError(msg);
       }
     })();
   }, [fetchState, fetchProposals]);
@@ -215,15 +217,16 @@ export default function PlayPage() {
     let client: ReturnType<typeof createSupabaseBrowserClient> | null = null;
     try {
       client = createSupabaseBrowserClient();
-    } catch (e: any) {
-      logger.debug('Realtime disabled:', e?.message || String(e));
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      logger.debug('Realtime disabled:', msg);
       return; // Early exit: supabase not configured in browser env
     }
 
     const channel = client
       .channel('game_changes')
-      .on('postgres_changes', { event: '*', schema: 'public', table: 'game_state' }, (payload: any) => {
-        const next = payload?.new;
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'game_state' }, (payload: { new: unknown }) => {
+        const next = payload?.new as GameState | null;
         if (next && typeof next === 'object') {
           setState(next);
         } else {
@@ -251,8 +254,8 @@ export default function PlayPage() {
       await fetchProposals();
       setGuideProgress(prev => ({ ...prev, generated: true }));
       setDismissedGuide(true);
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
     } finally {
       setLoading(false);
     }
@@ -265,8 +268,8 @@ export default function PlayPage() {
       const json = await res.json();
       if (!res.ok) throw new Error(json.error || 'Failed to scry');
       await fetchProposals();
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
     } finally {
       setLoading(false);
     }
@@ -293,8 +296,8 @@ export default function PlayPage() {
         setTimeout(() => setAcceptedNotice(null), 4000);
       }
       await fetchProposals();
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
     } finally {
       setLoading(false);
     }
@@ -303,8 +306,9 @@ export default function PlayPage() {
   // Sim helpers
   const canAfford = useCallback((cost: Partial<SimResourcesLocal>) => {
     if (!simResources) return false;
-    return (['grain','coin','mana','favor'] as SimResourceKey[]).every(k => {
-      const need = (cost as any)[k] ?? 0; return (simResources as any)[k] >= need;
+    return (['grain','coin','mana','favor'] as (keyof SimResourcesLocal)[]).every(k => {
+      const need = cost[k] ?? 0;
+      return simResources[k] >= need;
     });
   }, [simResources]);
 
@@ -312,8 +316,9 @@ export default function PlayPage() {
     setSimResources(prev => {
       if (!prev) return prev;
       const next = { ...prev };
-      (['grain','coin','mana','favor'] as SimResourceKey[]).forEach(k => {
-        const need = (cost as any)[k] ?? 0; (next as any)[k] = Math.max(0, (next as any)[k] - need);
+      (['grain','coin','mana','favor'] as (keyof SimResourcesLocal)[]).forEach(k => {
+        const need = cost[k] ?? 0;
+        next[k] = Math.max(0, next[k] - need);
       });
       return next;
     });
@@ -518,7 +523,7 @@ export default function PlayPage() {
     id: p.id,
     title: p.title,
     description: p.description,
-    type: p.guild.toLowerCase() as any,
+    type: p.guild.toLowerCase() as CouncilProposal['type'],
     cost: p.predicted_delta,
     benefit: p.predicted_delta,
     risk: 25,
@@ -573,7 +578,10 @@ export default function PlayPage() {
                     className={`px-3 py-2 rounded border text-sm ${selectedBuildType === b.id ? 'bg-emerald-600 text-white border-emerald-700' : 'bg-white border-slate-300 text-slate-700 hover:bg-slate-50'}`}
                   >
                     <div className="font-medium">{b.name}</div>
-                    <div className="text-[11px] text-slate-500">Cost: {['coin','grain','mana','favor'].map(k => (b.cost as any)[k] ? `${k[0].toUpperCase()+k.slice(1)} ${(b.cost as any)[k]}` : null).filter(Boolean).join(', ') || 'Free'}</div>
+                    <div className="text-[11px] text-slate-500">Cost: {(['coin','grain','mana','favor'] as (keyof SimResourcesLocal)[])
+                      .map(k => b.cost[k] ? `${k[0].toUpperCase()+k.slice(1)} ${b.cost[k]}` : null)
+                      .filter(Boolean)
+                      .join(', ') || 'Free'}</div>
                   </button>
                 ))}
               </div>

--- a/src/components/game/CouncilPanel.tsx
+++ b/src/components/game/CouncilPanel.tsx
@@ -1,36 +1,9 @@
 import React from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
-import { GameResources } from './GameHUD';
+import { GameResources, CouncilProposal, ProposalDelta } from '@/types/game';
 import { getResourceIcon, getResourceColor } from './resourceUtils';
 
-export interface ProposalDelta {
-  grain?: number;
-  coin?: number;
-  mana?: number;
-  favor?: number;
-  unrest?: number;
-  threat?: number;
-}
-
-export interface CouncilProposal {
-  id: string;
-  title: string;
-  description: string;
-  type: 'economic' | 'military' | 'diplomatic' | 'mystical' | 'infrastructure';
-  cost: ProposalDelta;
-  benefit: ProposalDelta;
-  risk: number; // 0-100 percentage
-  duration: number; // cycles to complete
-  requirements?: string[];
-  canScry: boolean;
-  scryResult?: {
-    successChance: number;
-    hiddenEffects?: string[];
-  };
-  status?: 'pending' | 'accepted' | 'rejected' | 'applied';
-}
-
-export interface CouncilPanelProps {
+interface CouncilPanelProps {
   isOpen: boolean;
   onClose: () => void;
   proposals: CouncilProposal[];

--- a/src/components/game/GameHUD.tsx
+++ b/src/components/game/GameHUD.tsx
@@ -14,23 +14,9 @@ import {
 import { ActionButton, ResourceIcon } from '../ui';
 import '../../styles/design-tokens.css';
 import '../../styles/animations.css';
+import { GameResources, GameTime } from '@/types/game';
 
-export interface GameResources {
-  grain: number;
-  coin: number;
-  mana: number;
-  favor: number;
-  unrest: number;
-  threat: number;
-}
-
-export interface GameTime {
-  cycle: number;
-  season: string;
-  timeRemaining: number; // seconds until next cycle
-}
-
-export interface GameHUDProps {
+interface GameHUDProps {
   resources: GameResources;
   time: GameTime;
   isPaused?: boolean;

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -1,0 +1,41 @@
+export interface GameResources {
+  grain: number;
+  coin: number;
+  mana: number;
+  favor: number;
+  unrest: number;
+  threat: number;
+}
+
+export interface GameTime {
+  cycle: number;
+  season: string;
+  timeRemaining: number; // seconds until next cycle
+}
+
+export interface ProposalDelta {
+  grain?: number;
+  coin?: number;
+  mana?: number;
+  favor?: number;
+  unrest?: number;
+  threat?: number;
+}
+
+export interface CouncilProposal {
+  id: string;
+  title: string;
+  description: string;
+  type: 'economic' | 'military' | 'diplomatic' | 'mystical' | 'infrastructure';
+  cost: ProposalDelta;
+  benefit: ProposalDelta;
+  risk: number; // 0-100 percentage
+  duration: number; // cycles to complete
+  requirements?: string[];
+  canScry: boolean;
+  scryResult?: {
+    successChance: number;
+    hiddenEffects?: string[];
+  };
+  status?: 'pending' | 'accepted' | 'rejected' | 'applied';
+}


### PR DESCRIPTION
## Summary
- centralize game domain interfaces in new `src/types/game.ts`
- update GameHUD and CouncilPanel to import shared types and internalize their props
- update Play page to consume shared types
- ensure branch merges cleanly with main

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5ef989d2c8325ace74f6aadda4a85