### PR TITLE
feat: simulate building production

### DIFF
--- a/src/components/game/GameHUD.tsx
+++ b/src/components/game/GameHUD.tsx
@@ -41,7 +41,21 @@ export interface GameHUDProps {
   onOpenEdicts?: () => void;
   onOpenOmens?: () => void;
   highlightAdvance?: boolean;
+  shortages?: Partial<Record<keyof GameResources, number>>;
 }
+
+const ShortageDisplay: React.FC<{ shortages: Partial<Record<keyof GameResources, number>> }> = ({ shortages }) => {
+  const entries = Object.entries(shortages) as [keyof GameResources, number][];
+  if (entries.length === 0) return null;
+  return (
+    <div className="mt-2 flex flex-wrap items-center text-xs text-red-600" style={{ gap: 'var(--spacing-xs)' }}>
+      <span>Needs:</span>
+      {entries.map(([k, v]) => (
+        <ResourceIcon key={k} type={k} value={v} />
+      ))}
+    </div>
+  );
+};
 
 // Using imported ResourceIcon component from '../ui'
 
@@ -103,7 +117,8 @@ export const GameHUD: React.FC<GameHUDProps> = ({
   onOpenCouncil,
   onOpenEdicts,
   onOpenOmens,
-  highlightAdvance = false
+  highlightAdvance = false,
+  shortages = {}
 }) => {
   const prevResources = useRef<GameResources>(resources);
   const [resourceChanges, setResourceChanges] = useState<Record<keyof GameResources, number | null>>({
@@ -153,7 +168,7 @@ export const GameHUD: React.FC<GameHUDProps> = ({
               Resources
             </h3>
           </div>
-          <div 
+          <div
             className="grid grid-cols-6 sm:grid-cols-6 md:grid-cols-3 xl:grid-cols-6 2xl:grid-cols-3"
             style={{ gap: 'var(--spacing-xs)' }}
           >
@@ -164,6 +179,7 @@ export const GameHUD: React.FC<GameHUDProps> = ({
             <ResourceIcon type="unrest" value={resources.unrest} delta={resourceChanges.unrest} className="animate-scale-in stagger-5" />
             <ResourceIcon type="threat" value={resources.threat} delta={resourceChanges.threat} className="animate-scale-in stagger-6" />
           </div>
+          <ShortageDisplay shortages={shortages} />
         </div>
 
         {/* Time Controls */}

--- a/src/components/game/resourceUtils.test.ts
+++ b/src/components/game/resourceUtils.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { getResourceIcon, getResourceColor } from './resourceUtils';
+import {
+  getResourceIcon,
+  getResourceColor,
+  applyProduction,
+  canAfford,
+  applyCost,
+  type SimResources,
+  type SimBuildingDef
+} from './resourceUtils';
 import { ICONS, COLORS, type ResourceType } from '../../lib/resources';
 
 describe('resourceUtils', () => {
@@ -13,5 +21,42 @@ describe('resourceUtils', () => {
     it(`returns correct color for ${type}`, () => {
       expect(getResourceColor(type)).toBe(COLORS[type]);
     });
+  });
+});
+
+describe('applyProduction', () => {
+  const catalog: Record<string, SimBuildingDef> = {
+    mill: { inputs: { grain: 2 }, outputs: { coin: 1 } }
+  };
+
+  it('produces outputs when inputs are available', () => {
+    const res: SimResources = { grain: 5, coin: 0, mana: 0, favor: 0, population: 0 };
+    const { updated, shortages } = applyProduction(res, [{ typeId: 'mill' }], catalog);
+    expect(updated.grain).toBe(3);
+    expect(updated.coin).toBe(1);
+    expect(shortages).toEqual({});
+  });
+
+  it('records shortages when inputs are missing', () => {
+    const res: SimResources = { grain: 1, coin: 0, mana: 0, favor: 0, population: 0 };
+    const { updated, shortages } = applyProduction(res, [{ typeId: 'mill' }], catalog);
+    expect(updated.grain).toBe(1);
+    expect(updated.coin).toBe(0);
+    expect(shortages).toEqual({ grain: 1 });
+  });
+});
+
+describe('canAfford and applyCost', () => {
+  const base: SimResources = { grain: 5, coin: 5, mana: 5, favor: 5, population: 0 };
+
+  it('determines affordability correctly', () => {
+    expect(canAfford({ grain: 3, coin: 2 }, base)).toBe(true);
+    expect(canAfford({ mana: 6 }, base)).toBe(false);
+  });
+
+  it('applies costs and clamps at zero', () => {
+    const next = applyCost(base, { grain: 3, coin: 10 });
+    expect(next.grain).toBe(2);
+    expect(next.coin).toBe(0);
   });
 });

--- a/src/components/game/resourceUtils.ts
+++ b/src/components/game/resourceUtils.ts
@@ -10,3 +10,75 @@ export function getResourceIcon(resource: ResourceType): IconDefinition {
 export function getResourceColor(resource: ResourceType): string {
   return COLORS[resource];
 }
+
+// Simulation resource helpers
+export type SimResourceKey = 'grain' | 'coin' | 'mana' | 'favor' | 'population';
+
+export interface SimResources {
+  grain: number;
+  coin: number;
+  mana: number;
+  favor: number;
+  population: number;
+}
+
+export interface SimBuildingDef {
+  inputs: Partial<SimResources>;
+  outputs: Partial<SimResources>;
+}
+
+export interface ApplyProductionResult {
+  updated: SimResources;
+  shortages: Partial<SimResources>;
+}
+
+export function applyProduction(
+  resources: SimResources,
+  buildings: Array<{ typeId: string }>,
+  catalog: Record<string, SimBuildingDef>
+): ApplyProductionResult {
+  const next: SimResources = { ...resources };
+  const shortages: Partial<SimResources> = {};
+
+  buildings.forEach((b) => {
+    const def = catalog[b.typeId];
+    if (!def) return;
+
+    let canProduce = true;
+    for (const [key, amount] of Object.entries(def.inputs) as [SimResourceKey, number | undefined][]) {
+      const current = next[key] ?? 0;
+      if (current < (amount ?? 0)) {
+        canProduce = false;
+        const deficit = (amount ?? 0) - current;
+        shortages[key] = (shortages[key] ?? 0) + deficit;
+      }
+    }
+
+    if (!canProduce) return;
+
+    for (const [key, amount] of Object.entries(def.inputs) as [SimResourceKey, number | undefined][]) {
+      next[key] = next[key] - (amount ?? 0);
+    }
+    for (const [key, amount] of Object.entries(def.outputs) as [SimResourceKey, number | undefined][]) {
+      next[key] = (next[key] ?? 0) + (amount ?? 0);
+    }
+  });
+
+  return { updated: next, shortages };
+}
+
+export function canAfford(cost: Partial<SimResources>, resources: SimResources): boolean {
+  return (['grain', 'coin', 'mana', 'favor'] as SimResourceKey[]).every((key) => {
+    const need = cost[key] ?? 0;
+    return resources[key] >= need;
+  });
+}
+
+export function applyCost(resources: SimResources, cost: Partial<SimResources>): SimResources {
+  const next: SimResources = { ...resources };
+  (['grain', 'coin', 'mana', 'favor'] as SimResourceKey[]).forEach((key) => {
+    const need = cost[key] ?? 0;
+    next[key] = Math.max(0, next[key] - need);
+  });
+  return next;
+}

--- a/src/components/game/simCatalog.ts
+++ b/src/components/game/simCatalog.ts
@@ -1,0 +1,21 @@
+import { SimResources } from './resourceUtils';
+
+export interface SimBuildingType {
+  id: string;
+  name: string;
+  cost: Partial<SimResources>;
+  inputs: Partial<SimResources>;
+  outputs: Partial<SimResources>;
+}
+
+export const SIM_BUILDINGS: Record<string, SimBuildingType> = {
+  farm: { id: 'farm', name: 'Farm', cost: { coin: 20, grain: 0 }, inputs: { coin: 1 }, outputs: { grain: 10 } },
+  house: { id: 'house', name: 'House', cost: { coin: 30, grain: 10 }, inputs: { grain: 1 }, outputs: { population: 5 } },
+  shrine: { id: 'shrine', name: 'Shrine', cost: { coin: 25, mana: 5 }, inputs: { mana: 1 }, outputs: { favor: 2 } },
+};
+
+export const BUILDABLE_TILES: Record<keyof typeof SIM_BUILDINGS, string[]> = {
+  farm: ['grass'],
+  house: ['grass'],
+  shrine: ['grass'],
+};


### PR DESCRIPTION
## Summary
- factor out simulation building catalog and helpers for cleaner PlayPage
- show per-cycle input shortages via a reusable HUD component
- test resource affordability and cost application alongside production

## Testing
- `npm test`
- `npm run lint` *(fails: 17 errors, 24 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b72893cbf08325814004cdc796fc5a