### PR TITLE
feat: add worker assignments

### DIFF
--- a/src/app/api/state/route.ts
+++ b/src/app/api/state/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase/server'
 import logger from '@/lib/logger'
+import { z } from 'zod'
 
 export async function GET() {
   try {
@@ -46,4 +47,40 @@ export async function GET() {
       { status: 503 }
     )
   }
+}
+
+const UpdateSchema = z.object({
+  id: z.string().uuid(),
+  resources: z.record(z.number()).optional(),
+  workers: z.number().optional(),
+  buildings: z.array(z.any()).optional(),
+})
+
+export async function PATCH(req: NextRequest) {
+  const json = await req.json().catch(() => ({}))
+  const parsed = UpdateSchema.safeParse(json)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.message }, { status: 400 })
+  }
+
+  const { id, resources, workers, buildings } = parsed.data
+  const updates: Record<string, any> = { updated_at: new Date().toISOString() }
+  if (resources) updates.resources = resources
+  if (typeof workers === 'number') updates.workers = workers
+  if (buildings) updates.buildings = buildings
+
+  const supabase = createSupabaseServerClient()
+  const { data, error } = await supabase
+    .from('game_state')
+    .update(updates)
+    .eq('id', id)
+    .select('*')
+    .single()
+
+  if (error) {
+    logger.error('Supabase update error:', error.message)
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json(data)
 }

--- a/src/app/api/state/tick/route.ts
+++ b/src/app/api/state/tick/route.ts
@@ -66,7 +66,14 @@ export async function POST() {
   const newMax = Math.max(Number(state.max_cycle ?? 0), newCycle)
   const { data: updated, error: upErr } = await supabase
     .from('game_state')
-    .update({ cycle: newCycle, max_cycle: newMax, resources, updated_at: new Date().toISOString() })
+    .update({
+      cycle: newCycle,
+      max_cycle: newMax,
+      resources,
+      workers: state.workers ?? 0,
+      buildings: state.buildings ?? [],
+      updated_at: new Date().toISOString(),
+    })
     .eq('id', state.id)
     .select('*')
     .single()

--- a/src/components/game/GameHUD.tsx
+++ b/src/components/game/GameHUD.tsx
@@ -30,9 +30,16 @@ export interface GameTime {
   timeRemaining: number; // seconds until next cycle
 }
 
+export interface WorkforceInfo {
+  total: number;
+  idle: number;
+  needed: number;
+}
+
 export interface GameHUDProps {
   resources: GameResources;
   time: GameTime;
+  workforce: WorkforceInfo;
   isPaused?: boolean;
   onPause?: () => void;
   onResume?: () => void;
@@ -110,6 +117,7 @@ const TimeDisplay: React.FC<{ time: GameTime; isPaused?: boolean }> = ({ time, i
 export const GameHUD: React.FC<GameHUDProps> = ({
   resources,
   time,
+  workforce,
   isPaused = false,
   onPause,
   onResume,
@@ -178,6 +186,15 @@ export const GameHUD: React.FC<GameHUDProps> = ({
             <ResourceIcon type="favor" value={resources.favor} delta={resourceChanges.favor} className="animate-scale-in stagger-4" />
             <ResourceIcon type="unrest" value={resources.unrest} delta={resourceChanges.unrest} className="animate-scale-in stagger-5" />
             <ResourceIcon type="threat" value={resources.threat} delta={resourceChanges.threat} className="animate-scale-in stagger-6" />
+          </div>
+          <div className="mt-2 flex items-center text-xs" style={{ gap: 'var(--spacing-xs)' }}>
+            <span className="text-muted">Workers:</span>
+            <span className="font-mono text-foreground">{workforce.total}</span>
+            <span className="text-muted">Idle:</span>
+            <span className={`font-mono ${workforce.idle === 0 ? 'text-warning' : 'text-foreground'}`}>{workforce.idle}</span>
+            {workforce.needed > workforce.idle && (
+              <span className="text-red-600">Need {workforce.needed - workforce.idle}</span>
+            )}
           </div>
           <ShortageDisplay shortages={shortages} />
         </div>

--- a/src/components/game/WorkerPanel.tsx
+++ b/src/components/game/WorkerPanel.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { SIM_BUILDINGS } from './simCatalog';
+
+type WorkerBuilding = {
+  id: string;
+  typeId: keyof typeof SIM_BUILDINGS;
+  workers: number;
+};
+
+interface WorkerPanelProps {
+  buildings: WorkerBuilding[];
+  catalog: typeof SIM_BUILDINGS;
+  idleWorkers: number;
+  onAssign: (id: string) => void;
+  onUnassign: (id: string) => void;
+}
+
+const WorkerPanel: React.FC<WorkerPanelProps> = ({
+  buildings,
+  catalog,
+  idleWorkers,
+  onAssign,
+  onUnassign
+}) => {
+  return (
+    <div className="absolute left-2 bottom-24 bg-panel backdrop-blur-md border border-border p-3 rounded-lg shadow-lg pointer-events-auto"
+      style={{ width: '14rem' }}
+    >
+      <h3 className="text-xs font-semibold mb-2 text-foreground">
+        Workers: {idleWorkers} idle
+      </h3>
+      <div className="space-y-2">
+        {buildings.map(b => {
+          const def = catalog[b.typeId];
+          const cap = def.workCapacity ?? 0;
+          return (
+            <div key={b.id} className="flex items-center justify-between text-xs">
+              <span className="text-foreground mr-2 truncate">{def.name}</span>
+              <div className="flex items-center" style={{ gap: 'var(--spacing-xs)' }}>
+                <button
+                  onClick={() => onUnassign(b.id)}
+                  disabled={b.workers <= 0}
+                  className="px-2 py-0.5 border border-border rounded disabled:opacity-50"
+                >
+                  -
+                </button>
+                <span className="font-mono">
+                  {b.workers}/{cap}
+                </span>
+                <button
+                  onClick={() => onAssign(b.id)}
+                  disabled={idleWorkers <= 0 || b.workers >= cap}
+                  className="px-2 py-0.5 border border-border rounded disabled:opacity-50"
+                >
+                  +
+                </button>
+              </div>
+            </div>
+          );
+        })}
+        {buildings.length === 0 && (
+          <div className="text-muted text-xs">No buildings</div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default WorkerPanel;

--- a/src/components/game/resourceUtils.test.ts
+++ b/src/components/game/resourceUtils.test.ts
@@ -26,20 +26,20 @@ describe('resourceUtils', () => {
 
 describe('applyProduction', () => {
   const catalog: Record<string, SimBuildingDef> = {
-    mill: { inputs: { grain: 2 }, outputs: { coin: 1 } }
+    mill: { inputs: { grain: 2 }, outputs: { coin: 1 }, workCapacity: 1 }
   };
 
   it('produces outputs when inputs are available', () => {
-    const res: SimResources = { grain: 5, coin: 0, mana: 0, favor: 0, population: 0 };
-    const { updated, shortages } = applyProduction(res, [{ typeId: 'mill' }], catalog);
+    const res: SimResources = { grain: 5, coin: 0, mana: 0, favor: 0, workers: 0 };
+    const { updated, shortages } = applyProduction(res, [{ typeId: 'mill', workers: 1 }], catalog);
     expect(updated.grain).toBe(3);
     expect(updated.coin).toBe(1);
     expect(shortages).toEqual({});
   });
 
   it('records shortages when inputs are missing', () => {
-    const res: SimResources = { grain: 1, coin: 0, mana: 0, favor: 0, population: 0 };
-    const { updated, shortages } = applyProduction(res, [{ typeId: 'mill' }], catalog);
+    const res: SimResources = { grain: 1, coin: 0, mana: 0, favor: 0, workers: 0 };
+    const { updated, shortages } = applyProduction(res, [{ typeId: 'mill', workers: 1 }], catalog);
     expect(updated.grain).toBe(1);
     expect(updated.coin).toBe(0);
     expect(shortages).toEqual({ grain: 1 });
@@ -47,7 +47,7 @@ describe('applyProduction', () => {
 });
 
 describe('canAfford and applyCost', () => {
-  const base: SimResources = { grain: 5, coin: 5, mana: 5, favor: 5, population: 0 };
+  const base: SimResources = { grain: 5, coin: 5, mana: 5, favor: 5, workers: 0 };
 
   it('determines affordability correctly', () => {
     expect(canAfford({ grain: 3, coin: 2 }, base)).toBe(true);

--- a/src/components/game/simCatalog.ts
+++ b/src/components/game/simCatalog.ts
@@ -6,12 +6,35 @@ export interface SimBuildingType {
   cost: Partial<SimResources>;
   inputs: Partial<SimResources>;
   outputs: Partial<SimResources>;
+  /** Maximum number of workers this building can employ */
+  workCapacity?: number;
 }
 
 export const SIM_BUILDINGS: Record<string, SimBuildingType> = {
-  farm: { id: 'farm', name: 'Farm', cost: { coin: 20, grain: 0 }, inputs: { coin: 1 }, outputs: { grain: 10 } },
-  house: { id: 'house', name: 'House', cost: { coin: 30, grain: 10 }, inputs: { grain: 1 }, outputs: { population: 5 } },
-  shrine: { id: 'shrine', name: 'Shrine', cost: { coin: 25, mana: 5 }, inputs: { mana: 1 }, outputs: { favor: 2 } },
+  farm: {
+    id: 'farm',
+    name: 'Farm',
+    cost: { coin: 20, grain: 0 },
+    inputs: { coin: 1 },
+    outputs: { grain: 10 },
+    workCapacity: 5,
+  },
+  house: {
+    id: 'house',
+    name: 'House',
+    cost: { coin: 30, grain: 10 },
+    inputs: { grain: 1 },
+    outputs: { workers: 5 },
+    workCapacity: 0,
+  },
+  shrine: {
+    id: 'shrine',
+    name: 'Shrine',
+    cost: { coin: 25, mana: 5 },
+    inputs: { mana: 1 },
+    outputs: { favor: 2 },
+    workCapacity: 2,
+  },
 };
 
 export const BUILDABLE_TILES: Record<keyof typeof SIM_BUILDINGS, string[]> = {

--- a/supabase/migrations/20250904000000_add_workers_and_buildings_to_game_state.sql
+++ b/supabase/migrations/20250904000000_add_workers_and_buildings_to_game_state.sql
@@ -1,0 +1,4 @@
+-- Add workers and buildings columns to game_state
+alter table if exists game_state
+  add column if not exists workers int not null default 0,
+  add column if not exists buildings jsonb not null default '[]';


### PR DESCRIPTION
## Summary
- track workers in game state and simulate worker assignment
- scale production by staffed capacity and show workforce stats in HUD
- add worker management panel for buildings
- persist game state, workers, and buildings to Supabase for continuity

## Testing
- `npm test`
- `npm run lint` *(fails: 42 problems (19 errors, 23 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68b72b4eead083258df3c84df74eba95