### PR TITLE
refactor: extract game context builder

### DIFF
--- a/src/app/api/proposals/[id]/scry/route.ts
+++ b/src/app/api/proposals/[id]/scry/route.ts
@@ -3,7 +3,15 @@ import { createSupabaseServerClient } from '@/lib/supabase/server'
 import { generateText } from 'ai'
 import { createOpenAI } from '@ai-sdk/openai'
 import { z } from 'zod'
-import { accumulateEffects, generateSkillTree } from '@/components/game/skills/procgen'
+import { buildGameContext } from '@/lib/gameContext'
+
+interface GameState {
+  resources?: Record<string, number>
+  buildings?: Array<{ typeId?: string; traits?: Record<string, unknown> }>
+  routes?: unknown[]
+  skills?: string[]
+  skill_tree_seed?: number
+}
 
 const openai = createOpenAI({ apiKey: process.env.OPENAI_API_KEY })
 
@@ -20,10 +28,10 @@ const AIResponseSchema = z.object({
 
 // Minimal shape for proposals to avoid 'any' usages
 interface ProposalRow {
-  guild?: string;
-  title?: string;
-  description?: string;
-  game_state?: { resources?: Record<string, number> };
+  guild?: string
+  title?: string
+  description?: string
+  game_state?: GameState
 }
 
 export async function POST(req: NextRequest, context: RouteContext) {
@@ -128,45 +136,10 @@ export async function POST(req: NextRequest, context: RouteContext) {
   const system = `You are a scrying oracle. Given a proposal and current state context (resources, buildings, routes, terrain, skill modifiers), forecast likely deltas conservatively.
 Return strict JSON: { predicted_delta: {resource:number,...}, risk_note: string }`
 
-  const p = proposal as unknown as ProposalRow
+  const p = proposal as ProposalRow
   const stateRes = p.game_state?.resources ?? {}
-  // Fetch extra context from state row if present
-  const buildings: Array<{ typeId?: string; traits?: Record<string, any> }> = Array.isArray((proposal as any).game_state?.buildings) ? (proposal as any).game_state.buildings as any : []
-  const routes: Array<any> = Array.isArray((proposal as any).game_state?.routes) ? (proposal as any).game_state.routes as any : []
-  const byType: Record<string, number> = {}
-  let farmsNearWater = 0, shrinesNearMountains = 0, campsNearForest = 0
-  for (const b of buildings) {
-    const t = String(b.typeId || '')
-    byType[t] = (byType[t] ?? 0) + 1
-    const tr = (b as any).traits || {}
-    if (t === 'farm' && Number(tr.waterAdj || 0) > 0) farmsNearWater++
-    if (t === 'shrine' && Number(tr.mountainAdj || 0) > 0) shrinesNearMountains++
-    if (t === 'lumber_camp' && Number(tr.forestAdj || 0) > 0) campsNearForest++
-  }
-  let skillModifiers: any = { resource_multipliers: {}, building_multipliers: {}, upkeep_grain_per_worker_delta: 0 }
-  const skills: string[] = Array.isArray((proposal as any).game_state?.skills) ? (proposal as any).game_state.skills as any : []
-  if (skills.length > 0) {
-    try {
-      const tree = generateSkillTree(((proposal as any).game_state?.skill_tree_seed as number) ?? 12345)
-      const unlocked = tree.nodes.filter(n => skills.includes(n.id))
-      const acc = accumulateEffects(unlocked)
-      skillModifiers = {
-        resource_multipliers: acc.resMul,
-        building_multipliers: acc.bldMul,
-        upkeep_grain_per_worker_delta: acc.upkeepDelta,
-      }
-    } catch {}
-  }
-
-  const gameContext = {
-    resources: stateRes,
-    buildings_by_type: byType,
-    routes_count: routes.length,
-    storehouse_present: (byType['storehouse'] ?? 0) > 0,
-    terrain_summary: { farmsNearWater, shrinesNearMountains, campsNearForest },
-    skill_modifiers: skillModifiers,
-  }
-  const user = `Context: ${JSON.stringify(gameContext)}\nProposal: ${String(p.title ?? '')} - ${String(p.description ?? '')}`
+  const extraContext = buildGameContext(p.game_state)
+  const user = `Context: ${JSON.stringify({ resources: stateRes, ...extraContext })}\nProposal: ${String(p.title ?? '')} - ${String(p.description ?? '')}`
   const { text } = await generateText({ model: openai('gpt-4o-mini'), system, prompt: user })
 
   let parsedJson: unknown

--- a/src/app/api/proposals/generate/route.ts
+++ b/src/app/api/proposals/generate/route.ts
@@ -3,7 +3,17 @@ import { createSupabaseServerClient } from '@/lib/supabase/server'
 import { generateText } from 'ai'
 import { createOpenAI } from '@ai-sdk/openai'
 import { z } from 'zod'
-import { accumulateEffects, generateSkillTree } from '@/components/game/skills/procgen'
+import { buildGameContext } from '@/lib/gameContext'
+
+interface GameState {
+  id: string
+  cycle: number
+  resources: Record<string, number>
+  buildings?: Array<{ typeId?: string; traits?: Record<string, unknown> }>
+  routes?: unknown[]
+  skills?: string[]
+  skill_tree_seed?: number
+}
 
 const openai = createOpenAI({ apiKey: process.env.OPENAI_API_KEY })
 
@@ -32,13 +42,14 @@ export async function POST(req: NextRequest) {
   const { guild = 'Wardens' } = parsedBody.data
 
   // Get latest state
-  const { data: state, error: stateErr } = await supabase
+  const { data: stateRow, error: stateErr } = await supabase
     .from('game_state')
     .select('*')
     .order('created_at', { ascending: false })
     .limit(1)
     .maybeSingle()
   if (stateErr) return NextResponse.json({ error: stateErr.message }, { status: 500 })
+  const state = stateRow as GameState | null
   if (!state) return NextResponse.json({ error: 'No game state' }, { status: 400 })
 
   const hasOpenAI = !!process.env.OPENAI_API_KEY &&
@@ -88,47 +99,14 @@ Guilds: Wardens(defense), Alchemists(resources), Scribes(infra), Stewards(policy
 Return JSON array, each item: { title, description, predicted_delta: {resource:number,...} }`
 
   // Build planning context
-  const buildings: Array<{ typeId?: string; traits?: Record<string, any> }> = Array.isArray((state as any).buildings) ? (state as any).buildings as any : []
-  const routes: Array<any> = Array.isArray((state as any).routes) ? (state as any).routes as any : []
-  const byType: Record<string, number> = {}
-  let farmsNearWater = 0, shrinesNearMountains = 0, campsNearForest = 0
-  for (const b of buildings) {
-    const t = String(b.typeId || '')
-    byType[t] = (byType[t] ?? 0) + 1
-    const tr = (b as any).traits || {}
-    if (t === 'farm' && Number(tr.waterAdj || 0) > 0) farmsNearWater++
-    if (t === 'shrine' && Number(tr.mountainAdj || 0) > 0) shrinesNearMountains++
-    if (t === 'lumber_camp' && Number(tr.forestAdj || 0) > 0) campsNearForest++
-  }
-  const storehousePresent = (byType['storehouse'] ?? 0) > 0
-  const routesCount = routes.length
-  const terrainSummary = { farmsNearWater, shrinesNearMountains, campsNearForest }
-  // Compute skill modifiers if state.skills present
-  let skillModifiers: any = { resource_multipliers: {}, building_multipliers: {}, upkeep_grain_per_worker_delta: 0 }
-  const skills: string[] = Array.isArray((state as any).skills) ? (state as any).skills as any : []
-  if (skills.length > 0) {
-    try {
-      const tree = generateSkillTree((state as any).skill_tree_seed ?? 12345)
-      const unlocked = tree.nodes.filter(n => skills.includes(n.id))
-      const acc = accumulateEffects(unlocked)
-      skillModifiers = {
-        resource_multipliers: acc.resMul,
-        building_multipliers: acc.bldMul,
-        upkeep_grain_per_worker_delta: acc.upkeepDelta,
-      }
-    } catch {}
-  }
+  const gameContext = buildGameContext(state)
 
   const context = {
     cycle: state.cycle,
     resources: state.resources,
     guild,
-    skill_tree_seed: (state as any).skill_tree_seed ?? 12345,
-    buildings_by_type: byType,
-    routes_count: routesCount,
-    storehouse_present: storehousePresent,
-    terrain_summary: terrainSummary,
-    skill_modifiers: skillModifiers,
+    skill_tree_seed: state.skill_tree_seed ?? 12345,
+    ...gameContext,
   }
 
   const user = `Context: ${JSON.stringify(context)}\nGenerate 2 proposals rooted in this guild focus and the game's tone. Keep predicted_delta conservative and numeric. JSON only.`

--- a/src/lib/__tests__/gameContext.test.ts
+++ b/src/lib/__tests__/gameContext.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { buildGameContext } from '../gameContext'
+import { generateSkillTree, accumulateEffects } from '../../components/game/skills/procgen'
+
+describe('buildGameContext', () => {
+  it('summarizes buildings, routes, terrain and skills', () => {
+    const state = {
+      buildings: [
+        { typeId: 'farm', traits: { waterAdj: 1 } },
+        { typeId: 'farm' },
+        { typeId: 'shrine', traits: { mountainAdj: 2 } },
+        { typeId: 'lumber_camp', traits: { forestAdj: 1 } },
+        { typeId: 'storehouse' },
+      ],
+      routes: [{}, {}, {}],
+      skills: [],
+    }
+    const ctx = buildGameContext(state)
+    expect(ctx).toEqual({
+      buildings_by_type: { farm: 2, shrine: 1, lumber_camp: 1, storehouse: 1 },
+      routes_count: 3,
+      storehouse_present: true,
+      terrain_summary: { farmsNearWater: 1, shrinesNearMountains: 1, campsNearForest: 1 },
+      skill_modifiers: {
+        resource_multipliers: {},
+        building_multipliers: {},
+        upkeep_grain_per_worker_delta: 0,
+      },
+    })
+  })
+
+  it('computes skill modifiers from unlocked skills', () => {
+    const seed = 99
+    const tree = generateSkillTree(seed)
+    const unlocked = tree.nodes.slice(0, 2)
+    const state = { skills: unlocked.map(n => n.id), skill_tree_seed: seed }
+    const ctx = buildGameContext(state)
+    const expected = accumulateEffects(unlocked)
+    expect(ctx.skill_modifiers).toEqual({
+      resource_multipliers: expected.resMul,
+      building_multipliers: expected.bldMul,
+      upkeep_grain_per_worker_delta: expected.upkeepDelta,
+    })
+  })
+})

--- a/src/lib/gameContext.ts
+++ b/src/lib/gameContext.ts
@@ -1,0 +1,76 @@
+import { accumulateEffects, generateSkillTree } from '../components/game/skills/procgen'
+
+interface RawBuilding {
+  typeId?: string
+  traits?: Record<string, unknown>
+}
+
+interface RawState {
+  buildings?: RawBuilding[]
+  routes?: unknown[]
+  skills?: string[]
+  skill_tree_seed?: number
+}
+
+export interface GameContext {
+  buildings_by_type: Record<string, number>
+  routes_count: number
+  storehouse_present: boolean
+  terrain_summary: {
+    farmsNearWater: number
+    shrinesNearMountains: number
+    campsNearForest: number
+  }
+  skill_modifiers: {
+    resource_multipliers: Record<string, number>
+    building_multipliers: Record<string, number>
+    upkeep_grain_per_worker_delta: number
+  }
+}
+
+export function buildGameContext(state: RawState | null | undefined): GameContext {
+  const buildings: RawBuilding[] = Array.isArray(state?.buildings) ? state!.buildings! : []
+  const routes: unknown[] = Array.isArray(state?.routes) ? state!.routes! : []
+
+  const byType: Record<string, number> = {}
+  let farmsNearWater = 0
+  let shrinesNearMountains = 0
+  let campsNearForest = 0
+  for (const b of buildings) {
+    const t = String(b.typeId || '')
+    byType[t] = (byType[t] ?? 0) + 1
+    const tr = b.traits || {}
+    if (t === 'farm' && Number((tr as Record<string, unknown>).waterAdj || 0) > 0) farmsNearWater++
+    if (t === 'shrine' && Number((tr as Record<string, unknown>).mountainAdj || 0) > 0) shrinesNearMountains++
+    if (t === 'lumber_camp' && Number((tr as Record<string, unknown>).forestAdj || 0) > 0) campsNearForest++
+  }
+
+  let skillModifiers: GameContext['skill_modifiers'] = {
+    resource_multipliers: {},
+    building_multipliers: {},
+    upkeep_grain_per_worker_delta: 0,
+  }
+  const skills: string[] = Array.isArray(state?.skills) ? state!.skills! : []
+  if (skills.length > 0) {
+    try {
+      const tree = generateSkillTree(state?.skill_tree_seed ?? 12345)
+      const unlocked = tree.nodes.filter(n => skills.includes(n.id))
+      const acc = accumulateEffects(unlocked)
+      skillModifiers = {
+        resource_multipliers: acc.resMul,
+        building_multipliers: acc.bldMul,
+        upkeep_grain_per_worker_delta: acc.upkeepDelta,
+      }
+    } catch {
+      // ignore skill tree errors
+    }
+  }
+
+  return {
+    buildings_by_type: byType,
+    routes_count: routes.length,
+    storehouse_present: (byType['storehouse'] ?? 0) > 0,
+    terrain_summary: { farmsNearWater, shrinesNearMountains, campsNearForest },
+    skill_modifiers: skillModifiers,
+  }
+}


### PR DESCRIPTION
## Summary
- factor game context builder into `src/lib/gameContext.ts`
- reuse helper in proposal generation and scry routes
- test game context assembly for buildings, routes, terrain, and skills

## Testing
- `npm test`
- `npm run lint` *(fails: 218 problems including existing errors in other files)*
- `npx eslint src/lib/gameContext.ts src/app/api/proposals/generate/route.ts src/app/api/proposals/[id]/scry/route.ts src/lib/__tests__/gameContext.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68baa3d98220832598600872f2e542f6