### PR TITLE
refactor: introduce repository pattern

### DIFF
--- a/src/app/api/proposals/[id]/decide/route.ts
+++ b/src/app/api/proposals/[id]/decide/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase/server'
+import { SupabaseUnitOfWork } from '@/infrastructure/supabase/unit-of-work'
 import { z } from 'zod'
 
 interface RouteContext {
@@ -14,6 +15,7 @@ const BodySchema = z.object({
 export async function POST(req: NextRequest, context: RouteContext) {
   const params = await context.params
   const supabase = createSupabaseServerClient()
+  const uow = new SupabaseUnitOfWork(supabase)
   const { id } = params
   const json = await req.json().catch(() => ({}))
   const parsed = BodySchema.safeParse(json)
@@ -25,8 +27,7 @@ export async function POST(req: NextRequest, context: RouteContext) {
   }
   const { decision, comment } = parsed.data
 
-  const { data: prop, error: propErr } = await supabase.from('proposals').select('*').eq('id', id).maybeSingle()
-  if (propErr) return NextResponse.json({ error: propErr.message }, { status: 500 })
+  const prop = await uow.proposals.getById(id)
   if (!prop) return NextResponse.json({ error: 'Proposal not found' }, { status: 404 })
 
   // Record decision
@@ -35,8 +36,11 @@ export async function POST(req: NextRequest, context: RouteContext) {
 
   // Update proposal status
   const status = decision === 'accept' ? 'accepted' : 'rejected'
-  const { error: upErr } = await supabase.from('proposals').update({ status }).eq('id', id)
-  if (upErr) return NextResponse.json({ error: upErr.message }, { status: 500 })
+  try {
+    await uow.proposals.update(id, { status })
+  } catch (upErr: any) {
+    return NextResponse.json({ error: upErr.message }, { status: 500 })
+  }
 
   return NextResponse.json({ ok: true })
 }

--- a/src/app/api/proposals/route.ts
+++ b/src/app/api/proposals/route.ts
@@ -1,40 +1,21 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase/server'
+import { SupabaseUnitOfWork } from '@/infrastructure/supabase/unit-of-work'
 import logger from '@/lib/logger'
 
 export async function GET(req: NextRequest) {
   try {
     const supabase = createSupabaseServerClient()
+    const uow = new SupabaseUnitOfWork(supabase)
 
-    // Get latest state
-    const { data: state, error: stateErr } = await supabase
-      .from('game_state')
-      .select('*')
-      .order('created_at', { ascending: false })
-      .limit(1)
-      .maybeSingle()
-    if (stateErr) {
-      logger.error('Supabase error in proposals route:', stateErr.message)
-      return NextResponse.json(
-        { error: 'Database connection failed' },
-        { status: 503 }
-      )
-    }
+    const state = await uow.gameStates.getLatest()
     if (!state) return NextResponse.json({ proposals: [] })
 
-    const { data: proposals, error: propErr } = await supabase
-      .from('proposals')
-      .select('*')
-      .eq('state_id', state.id)
-      .in('status', ['pending', 'accepted', 'rejected'])
-      .order('created_at', { ascending: false })
-    if (propErr) {
-      logger.error('Supabase error fetching proposals:', propErr.message)
-      return NextResponse.json(
-        { error: 'Failed to fetch proposals' },
-        { status: 503 }
-      )
-    }
+    const proposals = await uow.proposals.listByState(state.id, [
+      'pending',
+      'accepted',
+      'rejected',
+    ])
 
     return NextResponse.json({ proposals })
   } catch (error) {

--- a/src/domain/repositories/game-state-repository.ts
+++ b/src/domain/repositories/game-state-repository.ts
@@ -1,0 +1,19 @@
+export interface GameState {
+  id: string
+  cycle: number
+  resources: Record<string, number>
+  workers?: number
+  buildings?: unknown[]
+  routes?: unknown[]
+  edicts?: Record<string, number>
+  skills?: string[]
+  skill_tree_seed?: number
+  updated_at: string
+}
+
+export interface GameStateRepository {
+  getLatest(): Promise<GameState | null>
+  getById(id: string): Promise<GameState | null>
+  create(state: Partial<GameState>): Promise<GameState>
+  update(id: string, updates: Partial<GameState>): Promise<GameState>
+}

--- a/src/domain/repositories/proposal-repository.ts
+++ b/src/domain/repositories/proposal-repository.ts
@@ -1,0 +1,20 @@
+export type ProposalStatus = 'pending' | 'accepted' | 'rejected' | 'applied'
+
+export interface Proposal {
+  id: string
+  state_id: string
+  guild: string
+  title: string
+  description: string
+  predicted_delta: Record<string, number>
+  status: ProposalStatus
+  created_at?: string
+}
+
+export interface ProposalRepository {
+  listByState(stateId: string, statuses?: ProposalStatus[]): Promise<Proposal[]>
+  getById(id: string): Promise<Proposal | null>
+  create(proposals: Omit<Proposal, 'id'>[]): Promise<Proposal[]>
+  update(id: string, changes: Partial<Omit<Proposal, 'id'>>): Promise<Proposal>
+  updateMany(ids: string[], changes: Partial<Omit<Proposal, 'id'>>): Promise<void>
+}

--- a/src/domain/repositories/unit-of-work.ts
+++ b/src/domain/repositories/unit-of-work.ts
@@ -1,0 +1,8 @@
+import { GameStateRepository } from './game-state-repository'
+import { ProposalRepository } from './proposal-repository'
+
+export interface UnitOfWork {
+  gameStates: GameStateRepository
+  proposals: ProposalRepository
+  complete(): Promise<void>
+}

--- a/src/infrastructure/supabase/game-state-repository.ts
+++ b/src/infrastructure/supabase/game-state-repository.ts
@@ -1,0 +1,40 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { GameState, GameStateRepository } from '@/domain/repositories/game-state-repository'
+
+export class SupabaseGameStateRepository implements GameStateRepository {
+  constructor(private readonly client: SupabaseClient) {}
+
+  async getLatest(): Promise<GameState | null> {
+    const { data, error } = await this.client
+      .from('game_state')
+      .select('*')
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle()
+    if (error) throw error
+    return (data as GameState) || null
+  }
+
+  async getById(id: string): Promise<GameState | null> {
+    const { data, error } = await this.client.from('game_state').select('*').eq('id', id).maybeSingle()
+    if (error) throw error
+    return (data as GameState) || null
+  }
+
+  async create(state: Partial<GameState>): Promise<GameState> {
+    const { data, error } = await this.client.from('game_state').insert(state).select('*').single()
+    if (error) throw error
+    return data as GameState
+  }
+
+  async update(id: string, updates: Partial<GameState>): Promise<GameState> {
+    const { data, error } = await this.client
+      .from('game_state')
+      .update(updates)
+      .eq('id', id)
+      .select('*')
+      .single()
+    if (error) throw error
+    return data as GameState
+  }
+}

--- a/src/infrastructure/supabase/proposal-repository.ts
+++ b/src/infrastructure/supabase/proposal-repository.ts
@@ -1,0 +1,39 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { Proposal, ProposalRepository, ProposalStatus } from '@/domain/repositories/proposal-repository'
+
+export class SupabaseProposalRepository implements ProposalRepository {
+  constructor(private readonly client: SupabaseClient) {}
+
+  async listByState(stateId: string, statuses?: ProposalStatus[]): Promise<Proposal[]> {
+    let query = this.client.from('proposals').select('*').eq('state_id', stateId)
+    if (statuses && statuses.length) {
+      query = query.in('status', statuses)
+    }
+    const { data, error } = await query.order('created_at', { ascending: false })
+    if (error) throw error
+    return (data ?? []) as Proposal[]
+  }
+
+  async getById(id: string): Promise<Proposal | null> {
+    const { data, error } = await this.client.from('proposals').select('*').eq('id', id).maybeSingle()
+    if (error) throw error
+    return (data as Proposal) || null
+  }
+
+  async create(proposals: Omit<Proposal, 'id'>[]): Promise<Proposal[]> {
+    const { data, error } = await this.client.from('proposals').insert(proposals).select('*')
+    if (error) throw error
+    return (data ?? []) as Proposal[]
+  }
+
+  async update(id: string, changes: Partial<Omit<Proposal, 'id'>>): Promise<Proposal> {
+    const { data, error } = await this.client.from('proposals').update(changes).eq('id', id).select('*').single()
+    if (error) throw error
+    return data as Proposal
+  }
+
+  async updateMany(ids: string[], changes: Partial<Omit<Proposal, 'id'>>): Promise<void> {
+    const { error } = await this.client.from('proposals').update(changes).in('id', ids)
+    if (error) throw error
+  }
+}

--- a/src/infrastructure/supabase/unit-of-work.ts
+++ b/src/infrastructure/supabase/unit-of-work.ts
@@ -1,0 +1,19 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { UnitOfWork as UoW } from '@/domain/repositories/unit-of-work'
+import { SupabaseGameStateRepository } from './game-state-repository'
+import { SupabaseProposalRepository } from './proposal-repository'
+
+export class SupabaseUnitOfWork implements UoW {
+  public readonly gameStates: SupabaseGameStateRepository
+  public readonly proposals: SupabaseProposalRepository
+
+  constructor(private readonly client: SupabaseClient) {
+    this.gameStates = new SupabaseGameStateRepository(client)
+    this.proposals = new SupabaseProposalRepository(client)
+  }
+
+  async complete(): Promise<void> {
+    // Supabase auto-commits each statement; transactions require serverless functions.
+    // This method exists for interface compatibility.
+  }
+}


### PR DESCRIPTION
## Summary
- define GameStateRepository and ProposalRepository interfaces
- add Supabase-backed repository implementations and UnitOfWork
- update API routes to use repositories instead of raw Supabase queries

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any...)*

------
https://chatgpt.com/codex/tasks/task_e_68baa62e422c83258fc11d49ef21e683