### PR TITLE
feat: introduce event sourcing for ticks

### DIFF
--- a/src/domain/events/index.ts
+++ b/src/domain/events/index.ts
@@ -1,0 +1,24 @@
+export interface DomainEvent {
+  type: string;
+  cycle: number;
+  timestamp: string;
+}
+
+export interface ProposalAccepted extends DomainEvent {
+  type: 'ProposalAccepted';
+  proposalId: string;
+  delta: Record<string, number>;
+}
+
+export interface ResourcesUpdated extends DomainEvent {
+  type: 'ResourcesUpdated';
+  resources: Record<string, number>;
+}
+
+export interface BuildingProduced extends DomainEvent {
+  type: 'BuildingProduced';
+  buildingId: string;
+  output: Record<string, number>;
+}
+
+export type GameEvent = ProposalAccepted | ResourcesUpdated | BuildingProduced;

--- a/src/infrastructure/eventStore.ts
+++ b/src/infrastructure/eventStore.ts
@@ -1,0 +1,53 @@
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { GameEvent } from '@/domain/events';
+
+export interface GameState {
+  cycle: number;
+  resources: Record<string, number>;
+}
+
+export interface EventStore {
+  append(event: GameEvent): Promise<void>;
+  loadEvents(fromCycle?: number): Promise<GameEvent[]>;
+  saveSnapshot(cycle: number, state: GameState): Promise<void>;
+  getSnapshot(cycle?: number): Promise<GameState | null>;
+}
+
+export class SupabaseEventStore implements EventStore {
+  private client = createSupabaseServerClient();
+
+  async append(event: GameEvent): Promise<void> {
+    await this.client.from('events').insert({
+      type: event.type,
+      cycle: event.cycle,
+      timestamp: event.timestamp,
+      payload: event,
+    });
+  }
+
+  async loadEvents(fromCycle = 0): Promise<GameEvent[]> {
+    const { data } = await this.client
+      .from('events')
+      .select('payload')
+      .gte('cycle', fromCycle)
+      .order('cycle', { ascending: true });
+    return (data ?? []).map((r: { payload: GameEvent }) => r.payload as GameEvent);
+  }
+
+  async saveSnapshot(cycle: number, state: GameState): Promise<void> {
+    await this.client
+      .from('event_snapshots')
+      .upsert({ cycle, state }, { onConflict: 'cycle' });
+  }
+
+  async getSnapshot(cycle?: number): Promise<GameState | null> {
+    let query = this.client
+      .from('event_snapshots')
+      .select('state, cycle')
+      .order('cycle', { ascending: false })
+      .limit(1);
+    if (typeof cycle === 'number') query = query.eq('cycle', cycle);
+    const { data } = await query.maybeSingle();
+    return (data?.state as GameState) ?? null;
+  }
+}

--- a/src/services/tickService.ts
+++ b/src/services/tickService.ts
@@ -1,0 +1,57 @@
+import { EventStore, GameState } from '@/infrastructure/eventStore';
+import { GameEvent, ProposalAccepted, BuildingProduced, ResourcesUpdated } from '@/domain/events';
+
+function applyEvent(state: GameState, event: GameEvent): GameState {
+  switch (event.type) {
+    case 'ProposalAccepted':
+      for (const [k, v] of Object.entries(event.delta)) {
+        state.resources[k] = (state.resources[k] || 0) + v;
+      }
+      break;
+    case 'BuildingProduced':
+      for (const [k, v] of Object.entries(event.output)) {
+        state.resources[k] = (state.resources[k] || 0) + v;
+      }
+      break;
+    case 'ResourcesUpdated':
+      state.resources = { ...event.resources };
+      state.cycle = event.cycle;
+      break;
+  }
+  return state;
+}
+
+export class TickService {
+  constructor(private store: EventStore) {}
+
+  async emit(event: GameEvent): Promise<void> {
+    await this.store.append(event);
+  }
+
+  async rebuild(): Promise<GameState> {
+    const snapshot = await this.store.getSnapshot();
+    let state: GameState = snapshot ?? { cycle: 0, resources: {} };
+    const events = await this.store.loadEvents(state.cycle + 1);
+    for (const e of events) {
+      state = applyEvent(state, e);
+    }
+    return state;
+  }
+
+  async snapshot(state: GameState): Promise<void> {
+    await this.store.saveSnapshot(state.cycle, state);
+  }
+
+  async replay(cycle: number): Promise<GameState> {
+    const snapshot = await this.store.getSnapshot();
+    let state: GameState = snapshot ?? { cycle: 0, resources: {} };
+    const events = await this.store.loadEvents(state.cycle + 1);
+    for (const e of events) {
+      if (e.cycle > cycle) break;
+      state = applyEvent(state, e);
+    }
+    return state;
+  }
+}
+
+export type { GameState, ProposalAccepted, BuildingProduced, ResourcesUpdated };


### PR DESCRIPTION
## Summary
- model game events (ProposalAccepted, ResourcesUpdated, BuildingProduced)
- add Supabase-backed event store with snapshots
- add TickService and update tick route to emit and replay events

## Testing
- `npm test`
- `npm run lint` *(fails: 226 problems; existing any types in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68baa637650c8325a208672a0f955a78