### PR TITLE
feat: add prompt registry and version tracking

### DIFF
--- a/src/app/api/proposals/[id]/scry/route.ts
+++ b/src/app/api/proposals/[id]/scry/route.ts
@@ -5,17 +5,9 @@ import { config } from '@/infrastructure/config'
 import { generateText } from 'ai'
 import { createOpenAI } from '@ai-sdk/openai'
 import { z } from 'zod'
-import { accumulateEffects, generateSkillTree } from '@/components/game/skills/procgen'
 import { rateLimit } from '@/middleware/rateLimit'
 import { buildGameContext } from '@/lib/gameContext'
-
-interface GameState {
-  resources?: Record<string, number>
-  buildings?: Array<{ typeId?: string; traits?: Record<string, unknown> }>
-  routes?: unknown[]
-  skills?: string[]
-  skill_tree_seed?: number
-}
+import { getPrompt } from '@/prompts/registry'
 
 const openai = createOpenAI({ apiKey: config.openAiApiKey })
 
@@ -66,6 +58,8 @@ export async function POST(req: NextRequest, context: RouteContext) {
 
   // Deterministic fallback when OpenAI is not configured
   if (!hasOpenAI) {
+    const promptVersion = 'scry-fallback-v1'
+    const modelVersion = 'deterministic'
     const p = proposal as unknown as ProposalRow
     const guild = String(p.guild ?? '')
     const title = String(p.title ?? '')
@@ -131,21 +125,26 @@ export async function POST(req: NextRequest, context: RouteContext) {
     }
 
     const predicted_delta = inferDelta()
-    await uow.proposals.update(id, { predicted_delta })
+    await uow.proposals.update(id, { predicted_delta, scry_prompt_version: promptVersion, scry_model_version: modelVersion })
     return NextResponse.json({
       predicted_delta,
       risk_note: 'Deterministic fallback estimate based on guild heuristics (no OpenAI configured).',
     })
   }
 
-  const system = `You are a scrying oracle. Given a proposal and current state context (resources, buildings, routes, terrain, skill modifiers), forecast likely deltas conservatively.
-Return strict JSON: { predicted_delta: {resource:number,...}, risk_note: string }`
+  const promptDef = getPrompt('proposalScry')
+  const promptVersion = `${promptDef.id}-v${promptDef.version}`
+  const model = 'gpt-4o-mini'
 
   const p = proposal as ProposalRow
   const stateRes = gameState?.resources ?? {}
   const extraContext = buildGameContext(gameState)
   const user = `Context: ${JSON.stringify({ resources: stateRes, ...extraContext })}\nProposal: ${String(p.title ?? '')} - ${String(p.description ?? '')}`
-  const { text } = await generateText({ model: openai('gpt-4o-mini'), system, prompt: user })
+  const { text } = await generateText({
+    model: openai(model, { response_format: { type: 'json_schema', schema: promptDef.schema } }),
+    system: promptDef.system,
+    prompt: user,
+  })
 
   let parsedJson: unknown
   try {
@@ -166,6 +165,10 @@ Return strict JSON: { predicted_delta: {resource:number,...}, risk_note: string 
     )
   }
 
-  await uow.proposals.update(id, { predicted_delta: parsed.data.predicted_delta })
+  await uow.proposals.update(id, {
+    predicted_delta: parsed.data.predicted_delta,
+    scry_prompt_version: promptVersion,
+    scry_model_version: model,
+  })
   return NextResponse.json(parsed.data)
 }

--- a/src/app/api/proposals/generate/route.ts
+++ b/src/app/api/proposals/generate/route.ts
@@ -5,19 +5,9 @@ import { config } from '@/infrastructure/config'
 import { generateText } from 'ai'
 import { createOpenAI } from '@ai-sdk/openai'
 import { z } from 'zod'
-import { accumulateEffects, generateSkillTree } from '@/components/game/skills/procgen'
 import { rateLimit } from '@/middleware/rateLimit'
 import { buildGameContext } from '@/lib/gameContext'
-
-interface GameState {
-  id: string
-  cycle: number
-  resources: Record<string, number>
-  buildings?: Array<{ typeId?: string; traits?: Record<string, unknown> }>
-  routes?: unknown[]
-  skills?: string[]
-  skill_tree_seed?: number
-}
+import { getPrompt } from '@/prompts/registry'
 
 const openai = createOpenAI({ apiKey: config.openAiApiKey })
 
@@ -61,6 +51,8 @@ export async function POST(req: NextRequest) {
 
   if (!hasOpenAI) {
     // Deterministic, rule-based fallback when OpenAI is not configured
+    const promptVersion = 'generate-fallback-v1'
+    const modelVersion = 'deterministic'
     const guildMap: Record<string, { title: string; desc: string; delta: Record<string, number> }[]> = {
       Wardens: [
         { title: 'Fortify the Outer Walls', desc: 'Repair battlements and station extra sentries along the perimeter.', delta: { threat: -3, unrest: -1, coin: -10 } },
@@ -88,6 +80,8 @@ export async function POST(req: NextRequest) {
       description: p.desc,
       predicted_delta: p.delta,
       status: 'pending' as const,
+      gen_prompt_version: promptVersion,
+      gen_model_version: modelVersion,
     }))
 
     try {
@@ -100,10 +94,9 @@ export async function POST(req: NextRequest) {
   }
 
   // Use AI to draft 1-3 proposals aligned with README fantasy
-  const system = `You are an autonomous guild agent in a fantasy realm management game. Propose concise, actionable proposals with predicted resource deltas.
-Resources: grain, coin, mana, favor, unrest, threat.
-Guilds: Wardens(defense), Alchemists(resources), Scribes(infra), Stewards(policy).
-Return JSON array, each item: { title, description, predicted_delta: {resource:number,...} }`
+  const promptDef = getPrompt('proposalGeneration')
+  const promptVersion = `${promptDef.id}-v${promptDef.version}`
+  const model = 'gpt-4o-mini'
 
   // Build planning context
   const gameContext = buildGameContext(state)
@@ -119,8 +112,8 @@ Return JSON array, each item: { title, description, predicted_delta: {resource:n
   const user = `Context: ${JSON.stringify(context)}\nGenerate 2 proposals rooted in this guild focus and the game's tone. Keep predicted_delta conservative and numeric. JSON only.`
 
   const { text } = await generateText({
-    model: openai('gpt-4o-mini'),
-    system,
+    model: openai(model, { response_format: { type: 'json_schema', schema: promptDef.schema } }),
+    system: promptDef.system,
     prompt: user,
   })
 
@@ -151,6 +144,8 @@ Return JSON array, each item: { title, description, predicted_delta: {resource:n
     description: p.description,
     predicted_delta: p.predicted_delta,
     status: 'pending' as const,
+    gen_prompt_version: promptVersion,
+    gen_model_version: model,
   }))
 
   try {

--- a/src/domain/repositories/proposal-repository.ts
+++ b/src/domain/repositories/proposal-repository.ts
@@ -9,6 +9,10 @@ export interface Proposal {
   predicted_delta: Record<string, number>
   status: ProposalStatus
   created_at?: string
+  gen_prompt_version?: string | null
+  gen_model_version?: string | null
+  scry_prompt_version?: string | null
+  scry_model_version?: string | null
 }
 
 export interface ProposalRepository {

--- a/src/prompts/registry.ts
+++ b/src/prompts/registry.ts
@@ -1,0 +1,65 @@
+export interface PromptDefinition {
+  /** Logical name of the prompt */
+  id: string
+  /** Incremented when template or schema changes */
+  version: number
+  /** System prompt text */
+  system: string
+  /** JSON schema enforcing the model response */
+  schema: Record<string, unknown>
+}
+
+/**
+ * Central registry for model prompts and their schemas.
+ * Versioned for reproducible audits.
+ */
+export const promptRegistry = {
+  proposalGeneration: {
+    id: 'proposal-generation',
+    version: 1,
+    system: `You are an autonomous guild agent in a fantasy realm management game. Propose concise, actionable proposals with predicted resource deltas.
+Resources: grain, coin, mana, favor, unrest, threat.
+Guilds: Wardens(defense), Alchemists(resources), Scribes(infra), Stewards(policy).
+Return JSON array, each item: { title, description, predicted_delta: {resource:number,...} }`,
+    schema: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['title', 'description', 'predicted_delta'],
+        properties: {
+          title: { type: 'string' },
+          description: { type: 'string' },
+          predicted_delta: {
+            type: 'object',
+            additionalProperties: { type: 'number' },
+          },
+        },
+      },
+    },
+  },
+  proposalScry: {
+    id: 'proposal-scry',
+    version: 1,
+    system: `You are a scrying oracle. Given a proposal and current state context (resources, buildings, routes, terrain, skill modifiers), forecast likely deltas conservatively.
+Return strict JSON: { predicted_delta: {resource:number,...}, risk_note: string }`,
+    schema: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['predicted_delta', 'risk_note'],
+      properties: {
+        predicted_delta: {
+          type: 'object',
+          additionalProperties: { type: 'number' },
+        },
+        risk_note: { type: 'string' },
+      },
+    },
+  },
+} as const
+
+export type PromptName = keyof typeof promptRegistry
+
+export function getPrompt(name: PromptName) {
+  return promptRegistry[name]
+}

--- a/supabase/migrations/20240101000000_initial_schema.sql
+++ b/supabase/migrations/20240101000000_initial_schema.sql
@@ -19,7 +19,11 @@ create table if not exists proposals (
   title text not null,
   description text not null,
   predicted_delta jsonb not null default '{}',
-  status text not null default 'pending' check (status in ('pending','accepted','rejected','applied'))
+  status text not null default 'pending' check (status in ('pending','accepted','rejected','applied')),
+  gen_prompt_version text,
+  gen_model_version text,
+  scry_prompt_version text,
+  scry_model_version text
 );
 
 create table if not exists decisions (

--- a/supabase/migrations/20250831001000_ensure_core_tables.sql
+++ b/supabase/migrations/20250831001000_ensure_core_tables.sql
@@ -21,7 +21,11 @@ create table if not exists proposals (
   title text not null,
   description text not null,
   predicted_delta jsonb not null default '{}',
-  status text not null default 'pending'
+  status text not null default 'pending',
+  gen_prompt_version text,
+  gen_model_version text,
+  scry_prompt_version text,
+  scry_model_version text
 );
 
 create table if not exists decisions (

--- a/supabase/migrations/20260101000000_add_proposal_versions.sql
+++ b/supabase/migrations/20260101000000_add_proposal_versions.sql
@@ -1,0 +1,4 @@
+alter table proposals add column if not exists gen_prompt_version text;
+alter table proposals add column if not exists gen_model_version text;
+alter table proposals add column if not exists scry_prompt_version text;
+alter table proposals add column if not exists scry_model_version text;


### PR DESCRIPTION
## Summary
- add central prompt registry with versioned templates and JSON schemas
- integrate registry in proposal generation and scry routes with schema-enforced outputs
- store prompt and model version metadata on proposals for auditability

## Testing
- `npm test`
- `npm run lint` *(fails: 207 problems, pre-existing)*

------
https://chatgpt.com/codex/tasks/task_e_68baade94a988325adc990c0f9ff7522