### PR TITLE
feat(engine): add deterministic simulation engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,8 +35,10 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "assemblyscript": "^0.27.5",
         "eslint": "^9",
         "eslint-config-next": "15.5.2",
+        "tsup": "^8.0.1",
         "typescript": "^5",
         "vitest": "^1.6.0"
       }
@@ -436,6 +438,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.9.tgz",
+      "integrity": "sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -453,6 +472,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz",
+      "integrity": "sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -468,6 +504,23 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.9.tgz",
+      "integrity": "sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -3651,6 +3704,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assemblyscript": {
+      "version": "0.27.37",
+      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.27.37.tgz",
+      "integrity": "sha512-YtY5k3PiV3SyUQ6gRlR2OCn8dcVRwkpiG/k2T5buoL2ymH/Z/YbaYWbk/f9mO2HTgEtGWjPiAQrIuvA7G/63Gg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "binaryen": "116.0.0-nightly.20240114",
+        "long": "^5.2.4"
+      },
+      "bin": {
+        "asc": "bin/asc.js",
+        "asinit": "bin/asinit.js"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/assemblyscript"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -3769,6 +3845,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/binaryen": {
+      "version": "116.0.0-nightly.20240114",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-116.0.0-nightly.20240114.tgz",
+      "integrity": "sha512-0GZrojJnuhoe+hiwji7QFaL3tBlJoA+KFUN7ouYSDGZLSo9CKM8swQX8n/UcbR0d1VuZKU+nhogNzv423JEu5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "wasm-opt": "bin/wasm-opt",
+        "wasm2js": "bin/wasm2js"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -3822,6 +3909,22 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
       }
     },
     "node_modules/cac": {
@@ -4079,6 +4182,16 @@
       "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -5152,6 +5265,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -6158,6 +6283,16 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/js-binary-schema-parser": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/js-binary-schema-parser/-/js-binary-schema-parser-2.0.3.tgz",
@@ -6553,6 +6688,16 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/local-pkg": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
@@ -6593,6 +6738,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/loglevel": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
@@ -6605,6 +6757,13 @@
         "type": "tidelift",
         "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -7399,6 +7558,49 @@
         "postcss": "^8.4.21"
       }
     },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/postcss-nested": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
@@ -8118,6 +8320,20 @@
         "is-arrayish": "^0.3.1"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+      "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
+      "deprecated": "The work that was done in this beta branch won't be included in future versions",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "whatwg-url": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -8125,6 +8341,35 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map/node_modules/tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/source-map/node_modules/webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/source-map/node_modules/whatwg-url": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
       }
     },
     "node_modules/stable-hash": {
@@ -8634,6 +8879,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
@@ -8720,6 +8972,16 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -8757,6 +9019,532 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsup": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.0.tgz",
+      "integrity": "sha512-VmBp77lWNQq6PfuMqCHD3xWl22vEoWsKajkF8t+yMBawlUS8JzEI+vOVMeuNZIuMML8qXRizFKi9oD5glKQVcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.25.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "0.8.0-beta.0",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz",
+      "integrity": "sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/android-arm": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.9.tgz",
+      "integrity": "sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz",
+      "integrity": "sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/android-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.9.tgz",
+      "integrity": "sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz",
+      "integrity": "sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz",
+      "integrity": "sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz",
+      "integrity": "sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz",
+      "integrity": "sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz",
+      "integrity": "sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz",
+      "integrity": "sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz",
+      "integrity": "sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz",
+      "integrity": "sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz",
+      "integrity": "sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz",
+      "integrity": "sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz",
+      "integrity": "sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz",
+      "integrity": "sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz",
+      "integrity": "sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.9.tgz",
+      "integrity": "sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.9.tgz",
+      "integrity": "sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz",
+      "integrity": "sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz",
+      "integrity": "sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz",
+      "integrity": "sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz",
+      "integrity": "sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/tsup/node_modules/esbuild": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz",
+      "integrity": "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.9",
+        "@esbuild/android-arm": "0.25.9",
+        "@esbuild/android-arm64": "0.25.9",
+        "@esbuild/android-x64": "0.25.9",
+        "@esbuild/darwin-arm64": "0.25.9",
+        "@esbuild/darwin-x64": "0.25.9",
+        "@esbuild/freebsd-arm64": "0.25.9",
+        "@esbuild/freebsd-x64": "0.25.9",
+        "@esbuild/linux-arm": "0.25.9",
+        "@esbuild/linux-arm64": "0.25.9",
+        "@esbuild/linux-ia32": "0.25.9",
+        "@esbuild/linux-loong64": "0.25.9",
+        "@esbuild/linux-mips64el": "0.25.9",
+        "@esbuild/linux-ppc64": "0.25.9",
+        "@esbuild/linux-riscv64": "0.25.9",
+        "@esbuild/linux-s390x": "0.25.9",
+        "@esbuild/linux-x64": "0.25.9",
+        "@esbuild/netbsd-arm64": "0.25.9",
+        "@esbuild/netbsd-x64": "0.25.9",
+        "@esbuild/openbsd-arm64": "0.25.9",
+        "@esbuild/openbsd-x64": "0.25.9",
+        "@esbuild/openharmony-arm64": "0.25.9",
+        "@esbuild/sunos-x64": "0.25.9",
+        "@esbuild/win32-arm64": "0.25.9",
+        "@esbuild/win32-ia32": "0.25.9",
+        "@esbuild/win32-x64": "0.25.9"
+      }
+    },
+    "node_modules/tsup/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/tsup/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "eslint": "^9",
     "eslint-config-next": "15.5.2",
     "typescript": "^5",
-    "vitest": "^1.6.0"
+    "vitest": "^1.6.0",
+    "tsup": "^8.0.1",
+    "assemblyscript": "^0.27.5"
   }
 }

--- a/packages/engine/.gitignore
+++ b/packages/engine/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/packages/engine/assembly/index.ts
+++ b/packages/engine/assembly/index.ts
@@ -1,0 +1,7 @@
+export function applyPressures(mana: i32, unrest: i32, threat: i32): Int32Array {
+  const res = new Int32Array(3);
+  res[0] = mana > 5 ? mana - 5 : 0;
+  res[1] = unrest + 1;
+  res[2] = threat + 1;
+  return res;
+}

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@arcane/engine",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "npx tsup src/index.ts --format cjs,esm --dts",
+    "build:wasm": "npx asc assembly/index.ts --outFile dist/engine.wasm --optimize"
+  }
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -1,0 +1,229 @@
+export interface SimResources {
+  grain: number;
+  coin: number;
+  mana: number;
+  favor: number;
+  workers: number;
+  wood: number;
+  planks: number;
+}
+
+export interface SimBuildingType {
+  id: string;
+  name: string;
+  cost: Partial<SimResources>;
+  inputs: Partial<SimResources>;
+  outputs: Partial<SimResources>;
+  workCapacity?: number;
+  maxLevel?: number;
+}
+
+export interface Proposal {
+  id: string;
+  state_id: string;
+  guild?: string;
+  title?: string;
+  description?: string;
+  predicted_delta: Record<string, number>;
+  status?: string;
+}
+
+export interface BuildingData {
+  id?: string;
+  typeId?: string;
+  workers?: number;
+  level?: number;
+  traits?: Record<string, unknown>;
+  recipe?: string;
+  x?: number;
+  y?: number;
+}
+
+export interface RouteData {
+  id: string;
+  fromId: string;
+  toId: string;
+  length?: number;
+}
+
+export interface GameState {
+  id: string;
+  cycle: number;
+  resources: Record<string, number>;
+  workers?: number;
+  buildings?: BuildingData[];
+  routes?: RouteData[];
+  skills?: string[];
+  skill_tree_seed?: number;
+  edicts?: Record<string, number>;
+  max_cycle?: number;
+  updated_at?: string;
+}
+
+export interface TickCrisis {
+  type: 'unrest' | 'threat';
+  message: string;
+  penalty: Record<string, number>;
+}
+
+export interface TickResult {
+  state: GameState;
+  crisis: TickCrisis | null;
+}
+
+export function applyProposals(state: GameState, proposals: Proposal[]): GameState {
+  const next: GameState = { ...state, resources: { ...state.resources } };
+  for (const p of proposals) {
+    const delta = p.predicted_delta || {};
+    for (const key of Object.keys(delta)) {
+      const value = Number(delta[key] ?? 0);
+      next.resources[key] = Math.max(0, Number(next.resources[key] ?? 0) + value);
+    }
+  }
+  return next;
+}
+
+export function produceBuildings(state: GameState, catalog: Record<string, SimBuildingType>): { resources: Record<string, number>; workers: number } {
+  const resources: Record<string, number> = { ...state.resources };
+  let workers = Number(state.workers ?? 0);
+  const buildings: BuildingData[] = Array.isArray(state.buildings) ? state.buildings : [];
+  const edicts: Record<string, number> = state.edicts ?? {};
+  const routes: RouteData[] = Array.isArray(state.routes) ? state.routes : [];
+  const tariffValue = Math.max(0, Math.min(100, Number(edicts['tariffs'] ?? 50)));
+  const routeCoinMultiplier = 0.8 + (tariffValue * 0.006);
+  const patrolsEnabled = Number(edicts['patrols'] ?? 0) === 1;
+  const byId = new Map<string, BuildingData>(buildings.map(b => [String(b.id), b]));
+  const connectedToStorehouse = new Set<string>();
+  if (routes.length > 0) {
+    for (const r of routes) {
+      const a = byId.get(String(r.fromId));
+      const b = byId.get(String(r.toId));
+      if (!a || !b) continue;
+      if (String(a.typeId) === 'storehouse' && b.id) connectedToStorehouse.add(String(b.id));
+      if (String(b.typeId) === 'storehouse' && a.id) connectedToStorehouse.add(String(a.id));
+    }
+  }
+  for (const b of buildings) {
+    const typeId = String(b.typeId || '');
+    const def = catalog[typeId];
+    if (!def) continue;
+    const level = Math.max(1, Number(b.level ?? 1));
+    const levelOutScale = 1 + 0.5 * (level - 1);
+    const levelCapScale = 1 + 0.25 * (level - 1);
+    const capacity = Math.round((def.workCapacity ?? 0) * levelCapScale);
+    const assigned = Math.min(typeof b.workers === 'number' ? b.workers : 0, capacity);
+    const ratio = capacity > 0 ? assigned / capacity : 1;
+    const traits = b.traits || {};
+    let canProduce = true;
+    for (const [k, v] of Object.entries(def.inputs)) {
+      if (k === 'workers') continue;
+      const need = (Number(v ?? 0)) * ratio;
+      const cur = Number(resources[k as keyof typeof resources] ?? 0);
+      if (cur < need) { canProduce = false; break; }
+    }
+    if (!canProduce) continue;
+    for (const [k, v] of Object.entries(def.inputs)) {
+      let mult = 1;
+      if (typeId === 'sawmill' && k === 'wood' && b.recipe === 'fine') mult = (4/3);
+      if (typeId === 'trade_post' && k === 'grain' && b.recipe === 'premium') mult = (3/2);
+      const need = Math.max(0, Math.round((Number(v ?? 0)) * ratio * mult));
+      if (k === 'workers') {
+        workers = Math.max(0, workers - need);
+      } else {
+        const key = k as keyof typeof resources;
+        resources[key] = Math.max(0, Number(resources[key] ?? 0) - need);
+      }
+    }
+    for (const [k, v] of Object.entries(def.outputs)) {
+      let out = (Number(v ?? 0)) * ratio * levelOutScale;
+      if (typeId === 'trade_post' && k === 'coin') {
+        const waterAdj = Math.min(2, Number((traits as any).waterAdj ?? 0));
+        out += 2 * waterAdj;
+      }
+      if (typeId === 'farm' && k === 'grain') {
+        const waterAdj = Math.min(2, Number((traits as any).waterAdj ?? 0));
+        out += 3 * waterAdj;
+      }
+      if (typeId === 'lumber_camp' && k === 'wood') {
+        const forestAdj = Math.min(3, Number((traits as any).forestAdj ?? 0));
+        out += 2 * forestAdj;
+      }
+      if (typeId === 'sawmill' && k === 'planks' && b.recipe === 'fine') {
+        out = 9 * ratio * levelOutScale;
+      }
+      if (b.id && connectedToStorehouse.has(String(b.id)) && (k === 'grain' || k === 'wood' || k === 'planks')) {
+        out *= 1.15;
+      }
+      if (typeId === 'shrine' && k === 'favor') {
+        const mountainAdj = Math.min(2, Number((traits as any).mountainAdj ?? 0));
+        out += 1 * mountainAdj;
+      }
+      out = Math.max(0, Math.round(out));
+      if (k === 'workers') {
+        workers = Math.max(0, workers + out);
+      } else {
+        const key = k as keyof typeof resources;
+        resources[key] = Math.max(0, Number(resources[key] ?? 0) + out);
+      }
+    }
+  }
+  if (routes.length > 0) {
+    const MAX_ROUTE_LEN = 20;
+    for (const r of routes) {
+      const a = byId.get(String(r.fromId));
+      const b = byId.get(String(r.toId));
+      if (!a || !b) continue;
+      const dist = Math.abs(Number(a.x ?? 0) - Number(b.x ?? 0)) + Math.abs(Number(a.y ?? 0) - Number(b.y ?? 0));
+      const length = Math.min(MAX_ROUTE_LEN, Number(r.length ?? dist));
+      const coinGain = Math.max(1, Math.round(length * 0.5 * routeCoinMultiplier));
+      resources.coin = Math.max(0, Number(resources.coin ?? 0) + coinGain);
+    }
+    let unrestBump = Math.floor(routes.length / 2);
+    if (tariffValue >= 60) unrestBump += 1;
+    if (patrolsEnabled) unrestBump = Math.max(0, unrestBump - 1);
+    resources.unrest = Math.max(0, Number(resources.unrest ?? 0) + unrestBump);
+    if (patrolsEnabled) {
+      resources.coin = Math.max(0, Number(resources.coin ?? 0) - 2);
+    }
+  }
+  return { resources, workers };
+}
+
+export function processTick(state: GameState, proposals: Proposal[], catalog: Record<string, SimBuildingType>): TickResult {
+  const afterProps = applyProposals(state, proposals);
+  const prod = produceBuildings(afterProps, catalog);
+  const resources = prod.resources;
+  const workers = prod.workers;
+  const unrestThreatDecay = 1 + Math.floor(afterProps.cycle / 10);
+  resources.mana = Math.max(0, Number(resources.mana ?? 0) - 5);
+  resources.unrest = Math.max(0, Number(resources.unrest ?? 0) + unrestThreatDecay);
+  resources.threat = Math.max(0, Number(resources.threat ?? 0) + unrestThreatDecay);
+  const upkeep = Math.max(0, Math.round(workers * 0.2));
+  if (upkeep > 0) {
+    resources.grain = Math.max(0, Number(resources.grain ?? 0) - upkeep);
+  }
+  let crisis: TickCrisis | null = null;
+  if (Number(resources.unrest ?? 0) >= 80) {
+    crisis = {
+      type: 'unrest',
+      message: 'Riots erupt across the dominion, draining supplies and goodwill.',
+      penalty: { grain: -10, coin: -10, favor: -5 }
+    };
+  } else if (Number(resources.threat ?? 0) >= 70) {
+    crisis = {
+      type: 'threat',
+      message: 'Roving warbands harry the borders, sapping mana and favor.',
+      penalty: { mana: -10, favor: -5 }
+    };
+  }
+  if (crisis) {
+    for (const [key, value] of Object.entries(crisis.penalty)) {
+      resources[key] = Math.max(0, Number(resources[key] ?? 0) + value);
+    }
+  }
+  const newCycle = Number(state.cycle) + 1;
+  const newMax = Math.max(Number(state.max_cycle ?? 0), newCycle);
+  const nextState: GameState = { ...afterProps, resources, workers, cycle: newCycle, max_cycle: newMax };
+  return { state: nextState, crisis };
+}
+

--- a/packages/engine/tsconfig.json
+++ b/packages/engine/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "module": "ESNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "moduleResolution": "node",
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"]
+}

--- a/src/app/api/proposals/[id]/scry/route.ts
+++ b/src/app/api/proposals/[id]/scry/route.ts
@@ -58,6 +58,9 @@ export async function POST(req: NextRequest, context: RouteContext) {
 
   const proposal = await uow.proposals.getById(id)
   if (!proposal) return NextResponse.json({ error: 'Proposal not found' }, { status: 404 })
+  if (!proposal.state_id) {
+    return NextResponse.json({ error: 'Proposal missing state reference' }, { status: 400 })
+  }
   const gameState = await uow.gameStates.getById(proposal.state_id)
 
   const hasOpenAI = !!config.openAiApiKey &&

--- a/src/app/api/state/route.ts
+++ b/src/app/api/state/route.ts
@@ -3,6 +3,7 @@ import { createSupabaseServerClient } from '@/lib/supabase/server'
 import { SupabaseUnitOfWork } from '@/infrastructure/supabase/unit-of-work'
 import logger from '@/lib/logger'
 import { z } from 'zod'
+import type { GameState } from '@engine'
 
 export async function GET() {
   try {
@@ -66,7 +67,7 @@ export async function PATCH(req: NextRequest) {
   const supabase = createSupabaseServerClient()
   const uow = new SupabaseUnitOfWork(supabase)
   try {
-    const data = await uow.gameStates.update(id, updates)
+    const data = await uow.gameStates.update(id, updates as Partial<GameState>)
     return NextResponse.json(data)
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error)

--- a/src/app/api/state/tick/route.ts
+++ b/src/app/api/state/tick/route.ts
@@ -2,218 +2,30 @@ import { NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase/server'
 import { SupabaseUnitOfWork } from '@/infrastructure/supabase/unit-of-work'
 import { SIM_BUILDINGS } from '@/lib/buildingCatalog'
-import type { GameState } from '@/domain/repositories/game-state-repository'
+import { processTick } from '@engine'
 
-type ResKey = 'grain' | 'wood' | 'planks' | 'coin' | 'mana' | 'favor' | 'unrest' | 'threat';
-
-interface BuildingData {
-  id?: string
-  typeId?: string
-  workers?: number
-  level?: number
-  traits?: Record<string, unknown>
-  recipe?: string
-  x?: number
-  y?: number
-}
-
-interface RouteData {
-  id: string
-  fromId: string
-  toId: string
-  length?: number
-}
-
-type ExtendedState = GameState & {
-  buildings?: BuildingData[]
-  routes?: RouteData[]
-  edicts?: Record<string, number>
-}
-
-// Advance one cycle: apply accepted proposals to resources with simple rules and clear applied
+// Advance one cycle: delegate to engine and persist results
 export async function POST() {
   const supabase = createSupabaseServerClient()
   const uow = new SupabaseUnitOfWork(supabase)
 
-  // Get latest state
   const state = await uow.gameStates.getLatest()
   if (!state) return NextResponse.json({ error: 'No game state' }, { status: 400 })
-  const extState = state as ExtendedState
 
-  // Fetch accepted proposals
   const accepted = await uow.proposals.listByState(state.id, ['accepted'])
 
-  // Apply predicted deltas
-  const resources = { ...state.resources }
-  for (const p of accepted ?? []) {
-    const delta = p.predicted_delta || {}
-    for (const key of Object.keys(delta)) {
-      const value = Number(delta[key] ?? 0)
-      resources[key] = Math.max(0, (Number(resources[key] ?? 0) + value))
-    }
-  }
+  const { state: nextState, crisis } = processTick(state as any, accepted ?? [], SIM_BUILDINGS)
 
-  // Apply per-building production (conservative: skip building if any input is missing)
-  const buildings: BuildingData[] = Array.isArray(extState.buildings) ? extState.buildings : []
-  let workers = Number(extState.workers ?? 0)
-  const edicts: Record<string, number> = extState.edicts ?? {}
-  // Trade tariffs: 0..100 -> route coin multiplier ~ 0.8..1.4
-  const tariffValue = Math.max(0, Math.min(100, Number(edicts['tariffs'] ?? 50)))
-  const routeCoinMultiplier = 0.8 + (tariffValue * 0.006) // 0.8..1.4
-  const patrolsEnabled = Number(edicts['patrols'] ?? 0) === 1
-  
-  // Precompute routing graph to detect storehouse connections
-  const routes2: RouteData[] = Array.isArray(extState.routes) ? extState.routes : []
-  const byId = new Map<string, BuildingData>(buildings.map(bb => [String(bb.id), bb]))
-  const connectedToStorehouse = new Set<string>()
-  if (routes2.length > 0) {
-    for (const r of routes2) {
-      const a = byId.get(String(r.fromId))
-      const b = byId.get(String(r.toId))
-      if (!a || !b) continue
-      if (String(a.typeId) === 'storehouse' && b?.id) connectedToStorehouse.add(String(b.id))
-      if (String(b.typeId) === 'storehouse' && a?.id) connectedToStorehouse.add(String(a.id))
-    }
-  }
-
-  for (const b of buildings) {
-    const typeId = String(b.typeId || '')
-    const def = SIM_BUILDINGS[typeId]
-    if (!def) continue
-    const level = Math.max(1, Number(b.level ?? 1))
-    const levelOutScale = 1 + 0.5 * (level - 1)
-    const levelCapScale = 1 + 0.25 * (level - 1)
-    const capacity = Math.round((def.workCapacity ?? 0) * levelCapScale)
-    const assigned = Math.min(typeof b.workers === 'number' ? b.workers : 0, capacity)
-    const ratio = capacity > 0 ? assigned / capacity : 1
-    const traits = b.traits || {}
-    // Check inputs
-    let canProduce = true
-    for (const [k, v] of Object.entries(def.inputs)) {
-      if (k === 'workers') continue
-      const need = (Number(v ?? 0)) * ratio
-      const cur = Number(resources[k as ResKey] ?? 0)
-      if (cur < need) { canProduce = false; break }
-    }
-    if (!canProduce) continue
-    // Consume inputs
-    for (const [k, v] of Object.entries(def.inputs)) {
-      let mult = 1
-      if (typeId === 'sawmill' && k === 'wood' && b.recipe === 'fine') mult = (4/3)
-      if (typeId === 'trade_post' && k === 'grain' && b.recipe === 'premium') mult = (3/2)
-      const need = Math.max(0, Math.round((Number(v ?? 0)) * ratio * mult))
-      if (k === 'workers') {
-        workers = Math.max(0, workers - need)
-      } else {
-        const key = k as ResKey
-        resources[key] = Math.max(0, Number(resources[key] ?? 0) - need)
-      }
-    }
-    // Produce outputs
-    for (const [k, v] of Object.entries(def.outputs)) {
-      let out = (Number(v ?? 0)) * ratio * levelOutScale
-      // adjacency bonuses
-      if (typeId === 'trade_post' && k === 'coin') {
-        const waterAdj = Math.min(2, Number(traits.waterAdj ?? 0))
-        out += 2 * waterAdj
-      }
-      if (typeId === 'farm' && k === 'grain') {
-        const waterAdj = Math.min(2, Number(traits.waterAdj ?? 0))
-        out += 3 * waterAdj
-      }
-      if (typeId === 'lumber_camp' && k === 'wood') {
-        const forestAdj = Math.min(3, Number(traits.forestAdj ?? 0))
-        out += 2 * forestAdj
-      }
-      if (typeId === 'sawmill' && k === 'planks' && b.recipe === 'fine') {
-        out = (9) * ratio * levelOutScale
-      }
-      if (b.id && connectedToStorehouse.has(String(b.id)) && (k === 'grain' || k === 'wood' || k === 'planks')) {
-        out *= 1.15
-      }
-      if (typeId === 'shrine' && k === 'favor') {
-        const mountainAdj = Math.min(2, Number(traits.mountainAdj ?? 0))
-        out += 1 * mountainAdj
-      }
-      out = Math.max(0, Math.round(out))
-      if (k === 'workers') {
-        workers = Math.max(0, workers + out)
-      } else {
-        const key = k as ResKey
-        resources[key] = Math.max(0, Number(resources[key] ?? 0) + out)
-      }
-    }
-  }
-
-  // Trade routes: add coin based on distance; minor unrest pressure
-  if (routes2.length > 0) {
-    const MAX_ROUTE_LEN = 20
-    for (const r of routes2) {
-      const a = byId.get(String(r.fromId))
-      const b = byId.get(String(r.toId))
-      if (!a || !b) continue
-      const dist = Math.abs(Number(a?.x ?? 0) - Number(b?.x ?? 0)) + Math.abs(Number(a?.y ?? 0) - Number(b?.y ?? 0))
-      const length = Math.min(MAX_ROUTE_LEN, Number(r.length ?? dist))
-      const coinGain = Math.max(1, Math.round(length * 0.5 * routeCoinMultiplier))
-      resources.coin = Math.max(0, Number(resources.coin ?? 0) + coinGain)
-    }
-    let unrestBump = Math.floor(routes2.length / 2)
-    // Tariffs add some unrest at high values
-    if (tariffValue >= 60) unrestBump += 1
-    if (patrolsEnabled) unrestBump = Math.max(0, unrestBump - 1)
-    resources.unrest = Math.max(0, Number(resources.unrest ?? 0) + unrestBump)
-    // Patrol upkeep
-    if (patrolsEnabled) {
-      resources.coin = Math.max(0, Number(resources.coin ?? 0) - 2)
-    }
-  }
-
-  // Natural decay/pressure (wards decay => mana -5, unrest/threat scale with cycle)
-  const unrestThreatDecay = 1 + Math.floor(Number(state.cycle) / 10)
-  resources.mana = Math.max(0, Number(resources.mana ?? 0) - 5)
-  resources.unrest = Math.max(0, Number(resources.unrest ?? 0) + unrestThreatDecay)
-  resources.threat = Math.max(0, Number(resources.threat ?? 0) + unrestThreatDecay)
-
-  // Worker upkeep: small grain consumption per worker (0.2 per worker, rounded)
-  const upkeep = Math.max(0, Math.round(workers * 0.2))
-  if (upkeep > 0) {
-    resources.grain = Math.max(0, Number(resources.grain ?? 0) - upkeep)
-  }
-
-  // Crisis check
-  let crisis: null | { type: 'unrest' | 'threat'; message: string; penalty: Record<string, number> } = null
-  if (resources.unrest >= 80) {
-    crisis = {
-      type: 'unrest',
-      message: 'Riots erupt across the dominion, draining supplies and goodwill.',
-      penalty: { grain: -10, coin: -10, favor: -5 }
-    }
-  } else if (resources.threat >= 70) {
-    crisis = {
-      type: 'threat',
-      message: 'Roving warbands harry the borders, sapping mana and favor.',
-      penalty: { mana: -10, favor: -5 }
-    }
-  }
-
-  if (crisis) {
-    for (const [key, value] of Object.entries(crisis.penalty)) {
-      resources[key] = Math.max(0, Number(resources[key] ?? 0) + value)
-    }
-  }
-
-  // Increment cycle and persist max_cycle
-  const newCycle = Number(state.cycle) + 1
-  const newMax = Math.max(Number(state.max_cycle ?? 0), newCycle)
   let updated
   try {
     updated = await uow.gameStates.update(state.id, {
-      cycle: newCycle,
-      max_cycle: newMax,
-      resources,
-      workers,
-      buildings: extState.buildings ?? [],
-      routes: extState.routes ?? [],
+      cycle: nextState.cycle,
+      max_cycle: nextState.max_cycle,
+      resources: nextState.resources,
+      workers: nextState.workers,
+      buildings: nextState.buildings ?? [],
+      routes: nextState.routes ?? [],
+      edicts: nextState.edicts ?? undefined,
       updated_at: new Date().toISOString(),
     })
   } catch (upErr: unknown) {
@@ -221,7 +33,6 @@ export async function POST() {
     return NextResponse.json({ error: message }, { status: 500 })
   }
 
-  // Mark proposals as applied
   if ((accepted?.length ?? 0) > 0) {
     await uow.proposals.updateMany(
       accepted!.map(p => p.id),
@@ -231,4 +42,3 @@ export async function POST() {
 
   return NextResponse.json({ state: updated, crisis })
 }
-

--- a/src/domain/repositories/game-state-repository.ts
+++ b/src/domain/repositories/game-state-repository.ts
@@ -1,16 +1,6 @@
-export interface GameState {
-  id: string
-  cycle: number
-  resources: Record<string, number>
-  workers?: number
-  buildings?: unknown[]
-  routes?: unknown[]
-  edicts?: Record<string, number>
-  skills?: string[]
-  skill_tree_seed?: number
-  max_cycle?: number
-  updated_at: string
-}
+import type { GameState } from '@engine'
+
+export type { GameState }
 
 export interface GameStateRepository {
   getLatest(): Promise<GameState | null>

--- a/src/domain/repositories/proposal-repository.ts
+++ b/src/domain/repositories/proposal-repository.ts
@@ -1,15 +1,8 @@
 export type ProposalStatus = 'pending' | 'accepted' | 'rejected' | 'applied'
 
-export interface Proposal {
-  id: string
-  state_id: string
-  guild: string
-  title: string
-  description: string
-  predicted_delta: Record<string, number>
-  status: ProposalStatus
-  created_at?: string
-}
+import type { Proposal } from '@engine'
+
+export type { Proposal }
 
 export interface ProposalRepository {
   listByState(stateId: string, statuses?: ProposalStatus[]): Promise<Proposal[]>

--- a/src/lib/buildingCatalog.ts
+++ b/src/lib/buildingCatalog.ts
@@ -1,4 +1,12 @@
-import { type SimResources } from '@/components/game/resourceUtils';
+export interface SimResources {
+  grain: number;
+  coin: number;
+  mana: number;
+  favor: number;
+  workers: number;
+  wood: number;
+  planks: number;
+}
 
 export interface SimBuildingType {
   id: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,9 +19,11 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@engine": ["./packages/engine/src"],
+      "@engine/*": ["./packages/engine/src/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "packages/engine/assembly"]
 }


### PR DESCRIPTION
## Summary
- refactor game tick logic into new `@arcane/engine` package with pure `applyProposals`, `produceBuildings`, and `processTick` helpers
- expose game-state and proposal models from the engine and wire API tick route to use them
- add AssemblyScript build for deterministic WebAssembly target alongside Node builds
- exclude AssemblyScript sources from Next.js type checking and tighten engine models in API routes

## Testing
- `npm --prefix packages/engine run build`
- `npm --prefix packages/engine run build:wasm`
- `npm test`
- `npm run build` *(fails: missing Supabase env vars during health check)*

------
https://chatgpt.com/codex/tasks/task_e_68baade8769c8325a5ae2f4b54a14942