### PR TITLE
refactor: modularize citizen AI types and patterns

### DIFF
--- a/packages/engine/src/simulation/ai/patterns.ts
+++ b/packages/engine/src/simulation/ai/patterns.ts
@@ -1,0 +1,83 @@
+import type { AIBehaviorPattern } from './types';
+
+// Behavior patterns library
+export const BEHAVIOR_PATTERNS: AIBehaviorPattern[] = [
+  {
+    id: 'urgent_food_seeking',
+    name: 'Urgent Food Seeking',
+    priority: 100,
+    conditions: [
+      { type: 'need', property: 'food', operator: '<', value: 25 }
+    ],
+    actions: [
+      { type: 'move_to', target: 'nearest_food_source', priority: 100 },
+      { type: 'interact', target: 'food_source', duration: 2 }
+    ],
+    cooldown: 0,
+    variance: 0.1
+  },
+  {
+    id: 'social_work_collaboration',
+    name: 'Social Work Collaboration',
+    priority: 60,
+    conditions: [
+      { type: 'need', property: 'social', operator: '<', value: 40 },
+      { type: 'time', property: 'hour', operator: '>=', value: 7 },
+      { type: 'time', property: 'hour', operator: '<', value: 16 }
+    ],
+    actions: [
+      { type: 'move_to', target: 'workplace_with_colleagues', priority: 60 },
+      { type: 'socialize', duration: 5 },
+      { type: 'work', duration: 12 }
+    ],
+    cooldown: 30,
+    variance: 0.3
+  },
+  {
+    id: 'exploration_drive',
+    name: 'Exploration Drive',
+    priority: 30,
+    conditions: [
+      { type: 'mood', property: 'curiosity', operator: '>', value: 70 },
+      { type: 'need', property: 'purpose', operator: '>', value: 50 }
+    ],
+    actions: [
+      { type: 'explore', target: 'unknown_area', duration: 8 },
+      { type: 'move_to', target: 'random_building', priority: 30 }
+    ],
+    cooldown: 60,
+    variance: 0.5
+  },
+  {
+    id: 'efficient_work_routine',
+    name: 'Efficient Work Routine',
+    priority: 70,
+    conditions: [
+      { type: 'time', property: 'hour', operator: '>=', value: 7 },
+      { type: 'time', property: 'hour', operator: '<', value: 16 },
+      { type: 'need', property: 'purpose', operator: '<', value: 80 }
+    ],
+    actions: [
+      { type: 'move_to', target: 'optimal_workplace', priority: 70 },
+      { type: 'work', duration: 18 }
+    ],
+    cooldown: 15,
+    variance: 0.2
+  },
+  {
+    id: 'evening_social_gathering',
+    name: 'Evening Social Gathering',
+    priority: 50,
+    conditions: [
+      { type: 'time', property: 'hour', operator: '>=', value: 18 },
+      { type: 'time', property: 'hour', operator: '<', value: 22 },
+      { type: 'need', property: 'social', operator: '<', value: 60 }
+    ],
+    actions: [
+      { type: 'move_to', target: 'social_hub', priority: 50 },
+      { type: 'socialize', duration: 12 }
+    ],
+    cooldown: 45,
+    variance: 0.4
+  }
+];

--- a/packages/engine/src/simulation/ai/types.ts
+++ b/packages/engine/src/simulation/ai/types.ts
@@ -1,0 +1,30 @@
+// AI behavior and pathfinding types
+export interface AIBehaviorPattern {
+  id: string;
+  name: string;
+  priority: number;
+  conditions: Array<{
+    type: 'need' | 'mood' | 'time' | 'location' | 'resource' | 'social';
+    property: string;
+    operator: '<' | '>' | '==' | '<=' | '>=';
+    value: number;
+  }>;
+  actions: Array<{
+    type: 'move_to' | 'interact' | 'work' | 'rest' | 'socialize' | 'explore';
+    target?: string;
+    duration?: number;
+    priority?: number;
+  }>;
+  cooldown: number;
+  variance: number; // randomization factor 0-1
+}
+
+export interface PathfindingGoal {
+  target: { x: number; y: number };
+  purpose: 'work' | 'home' | 'social' | 'resource' | 'explore' | 'emergency';
+  priority: number;
+  urgency: number; // 0-100
+  alternatives: Array<{ x: number; y: number; score: number }>;
+  timeLimit?: number;
+  requirements?: string[];
+}

--- a/packages/engine/src/simulation/citizenAI.ts
+++ b/packages/engine/src/simulation/citizenAI.ts
@@ -2,38 +2,8 @@ import type { SimResources } from '../index';
 import type { SimulatedBuilding } from './buildingSimulation';
 import type { Citizen } from './citizenBehavior';
 import type { GameTime } from '../types/gameTime';
-
-// Enhanced AI behavior patterns
-export interface AIBehaviorPattern {
-  id: string;
-  name: string;
-  priority: number;
-  conditions: Array<{
-    type: 'need' | 'mood' | 'time' | 'location' | 'resource' | 'social';
-    property: string;
-    operator: '<' | '>' | '==' | '<=' | '>=';
-    value: number;
-  }>;
-  actions: Array<{
-    type: 'move_to' | 'interact' | 'work' | 'rest' | 'socialize' | 'explore';
-    target?: string;
-    duration?: number;
-    priority?: number;
-  }>;
-  cooldown: number;
-  variance: number; // randomization factor 0-1
-}
-
-// Dynamic pathfinding with purpose
-export interface PathfindingGoal {
-  target: { x: number; y: number };
-  purpose: 'work' | 'home' | 'social' | 'resource' | 'explore' | 'emergency';
-  priority: number;
-  urgency: number; // 0-100
-  alternatives: Array<{ x: number; y: number; score: number }>;
-  timeLimit?: number;
-  requirements?: string[];
-}
+import type { AIBehaviorPattern, PathfindingGoal } from './ai/types';
+import { BEHAVIOR_PATTERNS } from './ai/patterns';
 
 // Enhanced citizen state
 export interface CitizenState {
@@ -71,88 +41,6 @@ export interface CitizenState {
     personalTime: { start: number; end: number; flexibility: number };
   };
 }
-
-// Behavior patterns library
-const BEHAVIOR_PATTERNS: AIBehaviorPattern[] = [
-  {
-    id: 'urgent_food_seeking',
-    name: 'Urgent Food Seeking',
-    priority: 100,
-    conditions: [
-      { type: 'need', property: 'food', operator: '<', value: 25 }
-    ],
-    actions: [
-      { type: 'move_to', target: 'nearest_food_source', priority: 100 },
-      { type: 'interact', target: 'food_source', duration: 2 } // Reduced from 5
-    ],
-    cooldown: 0,
-    variance: 0.1
-  },
-  {
-    id: 'social_work_collaboration',
-    name: 'Social Work Collaboration',
-    priority: 60,
-    conditions: [
-      { type: 'need', property: 'social', operator: '<', value: 40 },
-      { type: 'time', property: 'hour', operator: '>=', value: 7 },
-      { type: 'time', property: 'hour', operator: '<', value: 16 }
-    ],
-    actions: [
-      { type: 'move_to', target: 'workplace_with_colleagues', priority: 60 },
-      { type: 'socialize', duration: 5 }, // Reduced from 10
-      { type: 'work', duration: 12 } // Reduced from 20
-    ],
-    cooldown: 30,
-    variance: 0.3
-  },
-  {
-    id: 'exploration_drive',
-    name: 'Exploration Drive',
-    priority: 30,
-    conditions: [
-      { type: 'mood', property: 'curiosity', operator: '>', value: 70 },
-      { type: 'need', property: 'purpose', operator: '>', value: 50 }
-    ],
-    actions: [
-      { type: 'explore', target: 'unknown_area', duration: 8 }, // Reduced from 15
-      { type: 'move_to', target: 'random_building', priority: 30 }
-    ],
-    cooldown: 60,
-    variance: 0.5
-  },
-  {
-    id: 'efficient_work_routine',
-    name: 'Efficient Work Routine',
-    priority: 70,
-    conditions: [
-      { type: 'time', property: 'hour', operator: '>=', value: 7 },
-      { type: 'time', property: 'hour', operator: '<', value: 16 },
-      { type: 'need', property: 'purpose', operator: '<', value: 80 }
-    ],
-    actions: [
-      { type: 'move_to', target: 'optimal_workplace', priority: 70 },
-      { type: 'work', duration: 18 } // Reduced from 30
-    ],
-    cooldown: 15,
-    variance: 0.2
-  },
-  {
-    id: 'evening_social_gathering',
-    name: 'Evening Social Gathering',
-    priority: 50,
-    conditions: [
-      { type: 'time', property: 'hour', operator: '>=', value: 18 },
-      { type: 'time', property: 'hour', operator: '<', value: 22 },
-      { type: 'need', property: 'social', operator: '<', value: 60 }
-    ],
-    actions: [
-      { type: 'move_to', target: 'social_hub', priority: 50 },
-      { type: 'socialize', duration: 12 } // Reduced from 20
-    ],
-    cooldown: 45,
-    variance: 0.4
-  }
-];
 
 // Enhanced Citizen AI System
 export class CitizenAI {

--- a/packages/engine/src/simulation/citizenBehavior.ts
+++ b/packages/engine/src/simulation/citizenBehavior.ts
@@ -1,6 +1,7 @@
 import type { SimResources } from '../index';
 import type { SimulatedBuilding } from './buildingSimulation';
-import { citizenAI, type PathfindingGoal } from './citizenAI';
+import { citizenAI } from './citizenAI';
+import type { PathfindingGoal } from './ai/types';
 import type { GameTime } from '../types/gameTime';
 
 // Personality traits that influence citizen behavior


### PR DESCRIPTION
## Summary
- move `AIBehaviorPattern` and `PathfindingGoal` interfaces into `simulation/ai/types.ts`
- extract behavior pattern library to `simulation/ai/patterns.ts`
- update citizen AI and behavior modules to import shared types and patterns

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bdd3fcabec8325bac6f26f318c9090