### PR TITLE
Refactor worker scheduling into modular types

### DIFF
--- a/packages/engine/src/simulation/workerSimulation.ts
+++ b/packages/engine/src/simulation/workerSimulation.ts
@@ -1,7 +1,8 @@
 import type { SimResources } from '../index';
 import type { SimulatedBuilding } from './buildingSimulation';
 import type { Citizen } from './citizenBehavior';
-import { workerSystem, type WorkerProfile as SystemWorkerProfile, type JobAssignment } from './workerSystem';
+import { workerSystem } from './workerSystem';
+import type { WorkerProfile as SystemWorkerProfile, JobAssignment } from './workers/types';
 import type { GameTime } from '../types/gameTime';
 
 // Job specializations and skill requirements

--- a/packages/engine/src/simulation/workers/scheduling.ts
+++ b/packages/engine/src/simulation/workers/scheduling.ts
@@ -1,0 +1,95 @@
+import type { JobAssignment, WorkerProfile, WorkShift } from './types';
+
+export function generateShifts(buildingType: string, totalWorkers: number): WorkShift[] {
+  const shifts: WorkShift[] = [];
+
+  switch (buildingType) {
+    case 'farm':
+      // Farms work during daylight
+      shifts.push({
+        startHour: 6,
+        endHour: 14,
+        workersNeeded: Math.ceil(totalWorkers * 0.7),
+        currentWorkers: []
+      });
+      shifts.push({
+        startHour: 14,
+        endHour: 18,
+        workersNeeded: Math.ceil(totalWorkers * 0.3),
+        currentWorkers: []
+      });
+      break;
+
+    case 'lumber_camp':
+      // Lumber camps work early morning
+      shifts.push({
+        startHour: 5,
+        endHour: 13,
+        workersNeeded: totalWorkers,
+        currentWorkers: []
+      });
+      break;
+
+    case 'sawmill':
+      // Sawmills can work multiple shifts
+      shifts.push({
+        startHour: 7,
+        endHour: 15,
+        workersNeeded: Math.ceil(totalWorkers * 0.6),
+        currentWorkers: []
+      });
+      shifts.push({
+        startHour: 15,
+        endHour: 23,
+        workersNeeded: Math.ceil(totalWorkers * 0.4),
+        currentWorkers: []
+      });
+      break;
+
+    default:
+      shifts.push({
+        startHour: 8,
+        endHour: 16,
+        workersNeeded: totalWorkers,
+        currentWorkers: []
+      });
+  }
+
+  return shifts;
+}
+
+export function findBestShift(worker: WorkerProfile, job: JobAssignment): WorkShift | null {
+  const availableShifts = job.shifts.filter(
+    shift => shift.currentWorkers.length < shift.workersNeeded
+  );
+
+  if (availableShifts.length === 0) return null;
+
+  const scoredShifts = availableShifts.map(shift => {
+    let score = 50;
+
+    switch (worker.preferences.preferredShift) {
+      case 'morning':
+        if (shift.startHour >= 5 && shift.startHour <= 8) score += 30;
+        break;
+      case 'afternoon':
+        if (shift.startHour >= 12 && shift.startHour <= 16) score += 30;
+        break;
+      case 'evening':
+        if (shift.startHour >= 16 && shift.startHour <= 20) score += 30;
+        break;
+      case 'night':
+        if (shift.startHour >= 20 || shift.startHour <= 4) score += 30;
+        break;
+      case 'flexible':
+        score += 10;
+        break;
+    }
+
+    return { shift, score };
+  });
+
+  return scoredShifts.reduce((best, current) =>
+    current.score > best.score ? current : best
+  ).shift;
+}

--- a/packages/engine/src/simulation/workers/types.ts
+++ b/packages/engine/src/simulation/workers/types.ts
@@ -1,0 +1,128 @@
+export interface WorkShift {
+  startHour: number;
+  endHour: number;
+  workersNeeded: number;
+  currentWorkers: string[];
+}
+
+export interface WorkerSpecialization {
+  id: string;
+  name: string;
+  requiredSkills: Record<string, number>;
+  efficiency: number;
+  preferredBuildings: string[];
+  trainingTime: number;
+  prerequisites?: string[];
+}
+
+export const WORKER_SPECIALIZATIONS: WorkerSpecialization[] = [
+  {
+    id: 'farmer',
+    name: 'Farmer',
+    requiredSkills: { agriculture: 20, endurance: 15 },
+    efficiency: 1.2,
+    preferredBuildings: ['farm'],
+    trainingTime: 20
+  },
+  {
+    id: 'lumberjack',
+    name: 'Lumberjack',
+    requiredSkills: { forestry: 25, strength: 30 },
+    efficiency: 1.3,
+    preferredBuildings: ['lumber_camp'],
+    trainingTime: 25
+  },
+  {
+    id: 'carpenter',
+    name: 'Carpenter',
+    requiredSkills: { crafting: 35, precision: 25 },
+    efficiency: 1.4,
+    preferredBuildings: ['sawmill', 'house'],
+    trainingTime: 40,
+    prerequisites: ['lumberjack']
+  },
+  {
+    id: 'foreman',
+    name: 'Foreman',
+    requiredSkills: { leadership: 40, organization: 35 },
+    efficiency: 1.1,
+    preferredBuildings: ['farm', 'lumber_camp', 'sawmill'],
+    trainingTime: 60,
+    prerequisites: ['farmer', 'lumberjack']
+  },
+  {
+    id: 'apprentice',
+    name: 'Apprentice',
+    requiredSkills: { learning: 20 },
+    efficiency: 0.7,
+    preferredBuildings: ['farm', 'lumber_camp', 'sawmill'],
+    trainingTime: 10
+  },
+  {
+    id: 'specialist',
+    name: 'Specialist',
+    requiredSkills: { expertise: 50, innovation: 30 },
+    efficiency: 1.6,
+    preferredBuildings: ['sawmill'],
+    trainingTime: 80,
+    prerequisites: ['carpenter']
+  }
+];
+
+export interface JobAssignment {
+  id: string;
+  buildingId: string;
+  buildingType: string;
+  position: { x: number; y: number };
+  requiredWorkers: number;
+  currentWorkers: string[];
+  priority: number;
+  skillRequirements: Record<string, number>;
+  workConditions: {
+    safety: number;
+    comfort: number;
+    socialInteraction: number;
+    autonomy: number;
+  };
+  shifts: WorkShift[];
+  productivity: number;
+  lastUpdated: number;
+}
+
+export interface WorkerProfile {
+  citizenId: string;
+  specializations: string[];
+  currentJob?: string;
+  workHistory: Array<{
+    jobId: string;
+    buildingType: string;
+    startCycle: number;
+    endCycle?: number;
+    performance: number;
+    satisfaction: number;
+  }>;
+  preferences: {
+    preferredShift: 'morning' | 'afternoon' | 'evening' | 'night' | 'flexible';
+    maxCommute: number;
+    workStyle: 'independent' | 'collaborative' | 'leadership' | 'support';
+    riskTolerance: number;
+  };
+  performance: {
+    reliability: number;
+    efficiency: number;
+    adaptability: number;
+    teamwork: number;
+  };
+  availability: {
+    currentShift?: { start: number; end: number };
+    daysOff: number[];
+    vacationDays: number;
+    sickDays: number;
+  };
+  trainingProgress: Record<string, {
+    specializationId: string;
+    progress: number;
+    trainer?: string;
+    estimatedCompletion: number;
+  }>;
+}


### PR DESCRIPTION
## Summary
- centralize worker specialization data and job assignment interfaces in a new `workers/types` module
- extract shift generation and preference matching into `workers/scheduling`
- simplify worker system imports and delegate shift logic to scheduling helpers

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type, etc.)*
- `npx tsc -p packages/engine/tsconfig.json --noEmit --pretty false`


------
https://chatgpt.com/codex/tasks/task_e_68bdd3f1a4f88325bb32f622840fc721