### PR TITLE
refactor grid rendering

### DIFF
--- a/src/components/game/grid/TileOverlay.ts
+++ b/src/components/game/grid/TileOverlay.ts
@@ -1,0 +1,113 @@
+import * as PIXI from "pixi.js";
+import { gridToWorld } from "@/lib/isometric";
+
+export interface TileOverlayOptions {
+  tileWidth: number;
+  tileHeight: number;
+  getTileType: (x: number, y: number) => string | undefined;
+  onTileHover?: (x: number, y: number, tileType?: string) => void;
+  onTileClick?: (x: number, y: number, tileType?: string) => void;
+}
+
+export class TileOverlay {
+  hoverOverlay: PIXI.Graphics;
+  selectOverlay: PIXI.Graphics;
+  private lastHoverIndex: { x: number; y: number } | null = null;
+  private hoverDebounce: number | null = null;
+
+  constructor(private container: PIXI.Container, private opts: TileOverlayOptions) {
+    this.hoverOverlay = this.makeOverlay(0x4f46e5, 0.25);
+    this.selectOverlay = this.makeOverlay(0x10b981, 0.3);
+    container.addChild(this.hoverOverlay);
+    container.addChild(this.selectOverlay);
+
+    container.on("pointerleave", this.onPointerLeave);
+    container.on("pointermove", this.onPointerMove);
+    container.on("pointertap", this.onPointerTap);
+  }
+
+  private makeOverlay(color: number, alpha: number) {
+    const g = new PIXI.Graphics();
+    g.zIndex = 9999;
+      (g as unknown as { eventMode: string }).eventMode = "none";
+    g.clear();
+    g.fill({ color, alpha });
+    g.moveTo(0, -this.opts.tileHeight / 2);
+    g.lineTo(this.opts.tileWidth / 2, 0);
+    g.lineTo(0, this.opts.tileHeight / 2);
+    g.lineTo(-this.opts.tileWidth / 2, 0);
+    g.closePath();
+    g.fill();
+    g.visible = false;
+    return g;
+  }
+
+  private toTileIndex(wx: number, wy: number) {
+    const tw2 = this.opts.tileWidth / 2;
+    const th2 = this.opts.tileHeight / 2;
+    const fx = wy / th2 + wx / tw2;
+    const fy = wy / th2 - wx / tw2;
+    const gx = Math.round(fx / 2);
+    const gy = Math.round(fy / 2);
+    return { gx, gy };
+  }
+
+  private onPointerLeave = () => {
+    this.hoverOverlay.visible = false;
+    this.lastHoverIndex = null;
+  };
+
+  private onPointerMove = (e: PIXI.FederatedPointerEvent) => {
+      const local = this.container.toLocal({ x: e.globalX, y: e.globalY } as PIXI.IPointData);
+    const { gx, gy } = this.toTileIndex(local.x, local.y);
+    const keyType = this.opts.getTileType(gx, gy);
+    if (gx < 0 || gy < 0 || keyType === undefined) {
+      this.hoverOverlay.visible = false;
+      this.lastHoverIndex = null;
+      return;
+    }
+    const last = this.lastHoverIndex;
+    if (!last || last.x !== gx || last.y !== gy) {
+      if (this.hoverDebounce) {
+        clearTimeout(this.hoverDebounce);
+        this.hoverDebounce = null;
+      }
+      const targetX = gx, targetY = gy;
+      this.hoverDebounce = window.setTimeout(() => {
+        this.lastHoverIndex = { x: targetX, y: targetY };
+        const { worldX, worldY } = gridToWorld(targetX, targetY, this.opts.tileWidth, this.opts.tileHeight);
+        this.hoverOverlay.visible = true;
+        this.hoverOverlay.position.set(worldX, worldY);
+        this.opts.onTileHover?.(targetX, targetY, this.opts.getTileType(targetX, targetY));
+      }, 20);
+    }
+  };
+
+  private onPointerTap = (e: PIXI.FederatedPointerEvent) => {
+    const local = this.container.toLocal({ x: e.globalX, y: e.globalY } as PIXI.IPointData);
+    const { gx, gy } = this.toTileIndex(local.x, local.y);
+    const tileType = this.opts.getTileType(gx, gy);
+    if (gx < 0 || gy < 0 || tileType === undefined) return;
+    const { worldX, worldY } = gridToWorld(gx, gy, this.opts.tileWidth, this.opts.tileHeight);
+    this.selectOverlay.visible = true;
+    this.selectOverlay.position.set(worldX, worldY);
+    this.opts.onTileClick?.(gx, gy, tileType);
+  };
+
+  destroy() {
+    this.container.off("pointerleave", this.onPointerLeave);
+    this.container.off("pointermove", this.onPointerMove);
+    this.container.off("pointertap", this.onPointerTap);
+    if (this.hoverDebounce) {
+      clearTimeout(this.hoverDebounce);
+      this.hoverDebounce = null;
+    }
+    this.container.removeChild(this.hoverOverlay);
+    this.container.removeChild(this.selectOverlay);
+    this.hoverOverlay.destroy();
+    this.selectOverlay.destroy();
+  }
+}
+
+export type { TileOverlayOptions };
+

--- a/src/components/game/grid/TileRenderer.ts
+++ b/src/components/game/grid/TileRenderer.ts
@@ -1,0 +1,123 @@
+import * as PIXI from "pixi.js";
+import { gridToWorld, TILE_COLORS } from "@/lib/isometric";
+
+export interface GridTile {
+  x: number;
+  y: number;
+  worldX: number;
+  worldY: number;
+  tileType: string;
+  sprite: PIXI.Graphics;
+}
+
+function shade(hex: number, factor: number): number {
+  const r = Math.max(0, Math.min(255, Math.round(((hex >> 16) & 0xff) * factor)));
+  const g = Math.max(0, Math.min(255, Math.round(((hex >> 8) & 0xff) * factor)));
+  const b = Math.max(0, Math.min(255, Math.round((hex & 0xff) * factor)));
+  return (r << 16) | (g << 8) | b;
+}
+
+export function createTileSprite(
+  gridX: number,
+  gridY: number,
+  gridContainer: PIXI.Container,
+  tileWidth: number,
+  tileHeight: number,
+  tileTypes: string[][],
+): GridTile {
+  const { worldX, worldY } = gridToWorld(gridX, gridY, tileWidth, tileHeight);
+  const tileType = tileTypes[gridY]?.[gridX] || "unknown";
+
+  const tile = new PIXI.Graphics();
+  const base = TILE_COLORS[tileType] ?? 0xdde7f7;
+  const lighter = shade(base, 1.08);
+  const darker = shade(base, 0.85);
+
+  // Base diamond with subtle center light and beveled edges
+  tile.fill({ color: base, alpha: 0.96 });
+  tile.moveTo(0, -tileHeight / 2);
+  tile.lineTo(tileWidth / 2, 0);
+  tile.lineTo(0, tileHeight / 2);
+  tile.lineTo(-tileWidth / 2, 0);
+  tile.closePath();
+  tile.fill();
+
+  // Inner highlight diamond
+  tile.fill({ color: lighter, alpha: 0.12 });
+  tile.moveTo(0, -tileHeight * 0.36);
+  tile.lineTo(tileWidth * 0.36, 0);
+  tile.lineTo(0, tileHeight * 0.36);
+  tile.lineTo(-tileWidth * 0.36, 0);
+  tile.closePath();
+  tile.fill();
+
+  // Bevel: darker stroke on right/bottom edges
+  tile.setStrokeStyle({ width: 1.5, color: darker, alpha: 0.55 });
+  tile.moveTo(0, tileHeight / 2);
+  tile.lineTo(tileWidth / 2, 0);
+  tile.lineTo(0, -tileHeight / 2);
+  tile.stroke();
+  // Fine outline
+  tile.setStrokeStyle({ width: 1, color: 0x334155, alpha: 0.35 });
+  tile.moveTo(0, -tileHeight / 2);
+  tile.lineTo(tileWidth / 2, 0);
+  tile.lineTo(0, tileHeight / 2);
+  tile.lineTo(-tileWidth / 2, 0);
+  tile.lineTo(0, -tileHeight / 2);
+  tile.stroke();
+
+  // Subtle terrain micro-textures
+  const tex = new PIXI.Graphics();
+  tex.zIndex = 3;
+  tex.position.set(worldX, worldY);
+    (tex as unknown as { eventMode: string }).eventMode = "none";
+  if (tileType === "water") {
+    tex.setStrokeStyle({ width: 1, color: 0x93c5fd, alpha: 0.35 });
+    const y0 = -tileHeight * 0.12, y1 = 0, y2 = tileHeight * 0.12;
+    tex.moveTo(-tileWidth * 0.25, y0); tex.quadraticCurveTo(0, y0 + 2, tileWidth * 0.25, y0);
+    tex.moveTo(-tileWidth * 0.3, y1); tex.quadraticCurveTo(0, y1 + 2, tileWidth * 0.3, y1);
+    tex.moveTo(-tileWidth * 0.2, y2); tex.quadraticCurveTo(0, y2 + 2, tileWidth * 0.2, y2);
+    tex.stroke();
+  } else if (tileType === "forest") {
+    tex.fill({ color: 0x166534, alpha: 0.12 });
+    const s = Math.max(2, Math.floor(tileHeight * 0.08));
+    tex.drawPolygon([-s, 0, 0, -s, s, 0, -s, 0]);
+    tex.endFill();
+  } else if (tileType === "mountain") {
+    tex.setStrokeStyle({ width: 1, color: 0x64748b, alpha: 0.35 });
+    tex.moveTo(-tileWidth * 0.2, tileHeight * 0.05);
+    tex.lineTo(0, -tileHeight * 0.15);
+    tex.lineTo(tileWidth * 0.2, tileHeight * 0.05);
+    tex.stroke();
+  } else if (tileType === "grass") {
+    tex.setStrokeStyle({ width: 1, color: 0x16a34a, alpha: 0.15 });
+    tex.moveTo(-tileWidth * 0.1, tileHeight * 0.04);
+    tex.lineTo(-tileWidth * 0.02, tileHeight * 0.01);
+    tex.moveTo(tileWidth * 0.1, -tileHeight * 0.04);
+    tex.lineTo(tileWidth * 0.02, -tileHeight * 0.01);
+    tex.stroke();
+  }
+  gridContainer.addChild(tex);
+    (tile as PIXI.Graphics & { __tex?: PIXI.Graphics }).__tex = tex;
+
+  tile.x = worldX;
+  tile.y = worldY;
+    (tile as unknown as { eventMode: string }).eventMode = "static";
+  const hx = (tileWidth / 2) * 0.95;
+  const hy = (tileHeight / 2) * 0.95;
+  tile.hitArea = new PIXI.Polygon([0, -hy, hx, 0, 0, hy, -hx, 0]);
+  tile.cursor = "pointer";
+
+  // Optional animated overlays per tile type
+  const overlay = new PIXI.Graphics();
+  overlay.zIndex = 5;
+    (overlay as unknown as { eventMode: string }).eventMode = "none";
+  overlay.position.set(worldX, worldY);
+  gridContainer.addChild(overlay);
+    (tile as PIXI.Graphics & { __overlay?: PIXI.Graphics }).__overlay = overlay;
+
+  return { x: gridX, y: gridY, worldX, worldY, tileType, sprite: tile };
+}
+
+export { createTileSprite };
+


### PR DESCRIPTION
## Summary
- isolate tile sprite creation in `TileRenderer`
- manage hover and selection overlays via `TileOverlay`
- streamline `IsometricGrid` to compose renderer and overlays

## Testing
- `npm run lint src/components/game/IsometricGrid.tsx src/components/game/grid/TileRenderer.ts src/components/game/grid/TileOverlay.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bde3becfb88325ad6621532a98ef7e