### PR TITLE
refactor citizen rendering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@ Related docs: docs/agents/ARCHITECTURE.md, docs/agents/PROMPTS.md, docs/agents/S
 - `supabase/migrations/` — schema and idempotent updates for `game_state`, `proposals`
 - `src/components/game/buildingIcons/` — canvas icon drawers keyed by building type
 - `src/components/game/BuildingsLayer.tsx` — renders building sprites and tooltips
+- `src/components/game/citizens/` — animated citizen/vehicle helpers (types, pathfinding, renderers). Run `npm run lint src/components/game/AnimatedCitizensLayer.tsx src/components/game/citizens/*.ts` and `npm test` when modifying
 - `src/components/settings/` — reusable settings panel components and configuration
 - `packages/engine/src/simulation/traffic/` — modular traffic simulation system (vehicle, pedestrian, and light managers). Run `npm test` and `npm run lint packages/engine/src/simulation/traffic` when modifying
 - `src/components/game/skills/` — skill tree modules

--- a/src/components/game/citizens/CitizenRenderer.ts
+++ b/src/components/game/citizens/CitizenRenderer.ts
@@ -1,0 +1,53 @@
+import * as PIXI from 'pixi.js';
+import { AnimatedCitizen } from './types';
+import { gridToIso } from './citizenPathfinding';
+
+export function renderCitizen(citizen: AnimatedCitizen): PIXI.Graphics {
+  const isoPos = gridToIso(citizen.x, citizen.y);
+  const sprite = new PIXI.Graphics();
+
+  if (citizen.direction !== undefined) {
+    sprite.rotation = citizen.direction;
+  }
+
+  let baseColor = 0x7ED321; // Default green for citizens
+  if (citizen.type === 'worker') {
+    baseColor = 0x4A90E2; // Blue for workers
+  } else if (citizen.type === 'trader') {
+    baseColor = 0xF5A623; // Orange for traders
+  }
+
+  sprite.beginFill(baseColor);
+  sprite.drawCircle(0, 0, 3);
+
+  sprite.beginFill(baseColor, 0.7);
+  sprite.drawCircle(2, 0, 1.5);
+  sprite.endFill();
+
+  if (citizen.lastActivity) {
+    const timeSinceActivity = Date.now() - citizen.lastActivity;
+    const activityIntensity = Math.max(0, 1 - timeSinceActivity / 5000);
+
+    let activityColor = 0xFFFFFF;
+    if (citizen.type === 'worker') {
+      activityColor = 0xFFA500;
+    } else if (citizen.type === 'trader') {
+      activityColor = 0x32CD32;
+    } else {
+      activityColor = 0x87CEEB;
+    }
+
+    sprite.beginFill(activityColor, activityIntensity * 0.6);
+    sprite.drawCircle(-1, -4, 1.5);
+    sprite.endFill();
+  }
+
+  if (citizen.path && citizen.pathIndex !== undefined) {
+    sprite.beginFill(0x00FF00, 0.4);
+    sprite.drawCircle(0, -6, 1.5);
+    sprite.endFill();
+  }
+
+  sprite.position.set(isoPos.x, isoPos.y);
+  return sprite;
+}

--- a/src/components/game/citizens/VehicleRenderer.ts
+++ b/src/components/game/citizens/VehicleRenderer.ts
@@ -1,0 +1,53 @@
+import * as PIXI from 'pixi.js';
+import { AnimatedVehicle } from './types';
+import { gridToIso } from './citizenPathfinding';
+
+export function renderVehicle(vehicle: AnimatedVehicle): PIXI.Graphics {
+  const isoPos = gridToIso(vehicle.x, vehicle.y);
+  const sprite = new PIXI.Graphics();
+
+  if (vehicle.direction !== undefined) {
+    sprite.rotation = vehicle.direction;
+  }
+
+  if (vehicle.type === 'cart') {
+    sprite.beginFill(0x8B4513);
+    sprite.drawRect(-6, -3, 12, 6);
+    sprite.beginFill(0xA0522D);
+    sprite.drawRect(4, -2, 2, 4);
+  } else if (vehicle.type === 'wagon') {
+    sprite.beginFill(0x654321);
+    sprite.drawRect(-8, -4, 16, 8);
+    sprite.beginFill(0x8B4513);
+    sprite.drawRect(6, -3, 2, 6);
+  } else {
+    sprite.beginFill(0x4169E1);
+    sprite.drawEllipse(0, 0, 10, 5);
+    sprite.beginFill(0x6495ED);
+    sprite.drawEllipse(6, 0, 4, 2);
+  }
+  sprite.endFill();
+
+  if (vehicle.cargo) {
+    let cargoColor = 0xFFD700;
+    switch (vehicle.cargo) {
+      case 'wood': cargoColor = 0x8B4513; break;
+      case 'stone': cargoColor = 0x708090; break;
+      case 'food': cargoColor = 0x32CD32; break;
+      case 'goods': cargoColor = 0xFF6347; break;
+      case 'tools': cargoColor = 0x4682B4; break;
+    }
+    sprite.beginFill(cargoColor, 0.8);
+    sprite.drawCircle(-2, -2, 3);
+    sprite.endFill();
+  }
+
+  if (vehicle.path && vehicle.pathIndex !== undefined) {
+    sprite.beginFill(0x00FF00, 0.3);
+    sprite.drawCircle(0, -8, 2);
+    sprite.endFill();
+  }
+
+  sprite.position.set(isoPos.x, isoPos.y);
+  return sprite;
+}

--- a/src/components/game/citizens/citizenPathfinding.ts
+++ b/src/components/game/citizens/citizenPathfinding.ts
@@ -1,0 +1,128 @@
+import { Road } from './types';
+
+const TILE_WIDTH = 64;
+const TILE_HEIGHT = 32;
+
+export function gridToIso(gridX: number, gridY: number): { x: number; y: number } {
+  return {
+    x: (gridX - gridY) * (TILE_WIDTH / 2),
+    y: (gridX + gridY) * (TILE_HEIGHT / 2)
+  };
+}
+
+export function generatePath(
+  startX: number,
+  startY: number,
+  endX: number,
+  endY: number,
+  roads: Road[],
+  tileTypes: string[][]
+): { x: number; y: number }[] {
+  const roadSet = new Set(roads.map(r => `${r.x},${r.y}`));
+  const maxX = tileTypes[0]?.length || 20;
+  const maxY = tileTypes.length || 20;
+
+  interface PathNode {
+    x: number;
+    y: number;
+    g: number; // Cost from start
+    h: number; // Heuristic to end
+    f: number; // Total cost
+    parent?: PathNode;
+  }
+
+  const heuristic = (x1: number, y1: number, x2: number, y2: number) => {
+    return Math.abs(x1 - x2) + Math.abs(y1 - y2);
+  };
+
+  const getMoveCost = (x: number, y: number) => {
+    if (roadSet.has(`${x},${y}`)) return 1;
+    if (x >= 0 && x < maxX && y >= 0 && y < maxY) {
+      const tileType = tileTypes[y]?.[x];
+      if (tileType === 'water') return 10;
+      if (tileType === 'mountain') return 8;
+      return 3;
+    }
+    return 5;
+  };
+
+  const openSet: PathNode[] = [];
+  const closedSet = new Set<string>();
+
+  const startNode: PathNode = {
+    x: Math.round(startX),
+    y: Math.round(startY),
+    g: 0,
+    h: heuristic(Math.round(startX), Math.round(startY), Math.round(endX), Math.round(endY)),
+    f: 0
+  };
+  startNode.f = startNode.g + startNode.h;
+
+  openSet.push(startNode);
+
+  const directions = [[-1, 0], [1, 0], [0, -1], [0, 1], [-1, -1], [-1, 1], [1, -1], [1, 1]];
+
+  while (openSet.length > 0) {
+    let currentIndex = 0;
+    for (let i = 1; i < openSet.length; i++) {
+      if (openSet[i].f < openSet[currentIndex].f) {
+        currentIndex = i;
+      }
+    }
+
+    const current = openSet.splice(currentIndex, 1)[0];
+    closedSet.add(`${current.x},${current.y}`);
+
+    if (current.x === Math.round(endX) && current.y === Math.round(endY)) {
+      const path: { x: number; y: number }[] = [];
+      let node: PathNode | undefined = current;
+      while (node) {
+        path.unshift({ x: node.x, y: node.y });
+        node = node.parent;
+      }
+      return path;
+    }
+
+    for (const [dx, dy] of directions) {
+      const newX = current.x + dx;
+      const newY = current.y + dy;
+      const key = `${newX},${newY}`;
+
+      if (closedSet.has(key)) continue;
+
+      const moveCost = getMoveCost(newX, newY);
+      const g = current.g + moveCost;
+
+      let neighbor = openSet.find(n => n.x === newX && n.y === newY);
+
+      if (!neighbor) {
+        neighbor = {
+          x: newX,
+          y: newY,
+          g: g,
+          h: heuristic(newX, newY, Math.round(endX), Math.round(endY)),
+          f: 0,
+          parent: current
+        };
+        neighbor.f = neighbor.g + neighbor.h;
+        openSet.push(neighbor);
+      } else if (g < neighbor.g) {
+        neighbor.g = g;
+        neighbor.f = neighbor.g + neighbor.h;
+        neighbor.parent = current;
+      }
+    }
+  }
+
+  const path: { x: number; y: number }[] = [];
+  const steps = Math.max(Math.abs(endX - startX), Math.abs(endY - startY));
+
+  for (let i = 0; i <= steps; i++) {
+    const progress = steps > 0 ? i / steps : 0;
+    const x = Math.round(startX + (endX - startX) * progress);
+    const y = Math.round(startY + (endY - startY) * progress);
+    path.push({ x, y });
+  }
+
+  return path;
+}

--- a/src/components/game/citizens/types.ts
+++ b/src/components/game/citizens/types.ts
@@ -1,0 +1,43 @@
+export interface AnimatedCitizen {
+  id: string;
+  x: number;
+  y: number;
+  targetX: number;
+  targetY: number;
+  speed: number;
+  type: 'worker' | 'trader' | 'citizen';
+  buildingId?: string;
+  path?: { x: number; y: number }[];
+  pathIndex?: number;
+  lastActivity?: number;
+  direction?: number;
+}
+
+export interface AnimatedVehicle {
+  id: string;
+  x: number;
+  y: number;
+  targetX: number;
+  targetY: number;
+  speed: number;
+  type: 'cart' | 'wagon' | 'boat';
+  cargo?: string;
+  path?: { x: number; y: number }[];
+  pathIndex?: number;
+  direction?: number;
+  lastDelivery?: number;
+}
+
+export interface Building {
+  id: string;
+  typeId: string;
+  x: number;
+  y: number;
+  workers: number;
+  level: number;
+}
+
+export interface Road {
+  x: number;
+  y: number;
+}


### PR DESCRIPTION
## Summary
- extract AnimatedCitizen and AnimatedVehicle types and pathfinding to dedicated citizens helpers
- move citizen and vehicle drawing into dedicated renderers
- keep AnimatedCitizensLayer focused on coordination
- document citizen helpers in AGENTS and ensure effect tracks road and tile data

## Testing
- `npm run lint src/components/game/AnimatedCitizensLayer.tsx src/components/game/citizens/*.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bde3b1518c8325b861a2284715d321