### PR TITLE
refactor: modularize simulation integration

### DIFF
--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -144,15 +144,15 @@ export function produceBuildings(state: GameState, catalog: Record<string, SimBu
     for (const [k, v] of Object.entries(def.outputs)) {
       let out = (Number(v ?? 0)) * ratio * levelOutScale;
       if (typeId === 'trade_post' && k === 'coin') {
-        const waterAdj = Math.min(2, Number((traits as any).waterAdj ?? 0));
+        const waterAdj = Math.min(2, Number((traits as Record<string, number>).waterAdj ?? 0));
         out += 2 * waterAdj;
       }
       if (typeId === 'farm' && k === 'grain') {
-        const waterAdj = Math.min(2, Number((traits as any).waterAdj ?? 0));
+        const waterAdj = Math.min(2, Number((traits as Record<string, number>).waterAdj ?? 0));
         out += 3 * waterAdj;
       }
       if (typeId === 'lumber_camp' && k === 'wood') {
-        const forestAdj = Math.min(3, Number((traits as any).forestAdj ?? 0));
+        const forestAdj = Math.min(3, Number((traits as Record<string, number>).forestAdj ?? 0));
         out += 2 * forestAdj;
       }
       if (typeId === 'sawmill' && k === 'planks' && b.recipe === 'fine') {
@@ -162,7 +162,7 @@ export function produceBuildings(state: GameState, catalog: Record<string, SimBu
         out *= 1.15;
       }
       if (typeId === 'shrine' && k === 'favor') {
-        const mountainAdj = Math.min(2, Number((traits as any).mountainAdj ?? 0));
+        const mountainAdj = Math.min(2, Number((traits as Record<string, number>).mountainAdj ?? 0));
         out += 1 * mountainAdj;
       }
       out = Math.max(0, Math.round(out));
@@ -244,6 +244,9 @@ export * from './simulation/citizenBehavior';
 export * from './simulation/workerSimulation';
 export * from './simulation/simulationIntegration';
 export * from './simulation/gameplayEvents';
+export * from './simulation/integration/types';
+export * from './simulation/integration/visualFeedback';
+export * from './simulation/integration/performance';
 
 // Export time system
 export * from './systems/timeSystem';

--- a/packages/engine/src/simulation/integration/performance.ts
+++ b/packages/engine/src/simulation/integration/performance.ts
@@ -1,0 +1,30 @@
+import type { PerformanceMetrics } from './types';
+
+export class PerformanceTracker {
+  private metrics: PerformanceMetrics = {
+    totalUpdates: 0,
+    averageUpdateTime: 0,
+    systemLoad: 0,
+    memoryUsage: 0,
+  };
+
+  track(startTime: number): void {
+    const updateTime = performance.now() - startTime;
+    this.metrics.totalUpdates += 1;
+    this.metrics.averageUpdateTime =
+      (this.metrics.averageUpdateTime + updateTime) / 2;
+    this.metrics.systemLoad = Math.min(100, (updateTime / 16.67) * 100);
+    const perf = performance as unknown as { memory?: { usedJSHeapSize: number } };
+    const memory =
+      perf.memory?.usedJSHeapSize ??
+      (typeof process !== 'undefined'
+        ? process.memoryUsage().heapUsed
+        : 0);
+    this.metrics.memoryUsage = Math.round(memory / 1024 / 1024);
+  }
+
+  getMetrics(): PerformanceMetrics {
+    return { ...this.metrics };
+  }
+}
+

--- a/packages/engine/src/simulation/integration/types.ts
+++ b/packages/engine/src/simulation/integration/types.ts
@@ -1,0 +1,53 @@
+import type { SimResources } from '../../index';
+import type { GameTime } from '../../types/gameTime';
+import type { SimulatedBuilding } from '../buildingSimulation';
+import type { Citizen } from '../citizenBehavior';
+import type { WorkerProfile } from '../workers/types';
+import type { ActiveEvent } from '../gameplayEvents';
+
+// Enhanced game state interface
+export interface EnhancedGameState {
+  // Core game state
+  buildings: Array<{
+    id: string;
+    typeId: string;
+    x: number;
+    y: number;
+    level: number;
+    workers: number;
+    traits?: Record<string, number>;
+  }>;
+  resources: SimResources;
+  gameTime: GameTime;
+
+  // Enhanced simulation data
+  simulatedBuildings: SimulatedBuilding[];
+  citizens: Citizen[];
+  workers: WorkerProfile[];
+  activeEvents: ActiveEvent[];
+
+  // System metrics
+  systemHealth: {
+    economicHealth: number;
+    publicSafety: number;
+    socialCohesion: number;
+  };
+}
+
+// Visual feedback configuration
+export interface VisualFeedbackConfig {
+  showBuildingStatus: boolean;
+  showCitizenMood: boolean;
+  showResourceFlow: boolean;
+  showEventImpacts: boolean;
+  showSystemHealth: boolean;
+}
+
+// Performance metrics
+export interface PerformanceMetrics {
+  totalUpdates: number;
+  averageUpdateTime: number;
+  systemLoad: number;
+  memoryUsage: number;
+}
+

--- a/packages/engine/src/simulation/integration/visualFeedback.ts
+++ b/packages/engine/src/simulation/integration/visualFeedback.ts
@@ -1,0 +1,129 @@
+import { CitizenBehaviorSystem } from '../citizenBehavior';
+import { GameplayEventsSystem, VisualIndicator } from '../gameplayEvents';
+import type { EnhancedGameState, VisualFeedbackConfig } from './types';
+
+export class VisualFeedbackSystem {
+  private config: VisualFeedbackConfig;
+
+  constructor(
+    private citizenSystem: CitizenBehaviorSystem,
+    private eventSystem: GameplayEventsSystem,
+    config: Partial<VisualFeedbackConfig> = {}
+  ) {
+    this.config = {
+      showBuildingStatus: true,
+      showCitizenMood: true,
+      showResourceFlow: true,
+      showEventImpacts: true,
+      showSystemHealth: true,
+      ...config,
+    };
+  }
+
+  generateIndicators(gameState: EnhancedGameState): VisualIndicator[] {
+    const indicators: VisualIndicator[] = [];
+
+    if (this.config.showBuildingStatus) {
+      gameState.simulatedBuildings.forEach((building) => {
+        if (building.condition === 'poor' || building.condition === 'critical') {
+          indicators.push({
+            id: `building_${building.id}`,
+            type: 'building_status',
+            position: { x: building.x, y: building.y },
+            value: this.getConditionValue(building.condition),
+            change: -1,
+            color: building.condition === 'critical' ? '#ff4444' : '#ffaa44',
+            icon: 'warning',
+            animation: 'pulse',
+            duration: 3000,
+            priority: building.condition === 'critical' ? 'critical' : 'medium',
+          });
+        }
+      });
+    }
+
+    if (this.config.showCitizenMood) {
+      const communityMood = this.citizenSystem.getCommunityMood();
+      if (communityMood.happiness < 30 || communityMood.stress > 70) {
+        indicators.push({
+          id: 'community_mood',
+          type: 'citizen_mood',
+          position: { x: 0, y: 0 },
+          value: communityMood.happiness,
+          change: communityMood.stress > 70 ? -1 : 0,
+          color: communityMood.happiness < 30 ? '#ff6666' : '#ffaa66',
+          icon: 'mood',
+          animation: 'bounce',
+          duration: 2000,
+          priority: 'medium',
+        });
+      }
+    }
+
+    if (this.config.showEventImpacts) {
+      indicators.push(...this.eventSystem.getVisualIndicators());
+    }
+
+    if (this.config.showResourceFlow) {
+      Object.entries(gameState.resources).forEach(([resource, value]) => {
+        if (value < 20) {
+          indicators.push({
+            id: `resource_${resource}`,
+            type: 'resource_flow',
+            position: { x: 0, y: 0 },
+            value,
+            change: -1,
+            color: '#44aa44',
+            icon: resource,
+            animation: 'fade',
+            duration: 1500,
+            priority: 'low',
+          });
+        }
+      });
+    }
+
+    if (this.config.showSystemHealth) {
+      const { economicHealth, publicSafety, socialCohesion } = gameState.systemHealth;
+      const lowest = Math.min(economicHealth, publicSafety, socialCohesion);
+      if (lowest < 50) {
+        indicators.push({
+          id: 'system_health',
+          type: 'system_health',
+          position: { x: 0, y: 0 },
+          value: lowest,
+          change: 0,
+          color: '#66aaff',
+          icon: 'health',
+          animation: 'pulse',
+          duration: 2500,
+          priority: lowest < 30 ? 'high' : 'medium',
+        });
+      }
+    }
+
+    return indicators;
+  }
+
+  getConfig(): VisualFeedbackConfig {
+    return this.config;
+  }
+
+  private getConditionValue(condition: string): number {
+    switch (condition) {
+      case 'excellent':
+        return 100;
+      case 'good':
+        return 80;
+      case 'fair':
+        return 60;
+      case 'poor':
+        return 40;
+      case 'critical':
+        return 20;
+      default:
+        return 50;
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- centralize simulation interfaces for state, visual feedback, and metrics
- extract visual indicator generation into dedicated system and surface resource flow & system health
- move performance tracking to its own module with memory metrics and export integration utilities

## Testing
- `npm test`
- `npm run lint packages/engine/src/simulation/simulationIntegration.ts packages/engine/src/simulation/integration/types.ts packages/engine/src/simulation/integration/visualFeedback.ts packages/engine/src/simulation/integration/performance.ts packages/engine/src/index.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bde3e776808325bd8fd560927d3a7b