### PR TITLE
refactor: modularize city simulation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@ Related docs: docs/agents/ARCHITECTURE.md, docs/agents/PROMPTS.md, docs/agents/S
 - `src/components/game/BuildingsLayer.tsx` — renders building sprites and tooltips
 - `src/components/settings/` — reusable settings panel components and configuration
 - `packages/engine/src/simulation/traffic/` — modular traffic simulation system (vehicle, pedestrian, and light managers). Run `npm test` and `npm run lint packages/engine/src/simulation/traffic` when modifying
+- `packages/engine/src/simulation/city/` — city simulation engine (systems, metrics, events). Run `npm test`, `npm run lint packages/engine/src/simulation/city/*.ts`, and `npm run lint packages/engine/src/simulation/citySimulationEngine.ts` when modifying
 - `src/components/game/skills/` — skill tree modules
   - `types.ts` — shared skill interfaces
   - `generate.ts` — procedural tree generation

--- a/packages/engine/src/simulation/city/events.ts
+++ b/packages/engine/src/simulation/city/events.ts
@@ -1,0 +1,92 @@
+import { CityMetrics } from './types';
+
+export interface CityEvent {
+  id: string;
+  type: 'disaster' | 'economic' | 'social' | 'infrastructure';
+  title: string;
+  description: string;
+  impact: Partial<CityMetrics>;
+  duration: number;
+  startTime: number;
+}
+
+export class EventManager {
+  private events: CityEvent[] = [];
+
+  constructor(private metrics: CityMetrics, private getGameTime: () => number) {}
+
+  getEvents(): CityEvent[] {
+    return [...this.events];
+  }
+
+  update(deltaTime: number): void {
+    this.events = this.events.filter(event => {
+      event.duration -= deltaTime;
+      if (event.duration <= 0) {
+        this.resolveEvent(event);
+        return false;
+      }
+      return true;
+    });
+  }
+
+  processRandomEvents(): void {
+    if (Math.random() < 0.0001) {
+      this.generateRandomEvent();
+    }
+  }
+
+  private generateRandomEvent(): void {
+    const eventTypes = [
+      {
+        type: 'economic' as const,
+        title: 'Economic Boom',
+        description: 'The city experiences economic growth',
+        impact: { income: 20, happiness: 10 },
+        duration: 60000
+      },
+      {
+        type: 'social' as const,
+        title: 'Festival',
+        description: 'A city festival boosts happiness',
+        impact: { happiness: 15, traffic: 10 },
+        duration: 30000
+      },
+      {
+        type: 'infrastructure' as const,
+        title: 'Traffic Jam',
+        description: 'Heavy traffic affects the city',
+        impact: { traffic: 25, happiness: -5 },
+        duration: 45000
+      }
+    ];
+
+    const template = eventTypes[Math.floor(Math.random() * eventTypes.length)];
+    const event: CityEvent = {
+      id: `event_${Date.now()}`,
+      ...template,
+      startTime: this.getGameTime()
+    };
+
+    this.events.push(event);
+    this.applyEventImpact(event);
+  }
+
+  private applyEventImpact(event: CityEvent): void {
+    Object.entries(event.impact).forEach(([key, value]) => {
+      const metricKey = key as keyof CityMetrics;
+      const current = this.metrics[metricKey];
+      this.metrics[metricKey] = Math.max(0, current + (value ?? 0));
+    });
+  }
+
+  private resolveEvent(event: CityEvent): void {
+    if (event.type === 'infrastructure' || event.type === 'social') {
+      Object.entries(event.impact).forEach(([key, value]) => {
+        const metricKey = key as keyof CityMetrics;
+        const current = this.metrics[metricKey];
+        this.metrics[metricKey] = Math.max(0, current - (value ?? 0));
+      });
+    }
+  }
+}

--- a/packages/engine/src/simulation/city/initSystems.ts
+++ b/packages/engine/src/simulation/city/initSystems.ts
@@ -1,0 +1,29 @@
+import { AdvancedPathfinding } from '../pathfinding';
+import { RoadNetworkSystem } from '../roadNetwork';
+import { TrafficSimulationSystem } from '../trafficSimulation';
+import { ZoningSystem } from '../zoningSystem';
+import { CityServicesSystem } from '../cityServices';
+import { PublicTransportSystem } from '../publicTransport';
+import { CityConfig } from './types';
+
+export interface CitySystems {
+  pathfinding: AdvancedPathfinding;
+  roadNetwork: RoadNetworkSystem;
+  trafficSimulation: TrafficSimulationSystem;
+  zoningSystem: ZoningSystem;
+  cityServices: CityServicesSystem;
+  publicTransport: PublicTransportSystem;
+}
+
+export function initSystems(config: CityConfig): CitySystems {
+  const { gridWidth, gridHeight } = config;
+
+  return {
+    pathfinding: new AdvancedPathfinding(gridWidth, gridHeight),
+    roadNetwork: new RoadNetworkSystem(gridWidth, gridHeight),
+    trafficSimulation: new TrafficSimulationSystem(gridWidth, gridHeight),
+    zoningSystem: new ZoningSystem(gridWidth, gridHeight),
+    cityServices: new CityServicesSystem(gridWidth, gridHeight),
+    publicTransport: new PublicTransportSystem(gridWidth, gridHeight)
+  };
+}

--- a/packages/engine/src/simulation/city/metrics.ts
+++ b/packages/engine/src/simulation/city/metrics.ts
@@ -1,0 +1,98 @@
+import { CityMetrics } from './types';
+import { CityServicesSystem, ServiceType } from '../cityServices';
+import { PublicTransportSystem } from '../publicTransport';
+import { RoadNetworkSystem } from '../roadNetwork';
+
+interface CitizenInfo {
+  satisfaction?: number;
+  workId?: string;
+}
+
+interface BuildingInfo {
+  type?: string;
+  efficiency?: number;
+  population?: number;
+}
+
+export interface MetricsContext {
+  metrics: CityMetrics;
+  citizens: Map<string, CitizenInfo>;
+  buildings: Map<string, BuildingInfo>;
+  cityServices: CityServicesSystem;
+  publicTransport: PublicTransportSystem;
+  roadNetwork: RoadNetworkSystem;
+}
+
+export function updateMetrics(ctx: MetricsContext): void {
+  const { metrics, citizens, buildings, cityServices } = ctx;
+
+  metrics.population = citizens.size;
+
+  let totalSatisfaction = 0;
+  citizens.forEach(citizen => {
+    totalSatisfaction += citizen.satisfaction || 50;
+  });
+  metrics.happiness = citizens.size > 0 ? totalSatisfaction / citizens.size : 50;
+
+  metrics.traffic = 50;
+
+  let pollution = metrics.traffic * 0.1;
+  buildings.forEach(building => {
+    if (building.type === 'industrial') {
+      pollution += (building.efficiency ?? 0) * 0.05;
+    }
+  });
+  metrics.pollution = Math.min(100, pollution);
+
+  const policeStats = cityServices.getServiceStats(ServiceType.POLICE);
+  metrics.crime = Math.max(0, 50 - (policeStats?.coverage || 0) * 40);
+
+  const educationStats = cityServices.getServiceStats(ServiceType.EDUCATION);
+  const healthcareStats = cityServices.getServiceStats(ServiceType.HEALTHCARE);
+  metrics.education = educationStats.coverage * 100;
+  metrics.healthcare = healthcareStats.coverage * 100;
+
+  let employed = 0;
+  citizens.forEach(citizen => {
+    if (citizen.workId) employed++;
+  });
+  metrics.employment = citizens.size > 0 ? (employed / citizens.size) * 100 : 0;
+
+  updateBudget(ctx);
+}
+
+function updateBudget(ctx: MetricsContext): void {
+  const { metrics, buildings, cityServices, publicTransport, roadNetwork } = ctx;
+
+  let income = 0;
+  buildings.forEach(building => {
+    if (building.type === 'residential') {
+      income += building.population * 10;
+    } else if (building.type === 'commercial') {
+      income += building.efficiency * 5;
+    } else if (building.type === 'industrial') {
+      income += building.efficiency * 8;
+    }
+  });
+
+  const transportStats = publicTransport.getSystemStats();
+  income += transportStats.revenue;
+  metrics.income = income;
+
+  let expenses = 0;
+  const serviceStats = cityServices.getAllServiceStats();
+  Object.values(serviceStats).forEach(stats => {
+    expenses += stats.cost;
+  });
+  expenses += transportStats.operatingCost;
+
+  const roads = roadNetwork.getAllRoads();
+  const roadMaintenanceCost = roads.reduce((total, road) => {
+    const length = Math.sqrt(Math.pow(road.end.x - road.start.x, 2) + Math.pow(road.end.y - road.start.y, 2));
+    return total + (length * 10);
+  }, 0);
+  expenses += roadMaintenanceCost;
+
+  metrics.expenses = expenses;
+  metrics.budget += (income - expenses) * 0.001;
+}

--- a/packages/engine/src/simulation/city/types.ts
+++ b/packages/engine/src/simulation/city/types.ts
@@ -1,0 +1,21 @@
+export interface CityConfig {
+  gridWidth: number;
+  gridHeight: number;
+  initialPopulation: number;
+  startingBudget: number;
+  difficulty: 'easy' | 'normal' | 'hard';
+}
+
+export interface CityMetrics {
+  population: number;
+  happiness: number;
+  traffic: number;
+  pollution: number;
+  crime: number;
+  education: number;
+  healthcare: number;
+  employment: number;
+  budget: number;
+  income: number;
+  expenses: number;
+}


### PR DESCRIPTION
## Summary
- centralize city config and metrics interfaces under `simulation/city/types.ts`
- add `initSystems` helper for core city system setup
- introduce `EventManager` and metrics module to handle events and city metrics
- wire `CitySimulationEngine` to use new modules
- document test and lint requirements for city simulation in `AGENTS.md`

## Testing
- `npm test`
- `npm run lint packages/engine/src/simulation/city/*.ts`
- `npm run lint packages/engine/src/simulation/citySimulationEngine.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bde3e229e483259d9fefc2ec7c40f7