### PR TITLE
docs: add architecture docs and ADR framework

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 This guide defines the agent architecture, prompting standards, safety, and ops practices for the Arcane Dominion Tycoon. It is the canonical reference for building, extending, and operating the AI council. When new systems or knowledge are introduced, update this guide to keep it current. Always run npm run build after writing new code to ensure the changes are reflected in the game.
 
-Related docs: docs/agents/ARCHITECTURE.md, docs/agents/PROMPTS.md, docs/agents/SECURITY.md, docs/agents/OPERATIONS.md, docs/agents/EVALUATION.md, docs/agents/EXTENSIONS.md, docs/agents/CONTRIBUTING.md
+Related docs: docs/agents/ARCHITECTURE.md, docs/agents/PROMPTS.md, docs/agents/SECURITY.md, docs/agents/OPERATIONS.md, docs/agents/EVALUATION.md, docs/agents/EXTENSIONS.md, docs/agents/CONTRIBUTING.md, docs/architecture/overview.md, docs/architecture/packages.md, docs/adr/0001-initial-refactor.md, docs/adr/template.md
 
 ## Core Focus of the Game
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Environment variables are validated and layered in `src/infrastructure/config.ts
 | `NEXT_PUBLIC_OFFLINE_MODE` | Use local data instead of API | `false` |
 | `NEXT_PUBLIC_DISABLE_REALTIME` | Disable realtime updates | `false` |
 
+## Architecture
+
+See [Architecture Overview](docs/architecture/overview.md) and [Package Diagram](docs/architecture/packages.md) for system context. Architecture Decision Records live in [docs/adr](docs/adr/).
+
 ## Design Tokens
 
 Global color tokens are defined in `src/app/globals.css` and surfaced in Tailwind via `theme.extend.colors`.

--- a/docs/adr/0001-initial-refactor.md
+++ b/docs/adr/0001-initial-refactor.md
@@ -1,0 +1,20 @@
+# [ADR-0001] Establish Architecture Documentation and ADR Process
+
+- Status: Accepted
+- Deciders: Core Team
+- Date: 2025-01-12
+
+## Context
+
+The project lacked formal architecture documentation and a process for recording decisions,
+complicating maintenance and future refactors.
+
+## Decision
+
+Create dedicated architecture docs under `docs/architecture` with diagrams and adopt an
+Architecture Decision Record (ADR) process stored in `docs/adr`.
+
+## Consequences
+
+Team members can reference diagrams for system understanding and use the ADR template for
+future decisions, improving traceability of refactors.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,17 @@
+# [ADR-0000] Title
+
+- Status: Proposed
+- Deciders: 
+- Date: 
+
+## Context
+
+Describe the issue motivating this decision.
+
+## Decision
+
+State the decision taken.
+
+## Consequences
+
+Explain the consequences or follow-up work.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,13 @@
+# Architecture Overview
+
+This document provides a high-level view of the Arcane Dominion application.
+
+```mermaid
+graph TD
+    Client["Next.js Client"] --> API["API Routes"]
+    API --> DB[("Supabase")]
+    API --> Engine["Simulation Engine"]
+```
+
+The client renders the user interface, API routes orchestrate actions and state transitions,
+and the engine powers core simulation logic backed by Supabase storage.

--- a/docs/architecture/packages.md
+++ b/docs/architecture/packages.md
@@ -1,0 +1,10 @@
+# Package Diagram
+
+The repository currently includes a Next.js app and a reusable simulation engine.
+
+```mermaid
+graph LR
+    App["App (Next.js)"] --> Engine["packages/engine"]
+```
+
+The app depends on the engine package for simulation behavior.


### PR DESCRIPTION
## Summary
- document system architecture with overview and package diagrams
- introduce ADR template and initial decision record for refactor process
- link AGENTS guide and README to new architecture and ADR docs

## Testing
- `npm run lint docs/architecture/*.md docs/adr/*.md AGENTS.md README.md`
- `npm test`
- `npm run build` *(fails: Invalid input for Supabase environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf00e3ff883259d70e9774bc15e44