### PR TITLE
docs: add architecture docs and ADR framework

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 This guide defines the agent architecture, prompting standards, safety, and ops practices for the Arcane Dominion Tycoon. It is the canonical reference for building, extending, and operating the AI council. When new systems or knowledge are introduced, update this guide to keep it current. Always run npm run build after writing new code to ensure the changes are reflected in the game.
 
-Related docs: docs/agents/ARCHITECTURE.md, docs/agents/PROMPTS.md, docs/agents/SECURITY.md, docs/agents/OPERATIONS.md, docs/agents/EVALUATION.md, docs/agents/EXTENSIONS.md, docs/agents/CONTRIBUTING.md
+Related docs: docs/agents/ARCHITECTURE.md, docs/agents/PROMPTS.md, docs/agents/SECURITY.md, docs/agents/OPERATIONS.md, docs/agents/EVALUATION.md, docs/agents/EXTENSIONS.md, docs/agents/CONTRIBUTING.md, docs/architecture/overview.md, docs/architecture/packages.md, docs/adr/0001-initial-refactor.md, docs/adr/template.md
 
 ## Core Focus of the Game
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Environment variables are validated and layered in `src/infrastructure/config.ts
 | `NEXT_PUBLIC_OFFLINE_MODE` | Use local data instead of API | `false` |
 | `NEXT_PUBLIC_DISABLE_REALTIME` | Disable realtime updates | `false` |
 
+## Architecture
+
+See [Architecture Overview](docs/architecture/overview.md) and [Package Diagram](docs/architecture/packages.md) for system context. Architecture Decision Records live in [docs/adr](docs/adr/).
+
 ## Design Tokens
 
 Global color tokens are defined in `src/app/globals.css` and surfaced in Tailwind via `theme.extend.colors`.

--- a/docs/adr/0001-initial-refactor.md
+++ b/docs/adr/0001-initial-refactor.md
@@ -1,0 +1,20 @@
+# [ADR-0001] Establish Architecture Documentation and ADR Process
+
+- Status: Accepted
+- Deciders: Core Team
+- Date: 2025-01-12
+
+## Context
+
+The project lacked formal architecture documentation and a process for recording decisions,
+complicating maintenance and future refactors.
+
+## Decision
+
+Create dedicated architecture docs under `docs/architecture` with diagrams and adopt an
+Architecture Decision Record (ADR) process stored in `docs/adr`.
+
+## Consequences
+
+Team members can reference diagrams for system understanding and use the ADR template for
+future decisions, improving traceability of refactors.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,17 @@
+# [ADR-0000] Title
+
+- Status: Proposed
+- Deciders: 
+- Date: 
+
+## Context
+
+Describe the issue motivating this decision.
+
+## Decision
+
+State the decision taken.
+
+## Consequences
+
+Explain the consequences or follow-up work.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,63 @@
+# Architecture Overview
+
+This document explains the runtime structure and data flow of the Arcane Dominion application.
+
+## System Context
+
+```mermaid
+graph TD
+    Client["Next.js Client"]
+    API["API Routes"]
+    Agents["AI Services"]
+    Engine["Simulation Engine"]
+    DB[("Supabase")]
+    Client -->|HTTP| API
+    API -->|invoke| Agents
+    API -->|simulate| Engine
+    API -->|read/write| DB
+    Engine -->|persist| DB
+```
+
+## Components
+
+### Client (Next.js App Router)
+- Renders the user interface from `src/app`.
+- Calls API routes for game actions and state.
+- Hydrates session and game state from Supabase.
+
+### API Layer
+- Next.js route handlers under `src/app/api`.
+- Validates requests with Zod schemas.
+- Orchestrates agents, simulation, and persistence.
+
+### Simulation Engine (`packages/engine`)
+- Headless game logic executed server-side.
+- Modules for tick application, traffic, zoning, and transport.
+- Pure TypeScript for deterministic tests.
+
+### Supabase
+- Postgres database and authentication.
+- Tables `game_state` and `proposals` store core state.
+- Row-level security keeps client reads read-only.
+
+### AI Agents
+- OpenAI-backed agents invoked from API routes.
+- Generate proposals and conservative forecasts.
+
+## Request Lifecycle
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant A as API Route
+    participant E as Engine
+    participant D as Supabase
+    C->>A: action request
+    A->>E: simulate/update
+    E->>D: persist changes
+    A->>D: read state
+    A-->>C: JSON response
+```
+
+A player interaction triggers an API route. The route invokes the simulation engine, persists
+state to Supabase, optionally calls AI agents, and returns a JSON response to the client.

--- a/docs/architecture/packages.md
+++ b/docs/architecture/packages.md
@@ -1,0 +1,25 @@
+# Package Diagram
+
+The codebase is a small monorepo composed of a Next.js application and a reusable
+simulation engine published as an internal package.
+
+```mermaid
+graph LR
+    App["App (Next.js)"]
+    subgraph packages
+        Engine["engine"]
+    end
+    App --> Engine
+```
+
+## packages/engine
+
+The engine exposes deterministic game mechanics as a standalone TypeScript library.
+
+- `src/simulation/index.ts` – orchestrates tick execution.
+- `src/simulation/traffic` – vehicle and pedestrian flow.
+- `src/simulation/zoning` – zone management and effects.
+- `src/simulation/transport` – public transport routes and vehicles.
+
+The application imports these modules to apply game rules while keeping the engine
+isolated and testable.


### PR DESCRIPTION
## Summary
- document system architecture with overview and package diagrams
- introduce ADR template and initial decision record for refactor process
- link AGENTS guide and README to new architecture and ADR docs
- expand architecture overview with component breakdown and request lifecycle

## Testing
- `npm run lint docs/architecture/*.md docs/adr/*.md AGENTS.md README.md`
- `npm test`
- `npm run build` *(fails: Invalid input for Supabase environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf00e3ff883259d70e9774bc15e44