### PR TITLE
feat(logging): centralize logging and error handling

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,5 @@
+# Operations
+
+## Redaction Policy
+
+Logs should never include secrets or personally identifiable information. Replace sensitive fields such as API keys, tokens, email addresses, or user identifiers with `[REDACTED]`. When logging structured data, include only the fields necessary for debugging. If unsure whether data is sensitive, omit it. 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "@supabase/supabase-js": "^2.56.1",
         "ai": "^5.0.28",
         "autoprefixer": "^10.4.21",
-        "loglevel": "^1.9.2",
         "next": "15.5.2",
         "pixi-viewport": "^6.0.3",
         "pixi.js": "^8.12.0",
@@ -6744,19 +6743,6 @@
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/loglevel": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
-      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      },
-      "funding": {
-        "type": "tidelift",
-        "url": "https://tidelift.com/funding/github/npm/loglevel"
-      }
     },
     "node_modules/long": {
       "version": "5.3.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@supabase/supabase-js": "^2.56.1",
     "ai": "^5.0.28",
     "autoprefixer": "^10.4.21",
-    "loglevel": "^1.9.2",
     "next": "15.5.2",
     "pixi-viewport": "^6.0.3",
     "pixi.js": "^8.12.0",

--- a/packages/utils/logging/package.json
+++ b/packages/utils/logging/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@arcane/logging",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --dts"
+  },
+  "devDependencies": {
+    "tsup": "^8.5.0",
+    "typescript": "^5.9.2"
+  }
+}

--- a/packages/utils/logging/src/errors.ts
+++ b/packages/utils/logging/src/errors.ts
@@ -1,0 +1,15 @@
+export class AppError extends Error {
+  status: number;
+
+  constructor(message: string, status = 500) {
+    super(message);
+    this.status = status;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export class ValidationError extends AppError {
+  constructor(message: string) {
+    super(message, 400);
+  }
+}

--- a/packages/utils/logging/src/index.ts
+++ b/packages/utils/logging/src/index.ts
@@ -1,0 +1,3 @@
+export { Logger, createLogger } from './logger';
+export type { LogLevel } from './logger';
+export { AppError, ValidationError } from './errors';

--- a/packages/utils/logging/src/logger.ts
+++ b/packages/utils/logging/src/logger.ts
@@ -1,0 +1,48 @@
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+const levelOrder: Record<LogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+};
+
+export interface LoggerOptions {
+  level?: LogLevel;
+}
+
+export class Logger {
+  private level: LogLevel;
+
+  constructor(opts: LoggerOptions = {}) {
+    this.level = opts.level ?? 'info';
+  }
+
+  setLevel(level: LogLevel) {
+    this.level = level;
+  }
+
+  private shouldLog(level: LogLevel) {
+    return levelOrder[level] >= levelOrder[this.level];
+  }
+
+  debug(...args: unknown[]) {
+    if (this.shouldLog('debug')) console.debug(...args);
+  }
+
+  info(...args: unknown[]) {
+    if (this.shouldLog('info')) console.info(...args);
+  }
+
+  warn(...args: unknown[]) {
+    if (this.shouldLog('warn')) console.warn(...args);
+  }
+
+  error(...args: unknown[]) {
+    if (this.shouldLog('error')) console.error(...args);
+  }
+}
+
+export function createLogger(opts?: LoggerOptions) {
+  return new Logger(opts);
+}

--- a/src/app/api/proposals/route.ts
+++ b/src/app/api/proposals/route.ts
@@ -1,9 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase/server'
 import { SupabaseUnitOfWork } from '@/infrastructure/supabase/unit-of-work'
 import logger from '@/lib/logger'
+import { AppError } from '@logging'
 
-export async function GET(req: NextRequest) {
+export async function GET() {
   try {
     const supabase = createSupabaseServerClient()
     const uow = new SupabaseUnitOfWork(supabase)
@@ -20,6 +21,9 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ proposals })
   } catch (error) {
     logger.error('Supabase connection error in proposals route:', error)
+    if (error instanceof AppError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
     return NextResponse.json(
       { error: 'Service unavailable - database not configured' },
       { status: 503 }

--- a/src/app/api/state/route.ts
+++ b/src/app/api/state/route.ts
@@ -3,6 +3,7 @@ import { createSupabaseServerClient } from '@/lib/supabase/server'
 import { SupabaseUnitOfWork } from '@/infrastructure/supabase/unit-of-work'
 import logger from '@/lib/logger'
 import { z } from 'zod'
+import { AppError, ValidationError } from '@logging'
 import type { GameState } from '@engine'
 
 export async function GET() {
@@ -22,15 +23,16 @@ export async function GET() {
       return NextResponse.json(state)
     }
 
-    const needsSeed = !state.skill_tree_seed
-    const needsClockDefaults = typeof (state as any).tick_interval_ms !== 'number' || typeof (state as any).auto_ticking !== 'boolean' || !(state as any).last_tick_at
+    const clockState = state as GameState & { auto_ticking?: boolean; tick_interval_ms?: number; last_tick_at?: string }
+    const needsSeed = !clockState.skill_tree_seed
+    const needsClockDefaults = typeof clockState.tick_interval_ms !== 'number' || typeof clockState.auto_ticking !== 'boolean' || !clockState.last_tick_at
     if (needsSeed || needsClockDefaults) {
       const patch: Partial<GameState & { auto_ticking: boolean; tick_interval_ms: number; last_tick_at: string }> = {}
       if (needsSeed) patch.skill_tree_seed = Math.floor(Math.random() * 1e9)
       if (needsClockDefaults) {
-        if (typeof (state as any).auto_ticking !== 'boolean') (patch as any).auto_ticking = true
-        if (typeof (state as any).tick_interval_ms !== 'number') (patch as any).tick_interval_ms = 60000
-        if (!(state as any).last_tick_at) (patch as any).last_tick_at = new Date().toISOString()
+        if (typeof clockState.auto_ticking !== 'boolean') patch.auto_ticking = true
+        if (typeof clockState.tick_interval_ms !== 'number') patch.tick_interval_ms = 60000
+        if (!clockState.last_tick_at) patch.last_tick_at = new Date().toISOString()
       }
       const patched = await uow.gameStates.update(state.id, patch as Partial<GameState>)
       return NextResponse.json(patched)
@@ -39,6 +41,9 @@ export async function GET() {
     return NextResponse.json(state)
   } catch (error) {
     logger.error('Supabase connection error:', error)
+    if (error instanceof AppError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
     return NextResponse.json(
       { error: 'Service unavailable - database not configured' },
       { status: 503 }
@@ -66,13 +71,14 @@ const UpdateSchema = z.object({
 })
 
 export async function PATCH(req: NextRequest) {
-  const json = await req.json().catch(() => ({}))
-  const parsed = UpdateSchema.safeParse(json)
-  if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.message }, { status: 400 })
-  }
+  try {
+    const json = await req.json().catch(() => ({}))
+    const parsed = UpdateSchema.safeParse(json)
+    if (!parsed.success) {
+      throw new ValidationError(parsed.error.message)
+    }
 
-  const { id, resources, workers, buildings, routes, roads, citizens_seed, citizens_count, edicts, skills, skill_tree_seed, pinned_skill_targets, auto_ticking, tick_interval_ms, last_tick_at, map_size } = parsed.data
+    const { id, resources, workers, buildings, routes, roads, citizens_seed, citizens_count, edicts, skills, skill_tree_seed, pinned_skill_targets, auto_ticking, tick_interval_ms, last_tick_at, map_size } = parsed.data
   const updates: Partial<{ resources: Record<string, number>; workers: number; buildings: unknown[]; routes: unknown[]; roads: Array<{x:number;y:number}>; citizens_seed: number; citizens_count: number; edicts: Record<string, number>; skills: string[]; skill_tree_seed: number; pinned_skill_targets: string[]; updated_at: string; auto_ticking: boolean; tick_interval_ms: number; last_tick_at: string; map_size: number }> = { updated_at: new Date().toISOString() }
   if (resources) updates.resources = resources
   if (typeof workers === 'number') updates.workers = workers
@@ -84,10 +90,10 @@ export async function PATCH(req: NextRequest) {
   if (edicts) updates.edicts = edicts
   if (skills) updates.skills = skills
   if (typeof skill_tree_seed === 'number') updates.skill_tree_seed = skill_tree_seed
-  if (pinned_skill_targets) (updates as any).pinned_skill_targets = pinned_skill_targets
-  if (typeof auto_ticking === 'boolean') (updates as any).auto_ticking = auto_ticking
-  if (typeof tick_interval_ms === 'number') (updates as any).tick_interval_ms = tick_interval_ms
-  if (typeof last_tick_at === 'string') (updates as any).last_tick_at = last_tick_at
+    if (pinned_skill_targets) updates.pinned_skill_targets = pinned_skill_targets
+    if (typeof auto_ticking === 'boolean') updates.auto_ticking = auto_ticking
+    if (typeof tick_interval_ms === 'number') updates.tick_interval_ms = tick_interval_ms
+    if (typeof last_tick_at === 'string') updates.last_tick_at = last_tick_at
   if (typeof map_size === 'number') updates.map_size = map_size
 
   const supabase = createSupabaseServerClient()
@@ -98,6 +104,13 @@ export async function PATCH(req: NextRequest) {
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error)
     logger.error('Supabase update error:', message)
-    return NextResponse.json({ error: message }, { status: 500 })
+    throw new AppError(message)
+  }
+  } catch (error) {
+    if (error instanceof AppError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error('Unhandled error in state PATCH:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
 }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,10 +1,5 @@
-import log from 'loglevel';
+import { createLogger, LogLevel } from '@logging';
 import { config } from '@/infrastructure/config';
 
-const logger = log.getLogger('arcane-dominion');
-
-const level = config.logLevel as log.LogLevelDesc;
-
-logger.setLevel(level);
-
+export const logger = createLogger({ level: config.logLevel as LogLevel });
 export default logger;

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,5 +1,6 @@
 import { createClient } from '@supabase/supabase-js'
 import logger from '@/lib/logger'
+import { AppError } from '@logging'
 import { config } from '@/infrastructure/config'
 
 // Server-side Supabase client using the service role key (never sent to the browser)
@@ -17,7 +18,7 @@ export function createSupabaseServerClient() {
       urlContainsPlaceholder: url?.includes('placeholder'),
       serviceKeyContainsPlaceholder: serviceKey?.includes('placeholder')
     })
-    throw new Error('Supabase not configured - check environment variables')
+    throw new AppError('Supabase not configured - check environment variables', 503)
   }
 
   // Provide a fetch with timeout so DB issues fail fast instead of hanging

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,9 @@
     "paths": {
       "@/*": ["./src/*"],
       "@engine": ["./packages/engine/src"],
-      "@engine/*": ["./packages/engine/src/*"]
+      "@engine/*": ["./packages/engine/src/*"],
+      "@logging": ["./packages/utils/logging/src"],
+      "@logging/*": ["./packages/utils/logging/src/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## Summary
- add shared logging utilities with level filtering and custom errors
- use ValidationError/AppError in API routes and Supabase service
- document log redaction policy for operations

## Testing
- `npm run lint packages/utils/logging/src src/lib/logger.ts src/lib/supabase/server.ts src/app/api/proposals/route.ts src/app/api/state/route.ts src/app/api/proposals/[id]/decide/route.ts`
- `npm test`
- `NEXT_PUBLIC_SUPABASE_URL=http://example.com NEXT_PUBLIC_SUPABASE_ANON_KEY=anon SUPABASE_URL=http://example.com SUPABASE_SERVICE_ROLE_KEY=key SUPABASE_JWT_SECRET=secret npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdeffc51248325b572f38c6da9c97a