### PR TITLE
Refactor store into modular slices with persistence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,9 @@ Related docs: docs/agents/ARCHITECTURE.md, docs/agents/PROMPTS.md, docs/agents/S
   - `browser.ts` (anon; read-focused)
 - `docs/agents/` — this guide and deep dives
 - `supabase/migrations/` — schema and idempotent updates for `game_state`, `proposals`
+- `src/state/` — global client state management
+  - `slices/` — modular reducers (`notifications`, `session`, `game`) combined in `slices/index.ts`
+  - `persistence.ts` — localStorage hydration/persistence utilities
 - `src/components/game/buildingIcons/` — canvas icon drawers keyed by building type
 - `src/components/game/BuildingsLayer.tsx` — renders building sprites and tooltips
 - `src/components/game/GameLayers.tsx` — centralizes PIXI rendering layers

--- a/src/components/game/hud/NotificationHost.tsx
+++ b/src/components/game/hud/NotificationHost.tsx
@@ -3,12 +3,13 @@
 import React from 'react';
 import { useAppDispatch, useAppSelector } from '@/state/store';
 import { NotificationCenter } from './NotificationCenter';
-import { dismissNotification, markRead } from '@/state/notifications';
+import { dismissNotification, markRead } from '@/state/slices/notifications';
+import type { Notification } from './types';
 
 export default function NotificationHost() {
   const list = useAppSelector(s => s.notifications.list);
   const dispatch = useAppDispatch();
-  const handleAction = (n: any) => {
+  const handleAction = (n: Notification) => {
     dispatch(markRead(n.id));
     try { window.dispatchEvent(new CustomEvent('ad_notify_action', { detail: n })); } catch {}
   };

--- a/src/state/persistence.ts
+++ b/src/state/persistence.ts
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+
+export function useLocalStoragePersistence<T>(
+  key: string,
+  data: T,
+  onHydrate: (stored: T) => void,
+): void {
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(key);
+      if (raw) {
+        onHydrate(JSON.parse(raw) as T);
+      }
+    } catch {
+      // ignore
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(key, JSON.stringify(data));
+    } catch {
+      // ignore
+    }
+  }, [key, data]);
+}
+

--- a/src/state/slices/game.ts
+++ b/src/state/slices/game.ts
@@ -1,0 +1,26 @@
+export interface GameState {
+  id: string | null;
+}
+
+export type GameAction =
+  | { type: 'game/set'; payload: { id: string } }
+  | { type: 'game/clear' }
+  | { type: 'game/hydrate'; payload: GameState };
+
+export const initialGameState: GameState = {
+  id: null,
+};
+
+export function gameReducer(state: GameState, action: GameAction): GameState {
+  switch (action.type) {
+    case 'game/set':
+      return { id: action.payload.id };
+    case 'game/clear':
+      return { id: null };
+    case 'game/hydrate':
+      return action.payload;
+    default:
+      return state;
+  }
+}
+

--- a/src/state/slices/index.ts
+++ b/src/state/slices/index.ts
@@ -1,0 +1,40 @@
+import {
+  notificationsReducer,
+  initialNotificationsState,
+  type NotificationsAction,
+  type NotificationsState,
+} from './notifications';
+import { sessionReducer, initialSessionState, type SessionAction, type SessionState } from './session';
+import { gameReducer, initialGameState, type GameAction, type GameState } from './game';
+
+export interface RootState {
+  notifications: NotificationsState;
+  session: SessionState;
+  game: GameState;
+}
+
+export type RootAction = NotificationsAction | SessionAction | GameAction;
+
+export const initialState: RootState = {
+  notifications: initialNotificationsState,
+  session: initialSessionState,
+  game: initialGameState,
+};
+
+export function rootReducer(state: RootState, action: RootAction): RootState {
+  return {
+    notifications: notificationsReducer(state.notifications, action as NotificationsAction),
+    session: sessionReducer(state.session, action as SessionAction),
+    game: gameReducer(state.game, action as GameAction),
+  };
+}
+
+export {
+  notificationsReducer,
+  sessionReducer,
+  gameReducer,
+  initialNotificationsState,
+  initialSessionState,
+  initialGameState,
+};
+

--- a/src/state/slices/notifications.ts
+++ b/src/state/slices/notifications.ts
@@ -1,9 +1,8 @@
-import React from 'react';
 import type { Notification } from '@/components/game/hud/types';
 
-export type NotificationsState = {
+export interface NotificationsState {
   list: Notification[];
-};
+}
 
 export type NotificationsAction =
   | { type: 'notifications/add'; payload: Omit<Notification, 'id' | 'timestamp' | 'read'> & { id?: string } }
@@ -16,10 +15,17 @@ export const initialNotificationsState: NotificationsState = {
   list: [],
 };
 
-export function notificationsReducer(state: NotificationsState, action: NotificationsAction): NotificationsState {
+export function notificationsReducer(
+  state: NotificationsState,
+  action: NotificationsAction,
+): NotificationsState {
   switch (action.type) {
     case 'notifications/add': {
-      const id = action.payload.id || (typeof crypto !== 'undefined' && 'randomUUID' in crypto ? crypto.randomUUID() : Math.random().toString(36).slice(2));
+      const id =
+        action.payload.id ||
+        (typeof crypto !== 'undefined' && 'randomUUID' in crypto
+          ? crypto.randomUUID()
+          : Math.random().toString(36).slice(2));
       const n: Notification = {
         id,
         timestamp: Date.now(),
@@ -39,7 +45,10 @@ export function notificationsReducer(state: NotificationsState, action: Notifica
       return { ...state, list: [] };
     }
     case 'notifications/markRead': {
-      return { ...state, list: state.list.map(n => n.id === action.payload.id ? { ...n, read: true } : n) };
+      return {
+        ...state,
+        list: state.list.map((n) => (n.id === action.payload.id ? { ...n, read: true } : n)),
+      };
     }
     case 'notifications/hydrate': {
       return { ...state, list: action.payload.list };
@@ -49,7 +58,19 @@ export function notificationsReducer(state: NotificationsState, action: Notifica
   }
 }
 
-export const addNotification = (payload: Omit<Notification, 'id' | 'timestamp'> & { id?: string }): NotificationsAction => ({ type: 'notifications/add', payload });
-export const dismissNotification = (id: string): NotificationsAction => ({ type: 'notifications/dismiss', payload: { id } });
+export const addNotification = (
+  payload: Omit<Notification, 'id' | 'timestamp'> & { id?: string },
+): NotificationsAction => ({ type: 'notifications/add', payload });
+
+export const dismissNotification = (id: string): NotificationsAction => ({
+  type: 'notifications/dismiss',
+  payload: { id },
+});
+
 export const clearNotifications = (): NotificationsAction => ({ type: 'notifications/clear' });
-export const markRead = (id: string): NotificationsAction => ({ type: 'notifications/markRead', payload: { id } });
+
+export const markRead = (id: string): NotificationsAction => ({
+  type: 'notifications/markRead',
+  payload: { id },
+});
+

--- a/src/state/slices/session.ts
+++ b/src/state/slices/session.ts
@@ -1,0 +1,29 @@
+export interface SessionState {
+  user: { id: string } | null;
+}
+
+export type SessionAction =
+  | { type: 'session/set'; payload: { user: { id: string } } }
+  | { type: 'session/clear' }
+  | { type: 'session/hydrate'; payload: SessionState };
+
+export const initialSessionState: SessionState = {
+  user: null,
+};
+
+export function sessionReducer(
+  state: SessionState,
+  action: SessionAction,
+): SessionState {
+  switch (action.type) {
+    case 'session/set':
+      return { user: action.payload.user };
+    case 'session/clear':
+      return { user: null };
+    case 'session/hydrate':
+      return action.payload;
+    default:
+      return state;
+  }
+}
+

--- a/src/state/useNotify.ts
+++ b/src/state/useNotify.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { useAppDispatch } from './store';
-import { addNotification } from './notifications';
+import { addNotification } from './slices/notifications';
 
 export function useNotify() {
   const dispatch = useAppDispatch();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,7 @@
       "@engine": ["./packages/engine/src"],
       "@engine/*": ["./packages/engine/src/*"],
       "@arcane/infrastructure": ["./packages/infrastructure/src"],
-      "@arcane/infrastructure/*": ["./packages/infrastructure/src/*"]
+      "@arcane/infrastructure/*": ["./packages/infrastructure/src/*"],
       "@/utils/performance/*": ["./packages/utils/performance/*"]
     }
   },


### PR DESCRIPTION
## Summary
- create notifications, session, and game slices with a central root reducer
- extract reusable localStorage persistence hook
- update StoreProvider and notification components to use new slice modules
- document slice-based state structure in AGENTS guide

## Testing
- `npm run lint src/state src/components/game/hud/NotificationHost.tsx`
- `SUPABASE_URL=http://localhost SUPABASE_SERVICE_ROLE_KEY=test SUPABASE_JWT_SECRET=test NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=test npm run build`
- `npm run lint AGENTS.md`
- `SUPABASE_URL=http://localhost SUPABASE_SERVICE_ROLE_KEY=test SUPABASE_JWT_SECRET=test NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=test npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdf326fec0832595ae8fd757c197e4