### PR TITLE
Use cached render textures for tiles

### DIFF
--- a/src/components/game/MemoryManager.tsx
+++ b/src/components/game/MemoryManager.tsx
@@ -35,7 +35,7 @@ export default function MemoryManager({
   warnAtPercent = 85,
   warningCooldownMs = 60000,
 }: MemoryManagerProps) {
-  const cleanupIntervalRef = useRef<NodeJS.Timeout>();
+  const cleanupIntervalRef = useRef<NodeJS.Timeout | null>(null);
   const lastCleanupRef = useRef<number>(0);
   const lastWarningRef = useRef<number>(0);
   const memoryStatsRef = useRef<MemoryStats>({

--- a/src/components/game/ViewportManager.tsx
+++ b/src/components/game/ViewportManager.tsx
@@ -34,7 +34,7 @@ export default function ViewportManager({
   const { viewport, app } = useGameContext();
   const lastBoundsRef = useRef<ViewportBounds>({ x: 0, y: 0, width: 0, height: 0 });
   const lastScaleRef = useRef<number>(1);
-  const updateTimeoutRef = useRef<NodeJS.Timeout>();
+  const updateTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   // Throttled viewport change handler
   const handleViewportChange = useCallback(() => {

--- a/src/components/game/grid/TileRenderer.ts
+++ b/src/components/game/grid/TileRenderer.ts
@@ -1,4 +1,5 @@
 import * as PIXI from "pixi.js";
+import type { Renderer } from "pixi.js";
 import { gridToWorld, TILE_COLORS } from "@/lib/isometric";
 import logger from "@/lib/logger";
 
@@ -8,12 +9,13 @@ export interface GridTile {
   worldX: number;
   worldY: number;
   tileType: string;
-  sprite: PIXI.Graphics;
+  sprite: PIXI.Sprite;
+  overlay?: PIXI.Graphics;
   dispose: () => void; // Add cleanup method
 }
 
 // Texture cache to prevent memory leaks
-const textureCache = new Map<string, PIXI.Texture>();
+const textureCache = new Map<string, PIXI.RenderTexture>();
 const MAX_CACHED_TEXTURES = 100;
 
 // Clean up texture cache when it gets too large
@@ -36,6 +38,125 @@ function shade(hex: number, factor: number): number {
   return (r << 16) | (g << 8) | b;
 }
 
+function getTextureCacheKey(tileType: string, tileWidth: number, tileHeight: number) {
+  return `${tileType}-${tileWidth}x${tileHeight}`;
+}
+
+function createTileTexture(
+  tileType: string,
+  tileWidth: number,
+  tileHeight: number,
+  renderer: Renderer,
+  tileKey: string,
+): PIXI.RenderTexture {
+  const cacheKey = getTextureCacheKey(tileType, tileWidth, tileHeight);
+  const cached = textureCache.get(cacheKey);
+  if (cached) {
+    logger.debug(`[TILE_TEXTURE] Cache hit for ${tileKey} using key ${cacheKey}`);
+    return cached;
+  }
+
+  const startTime = performance.now();
+  const tempContainer = new PIXI.Container();
+  const baseGraphic = new PIXI.Graphics();
+  baseGraphic.position.set(tileWidth / 2, tileHeight / 2);
+
+  const baseColor = TILE_COLORS[tileType] ?? 0xdde7f7;
+  const lighter = shade(baseColor, 1.08);
+  const darker = shade(baseColor, 0.85);
+
+  // Base diamond with subtle center light and beveled edges
+  baseGraphic.fill({ color: baseColor, alpha: 0.96 });
+  baseGraphic.moveTo(0, -tileHeight / 2);
+  baseGraphic.lineTo(tileWidth / 2, 0);
+  baseGraphic.lineTo(0, tileHeight / 2);
+  baseGraphic.lineTo(-tileWidth / 2, 0);
+  baseGraphic.closePath();
+  baseGraphic.fill();
+
+  // Inner highlight diamond
+  baseGraphic.fill({ color: lighter, alpha: 0.12 });
+  baseGraphic.moveTo(0, -tileHeight * 0.36);
+  baseGraphic.lineTo(tileWidth * 0.36, 0);
+  baseGraphic.lineTo(0, tileHeight * 0.36);
+  baseGraphic.lineTo(-tileWidth * 0.36, 0);
+  baseGraphic.closePath();
+  baseGraphic.fill();
+
+  // Bevel: darker stroke on right/bottom edges
+  baseGraphic.setStrokeStyle({ width: 1.5, color: darker, alpha: 0.55 });
+  baseGraphic.moveTo(0, tileHeight / 2);
+  baseGraphic.lineTo(tileWidth / 2, 0);
+  baseGraphic.lineTo(0, -tileHeight / 2);
+  baseGraphic.stroke();
+  // Fine outline
+  baseGraphic.setStrokeStyle({ width: 1, color: 0x334155, alpha: 0.35 });
+  baseGraphic.moveTo(0, -tileHeight / 2);
+  baseGraphic.lineTo(tileWidth / 2, 0);
+  baseGraphic.lineTo(0, tileHeight / 2);
+  baseGraphic.lineTo(-tileWidth / 2, 0);
+  baseGraphic.lineTo(0, -tileHeight / 2);
+  baseGraphic.stroke();
+
+  tempContainer.addChild(baseGraphic);
+
+  // Subtle terrain micro-textures (drawn into the same render texture)
+  const detailGraphic = new PIXI.Graphics();
+  detailGraphic.position.set(tileWidth / 2, tileHeight / 2);
+  (detailGraphic as unknown as { eventMode: string }).eventMode = "none";
+
+  if (tileType === "water") {
+    detailGraphic.setStrokeStyle({ width: 1, color: 0x93c5fd, alpha: 0.35 });
+    const y0 = -tileHeight * 0.12;
+    const y1 = 0;
+    const y2 = tileHeight * 0.12;
+    detailGraphic.moveTo(-tileWidth * 0.25, y0);
+    detailGraphic.quadraticCurveTo(0, y0 + 2, tileWidth * 0.25, y0);
+    detailGraphic.moveTo(-tileWidth * 0.3, y1);
+    detailGraphic.quadraticCurveTo(0, y1 + 2, tileWidth * 0.3, y1);
+    detailGraphic.moveTo(-tileWidth * 0.2, y2);
+    detailGraphic.quadraticCurveTo(0, y2 + 2, tileWidth * 0.2, y2);
+    detailGraphic.stroke();
+  } else if (tileType === "forest") {
+    detailGraphic.fill({ color: 0x166534, alpha: 0.12 });
+    const s = Math.max(2, Math.floor(tileHeight * 0.08));
+    detailGraphic.drawPolygon([-s, 0, 0, -s, s, 0, -s, 0]);
+    detailGraphic.endFill();
+  } else if (tileType === "mountain") {
+    detailGraphic.setStrokeStyle({ width: 1, color: 0x64748b, alpha: 0.35 });
+    detailGraphic.moveTo(-tileWidth * 0.2, tileHeight * 0.05);
+    detailGraphic.lineTo(0, -tileHeight * 0.15);
+    detailGraphic.lineTo(tileWidth * 0.2, tileHeight * 0.05);
+    detailGraphic.stroke();
+  } else if (tileType === "grass") {
+    detailGraphic.setStrokeStyle({ width: 1, color: 0x16a34a, alpha: 0.15 });
+    detailGraphic.moveTo(-tileWidth * 0.1, tileHeight * 0.04);
+    detailGraphic.lineTo(-tileWidth * 0.02, tileHeight * 0.01);
+    detailGraphic.moveTo(tileWidth * 0.1, -tileHeight * 0.04);
+    detailGraphic.lineTo(tileWidth * 0.02, -tileHeight * 0.01);
+    detailGraphic.stroke();
+  }
+
+  if (!detailGraphic.destroyed) {
+    tempContainer.addChild(detailGraphic);
+  }
+
+  const renderTexture = PIXI.RenderTexture.create({ width: tileWidth, height: tileHeight });
+  renderer.render({ container: tempContainer, target: renderTexture, clear: true });
+
+  tempContainer.destroy({ children: true });
+
+  textureCache.set(cacheKey, renderTexture);
+  cleanupTextureCache();
+
+  const createTime = performance.now() - startTime;
+  logger.debug(
+    `[TILE_TEXTURE] Generated texture for ${tileKey} (type: ${tileType}) in ${createTime.toFixed(2)}ms`
+  );
+
+  return renderTexture;
+}
+
 export function createTileSprite(
   gridX: number,
   gridY: number,
@@ -43,177 +164,87 @@ export function createTileSprite(
   tileWidth: number,
   tileHeight: number,
   tileTypes: string[][],
+  renderer: Renderer,
 ): GridTile {
   const startTime = performance.now();
   const tileKey = `${gridX},${gridY}`;
-  
+
   logger.debug(`[TILE_CREATE] Starting creation of tile ${tileKey}`);
-  
+
   const { worldX, worldY } = gridToWorld(gridX, gridY, tileWidth, tileHeight);
   const tileType = tileTypes[gridY]?.[gridX] || "unknown";
 
   logger.debug(`[TILE_CREATE] Creating tile ${tileKey} (${tileType}) at world position (${worldX}, ${worldY})`);
-
-  const tile = new PIXI.Graphics();
-  const base = TILE_COLORS[tileType] ?? 0xdde7f7;
-  const lighter = shade(base, 1.08);
-  const darker = shade(base, 0.85);
-
-  // Base diamond with subtle center light and beveled edges
-  tile.fill({ color: base, alpha: 0.96 });
-  tile.moveTo(0, -tileHeight / 2);
-  tile.lineTo(tileWidth / 2, 0);
-  tile.lineTo(0, tileHeight / 2);
-  tile.lineTo(-tileWidth / 2, 0);
-  tile.closePath();
-  tile.fill();
-
-  // Inner highlight diamond
-  tile.fill({ color: lighter, alpha: 0.12 });
-  tile.moveTo(0, -tileHeight * 0.36);
-  tile.lineTo(tileWidth * 0.36, 0);
-  tile.lineTo(0, tileHeight * 0.36);
-  tile.lineTo(-tileWidth * 0.36, 0);
-  tile.closePath();
-  tile.fill();
-
-  // Bevel: darker stroke on right/bottom edges
-  tile.setStrokeStyle({ width: 1.5, color: darker, alpha: 0.55 });
-  tile.moveTo(0, tileHeight / 2);
-  tile.lineTo(tileWidth / 2, 0);
-  tile.lineTo(0, -tileHeight / 2);
-  tile.stroke();
-  // Fine outline
-  tile.setStrokeStyle({ width: 1, color: 0x334155, alpha: 0.35 });
-  tile.moveTo(0, -tileHeight / 2);
-  tile.lineTo(tileWidth / 2, 0);
-  tile.lineTo(0, tileHeight / 2);
-  tile.lineTo(-tileWidth / 2, 0);
-  tile.lineTo(0, -tileHeight / 2);
-  tile.stroke();
-
-  logger.debug(`[TILE_GRAPHICS] Created main sprite for ${tileKey} with base color 0x${base.toString(16)}`);
-
-  // Subtle terrain micro-textures
-  const tex = new PIXI.Graphics();
-  tex.zIndex = 3;
-  tex.position.set(worldX, worldY);
-    (tex as unknown as { eventMode: string }).eventMode = "none";
-  if (tileType === "water") {
-    tex.setStrokeStyle({ width: 1, color: 0x93c5fd, alpha: 0.35 });
-    const y0 = -tileHeight * 0.12, y1 = 0, y2 = tileHeight * 0.12;
-    tex.moveTo(-tileWidth * 0.25, y0); tex.quadraticCurveTo(0, y0 + 2, tileWidth * 0.25, y0);
-    tex.moveTo(-tileWidth * 0.3, y1); tex.quadraticCurveTo(0, y1 + 2, tileWidth * 0.3, y1);
-    tex.moveTo(-tileWidth * 0.2, y2); tex.quadraticCurveTo(0, y2 + 2, tileWidth * 0.2, y2);
-    tex.stroke();
-    logger.debug(`[TILE_GRAPHICS] Added water texture to tile ${tileKey}`);
-  } else if (tileType === "forest") {
-    tex.fill({ color: 0x166534, alpha: 0.12 });
-    const s = Math.max(2, Math.floor(tileHeight * 0.08));
-    tex.drawPolygon([-s, 0, 0, -s, s, 0, -s, 0]);
-    tex.endFill();
-    logger.debug(`[TILE_GRAPHICS] Added forest texture to tile ${tileKey}`);
-  } else if (tileType === "mountain") {
-    tex.setStrokeStyle({ width: 1, color: 0x64748b, alpha: 0.35 });
-    tex.moveTo(-tileWidth * 0.2, tileHeight * 0.05);
-    tex.lineTo(0, -tileHeight * 0.15);
-    tex.lineTo(tileWidth * 0.2, tileHeight * 0.05);
-    tex.stroke();
-    logger.debug(`[TILE_GRAPHICS] Added mountain texture to tile ${tileKey}`);
-  } else if (tileType === "grass") {
-    tex.setStrokeStyle({ width: 1, color: 0x16a34a, alpha: 0.15 });
-    tex.moveTo(-tileWidth * 0.1, tileHeight * 0.04);
-    tex.lineTo(-tileWidth * 0.02, tileHeight * 0.01);
-    tex.moveTo(tileWidth * 0.1, -tileHeight * 0.04);
-    tex.lineTo(tileWidth * 0.02, -tileHeight * 0.01);
-    tex.stroke();
-    logger.debug(`[TILE_GRAPHICS] Added grass texture to tile ${tileKey}`);
+  if (!renderer) {
+    throw new Error(`Renderer is required to create tile sprites. Missing for tile ${tileKey}`);
   }
-  gridContainer.addChild(tex);
-    (tile as PIXI.Graphics & { __tex?: PIXI.Graphics }).__tex = tex;
 
-  logger.debug(`[TILE_GRAPHICS] Added texture graphics to grid container for ${tileKey}. Container children: ${gridContainer.children.length}`);
-
-  tile.x = worldX;
-  tile.y = worldY;
-    (tile as unknown as { eventMode: string }).eventMode = "static";
+  const texture = createTileTexture(tileType, tileWidth, tileHeight, renderer, tileKey);
+  const sprite = new PIXI.Sprite(texture);
+  sprite.anchor.set(0.5, 0.5);
+  sprite.position.set(worldX, worldY);
+  sprite.zIndex = 2;
+  (sprite as unknown as { eventMode: string }).eventMode = "static";
   const hx = (tileWidth / 2) * 0.95;
   const hy = (tileHeight / 2) * 0.95;
-  tile.hitArea = new PIXI.Polygon([0, -hy, hx, 0, 0, hy, -hx, 0]);
-  tile.cursor = "pointer";
+  sprite.hitArea = new PIXI.Polygon([0, -hy, hx, 0, 0, hy, -hx, 0]);
+  sprite.cursor = "pointer";
+
+  logger.debug(`[TILE_GRAPHICS] Created sprite for ${tileKey} using cached texture`);
 
   // Optional animated overlays per tile type
   const overlay = new PIXI.Graphics();
   overlay.zIndex = 5;
-    (overlay as unknown as { eventMode: string }).eventMode = "none";
+  (overlay as unknown as { eventMode: string }).eventMode = "none";
   overlay.position.set(worldX, worldY);
   gridContainer.addChild(overlay);
-    (tile as PIXI.Graphics & { __overlay?: PIXI.Graphics }).__overlay = overlay;
-
   logger.debug(`[TILE_GRAPHICS] Added overlay graphics to grid container for ${tileKey}`);
 
   const createTime = performance.now() - startTime;
-  logger.info(`[TILE_CREATE] Created tile ${tileKey} (${tileType}) in ${createTime.toFixed(2)}ms. Sprite ID: ${tile.uid}`);
+  logger.info(`[TILE_CREATE] Created tile ${tileKey} (${tileType}) in ${createTime.toFixed(2)}ms. Sprite ID: ${sprite.uid}`);
 
   // Dispose method to properly clean up all PIXI objects
   const dispose = () => {
     const disposeStartTime = performance.now();
-    logger.debug(`[TILE_DISPOSE] Starting disposal of tile ${tileKey}. Sprite destroyed: ${tile.destroyed}`);
-    
+    logger.debug(`[TILE_DISPOSE] Starting disposal of tile ${tileKey}. Sprite destroyed: ${sprite.destroyed}`);
+
     let disposedObjects = 0;
-    
-    // Clean up texture graphics
-    const tileWithExtras = tile as PIXI.Graphics & { __tex?: PIXI.Graphics; __overlay?: PIXI.Graphics };
-    
+
     try {
-      if (tileWithExtras.__tex && !tileWithExtras.__tex.destroyed) {
-        if (tileWithExtras.__tex.parent) {
-          tileWithExtras.__tex.parent.removeChild(tileWithExtras.__tex);
+      if (overlay && !overlay.destroyed) {
+        if (overlay.parent) {
+          overlay.parent.removeChild(overlay);
         }
-        tileWithExtras.__tex.destroy({ children: true, texture: true });
-        tileWithExtras.__tex = undefined;
-        disposedObjects++;
-        logger.debug(`[TILE_DISPOSE] Destroyed texture graphics for tile ${tileKey}`);
-      }
-    } catch (error) {
-      logger.error(`[TILE_DISPOSE] Error destroying texture graphics for tile ${tileKey}:`, error);
-    }
-    
-    try {
-      if (tileWithExtras.__overlay && !tileWithExtras.__overlay.destroyed) {
-        if (tileWithExtras.__overlay.parent) {
-          tileWithExtras.__overlay.parent.removeChild(tileWithExtras.__overlay);
-        }
-        tileWithExtras.__overlay.destroy({ children: true, texture: true });
-        tileWithExtras.__overlay = undefined;
+        overlay.destroy({ children: true, texture: true });
         disposedObjects++;
         logger.debug(`[TILE_DISPOSE] Destroyed overlay graphics for tile ${tileKey}`);
       }
     } catch (error) {
       logger.error(`[TILE_DISPOSE] Error destroying overlay graphics for tile ${tileKey}:`, error);
     }
-    
+
     // Clean up main tile sprite
     try {
-      if (tile.parent) {
-        const parentChildrenBefore = tile.parent.children.length;
-        tile.parent.removeChild(tile);
-        logger.debug(`[TILE_DISPOSE] Removed tile ${tileKey} from parent. Parent children: ${parentChildrenBefore} -> ${tile.parent.children.length}`);
+      if (sprite.parent) {
+        const parent = sprite.parent;
+        const parentChildrenBefore = parent.children.length;
+        parent.removeChild(sprite);
+        logger.debug(`[TILE_DISPOSE] Removed tile ${tileKey} from parent. Parent children: ${parentChildrenBefore} -> ${parent.children.length}`);
       }
-      
-      if (!tile.destroyed) {
-        tile.destroy({ children: true, texture: true });
+
+      if (!sprite.destroyed) {
+        sprite.destroy({ children: true });
         disposedObjects++;
         logger.debug(`[TILE_DISPOSE] Destroyed main sprite for tile ${tileKey}`);
       }
     } catch (error) {
       logger.error(`[TILE_DISPOSE] Error destroying main sprite for tile ${tileKey}:`, error);
     }
-    
+
     const disposeTime = performance.now() - disposeStartTime;
     logger.info(`[TILE_DISPOSE] Disposed tile ${tileKey} in ${disposeTime.toFixed(2)}ms. Objects disposed: ${disposedObjects}`);
   };
 
-  return { x: gridX, y: gridY, worldX, worldY, tileType, sprite: tile, dispose };
+  return { x: gridX, y: gridY, worldX, worldY, tileType, sprite, overlay, dispose };
 }
 


### PR DESCRIPTION
## Summary
- generate and cache PIXI render textures per tile type and build sprites from them
- update isometric grid renderers to reuse cached textures and cleanly recreate tiles when types change
- fix strict ref initializations so builds succeed under current TypeScript config

## Testing
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=anon SUPABASE_URL=http://localhost SUPABASE_SERVICE_ROLE_KEY=role SUPABASE_JWT_SECRET=secret npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c86da873808325bae6ca479b6a786b