### PR TITLE
refactor: update tile sprites in place

### DIFF
--- a/src/components/game/IsometricGrid.tsx
+++ b/src/components/game/IsometricGrid.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import * as PIXI from "pixi.js";
 import { useGameContext } from "./GameContext";
 import logger from "@/lib/logger";
 import { gridToWorld, TILE_COLORS } from "@/lib/isometric";
-import { createTileSprite, type GridTile } from "./grid/TileRenderer";
+import { createTileSprite, getTileTexture, type GridTile } from "./grid/TileRenderer";
 import { TileOverlay } from "./grid/TileOverlay";
 
 interface IsometricGridProps {
@@ -36,6 +36,53 @@ export default function IsometricGrid({
     tileTypesRef.current = tileTypes;
   }, [tileTypes]);
   // no extra refs needed for min zoom snapping; we prevent underflow by clamping minScale to fit
+
+  const updateTileSprite = useCallback(
+    (gridTile: GridTile, nextType: string) => {
+      if (!app?.renderer) {
+        logger.warn(
+          `[TILE_UPDATE] Renderer unavailable when attempting to update tile ${gridTile.x},${gridTile.y}`
+        );
+        return;
+      }
+
+      if (gridTile.sprite.destroyed) {
+        logger.warn(
+          `[TILE_UPDATE] Attempted to update destroyed tile ${gridTile.x},${gridTile.y}`
+        );
+        return;
+      }
+
+      const tileKey = `${gridTile.x},${gridTile.y}`;
+      const previousType = gridTile.tileType;
+
+      const nextTexture = getTileTexture(
+        nextType,
+        tileWidth,
+        tileHeight,
+        app.renderer,
+        tileKey
+      );
+
+      if (gridTile.sprite.texture !== nextTexture) {
+        gridTile.sprite.texture = nextTexture;
+        gridTile.sprite.texture.updateUvs();
+      }
+
+      gridTile.tileType = nextType;
+
+      if (gridTile.overlay && gridTile.overlay.destroyed) {
+        logger.warn(
+          `[TILE_UPDATE] Overlay for tile ${tileKey} was destroyed prior to update and cannot be reused.`
+        );
+      }
+
+      logger.debug(
+        `[TILE_UPDATE] Updated tile ${tileKey} type from ${previousType} to ${nextType}`
+      );
+    },
+    [app, tileHeight, tileWidth]
+  );
 
   // Initialize grid
   useEffect(() => {
@@ -191,28 +238,18 @@ export default function IsometricGrid({
     if (!gridContainer || !app?.renderer) return;
     const tiles = tilesRef.current;
     let updates = 0;
-    tiles.forEach((gridTile, key) => {
-      const nextType = tileTypes[gridTile.y]?.[gridTile.x];
-      if (nextType && nextType !== gridTile.tileType) {
-        gridTile.dispose();
-        const newTile = createTileSprite(
-          gridTile.x,
-          gridTile.y,
-          gridContainer,
-          tileWidth,
-          tileHeight,
-          tileTypes,
-          app.renderer,
-        );
-        tiles.set(key, newTile);
-        gridContainer.addChild(newTile.sprite);
+    tiles.forEach((gridTile) => {
+      const rawType = tileTypes[gridTile.y]?.[gridTile.x];
+      const nextType = rawType ?? "unknown";
+      if (nextType !== gridTile.tileType) {
+        updateTileSprite(gridTile, nextType);
         updates++;
       }
     });
     if (updates > 0) {
       logger.debug(`IsometricGrid: updated ${updates} tiles due to tileTypes change`);
     }
-  }, [app, tileTypes, tileWidth, tileHeight]);
+  }, [app, tileTypes, tileWidth, tileHeight, updateTileSprite]);
 
   // Performance optimization: Viewport culling and LOD + lightweight animations
   useEffect(() => {

--- a/src/components/game/grid/TileRenderer.ts
+++ b/src/components/game/grid/TileRenderer.ts
@@ -42,7 +42,7 @@ function getTextureCacheKey(tileType: string, tileWidth: number, tileHeight: num
   return `${tileType}-${tileWidth}x${tileHeight}`;
 }
 
-function createTileTexture(
+export function getTileTexture(
   tileType: string,
   tileWidth: number,
   tileHeight: number,
@@ -179,7 +179,7 @@ export function createTileSprite(
     throw new Error(`Renderer is required to create tile sprites. Missing for tile ${tileKey}`);
   }
 
-  const texture = createTileTexture(tileType, tileWidth, tileHeight, renderer, tileKey);
+  const texture = getTileTexture(tileType, tileWidth, tileHeight, renderer, tileKey);
   const sprite = new PIXI.Sprite(texture);
   sprite.anchor.set(0.5, 0.5);
   sprite.position.set(worldX, worldY);


### PR DESCRIPTION
## Summary
- export the tile texture generator so sprites can refresh without recreation
- add an updateTileSprite helper that swaps textures while keeping existing overlays and events
- refresh tiles in place when tileTypes change to avoid destroying sprites

## Testing
- NEXT_PUBLIC_SUPABASE_URL="http://localhost" NEXT_PUBLIC_SUPABASE_ANON_KEY="anon-key" SUPABASE_URL="http://localhost" SUPABASE_SERVICE_ROLE_KEY="service-role" SUPABASE_JWT_SECRET="jwt-secret" npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8730a92d8832590eca53397fac48e