### PR TITLE
Optimize tile overlay updates to reduce draw calls

### DIFF
--- a/src/components/game/IsometricGrid.tsx
+++ b/src/components/game/IsometricGrid.tsx
@@ -4,9 +4,11 @@ import { useEffect, useRef } from "react";
 import * as PIXI from "pixi.js";
 import { useGameContext } from "./GameContext";
 import logger from "@/lib/logger";
-import { gridToWorld, TILE_COLORS } from "@/lib/isometric";
+import { gridToWorld } from "@/lib/isometric";
 import { createTileSprite, type GridTile } from "./grid/TileRenderer";
 import { TileOverlay } from "./grid/TileOverlay";
+
+type VisibilityUpdateOptions = { overlayUpdate?: boolean; animationTime?: number };
 
 interface IsometricGridProps {
   gridSize: number;
@@ -31,6 +33,7 @@ export default function IsometricGrid({
   const centeredRef = useRef<boolean>(false);
   const initializedRef = useRef<boolean>(false);
   const overlayManagerRef = useRef<TileOverlay | null>(null);
+  const updateVisibilityRef = useRef<((options?: VisibilityUpdateOptions) => void) | null>(null);
   const tileTypesRef = useRef<string[][]>(tileTypes);
   useEffect(() => {
     tileTypesRef.current = tileTypes;
@@ -182,6 +185,7 @@ export default function IsometricGrid({
     }
     if (added > 0) {
       logger.debug(`IsometricGrid: added ${added} tiles after gridSize changed to ${gridSize}`);
+      updateVisibilityRef.current?.({ overlayUpdate: true });
     }
   }, [app, gridSize, tileWidth, tileHeight, tileTypes]);
 
@@ -211,6 +215,7 @@ export default function IsometricGrid({
     });
     if (updates > 0) {
       logger.debug(`IsometricGrid: updated ${updates} tiles due to tileTypes change`);
+      updateVisibilityRef.current?.({ overlayUpdate: true });
     }
   }, [app, tileTypes, tileWidth, tileHeight]);
 
@@ -218,38 +223,44 @@ export default function IsometricGrid({
   useEffect(() => {
     if (!viewport || !gridContainerRef.current || !app?.ticker) return;
 
-    let lastScale = viewport.scale?.x || 1;
     let isUpdating = false;
-    let t = 0;
     let isTickerActive = false;
+    let overlayAccumulator = 0;
+    let overlayAnimationTime = 0;
+    let selectionPulseTime = 0;
+    const overlayUpdateInterval = 120; // milliseconds between overlay redraws
 
-    const updateVisibilityAndLOD = () => {
+    const updateVisibilityAndLOD = (options: VisibilityUpdateOptions = {}) => {
       if (!viewport || !viewport.scale || isUpdating) return;
-      
+
+      const { overlayUpdate = false, animationTime } = options;
+
       isUpdating = true;
       const scale = viewport.scale.x;
       const tiles = tilesRef.current;
-      
+
       // Get viewport bounds for culling
       const bounds = viewport.getVisibleBounds();
       const padding = Math.max(tileWidth, tileHeight) * 2; // Add padding for smooth scrolling
-      
+
       const visibleLeft = bounds.x - padding;
       const visibleRight = bounds.x + bounds.width + padding;
       const visibleTop = bounds.y - padding;
       const visibleBottom = bounds.y + bounds.height + padding;
-      
-      // Only update line width if scale changed significantly
+
+      const frameTime = animationTime ?? overlayAnimationTime;
+
       tiles.forEach((tile) => {
         // Viewport culling - only show tiles in visible area
-        const isInViewport = tile.worldX >= visibleLeft &&
-                           tile.worldX <= visibleRight &&
-                           tile.worldY >= visibleTop &&
-                           tile.worldY <= visibleBottom;
-        
+        const isInViewport =
+          tile.worldX >= visibleLeft &&
+          tile.worldX <= visibleRight &&
+          tile.worldY >= visibleTop &&
+          tile.worldY <= visibleBottom;
+
         // LOD - hide tiles when zoomed out too far
         const shouldShowTile = scale > 0.15 && isInViewport;
-        
+
         if (tile.sprite.visible !== shouldShowTile) {
           tile.sprite.visible = shouldShowTile;
         }
@@ -258,67 +269,76 @@ export default function IsometricGrid({
         const overlay = tile.overlay;
         if (overlay) {
           overlay.visible = shouldShowTile;
-          if (shouldShowTile) {
+          if (overlayUpdate && shouldShowTile) {
             overlay.clear();
-            if (tile.tileType === 'water') {
-              const r = (tileHeight / 4) + Math.sin(t * 0.005 + (tile.x + tile.y)) * 2;
+            if (tile.tileType === "water") {
+              const wave = frameTime * 0.005 + (tile.x + tile.y);
+              const r = tileHeight / 4 + Math.sin(wave) * 2;
               overlay.fill({ color: 0xffffff, alpha: 0.05 });
               overlay.drawCircle(0, 0, r);
               overlay.fill({ color: 0xffffff, alpha: 0.03 });
               overlay.drawCircle(0, 0, r * 0.6);
-            } else if (tile.tileType === 'forest') {
+            } else if (tile.tileType === "forest") {
+              const sway = Math.sin(frameTime * 0.006 + tile.x * 0.1) * 3;
               overlay.setStrokeStyle({ width: 1, color: 0x14532d, alpha: 0.2 });
-              const sway = Math.sin(t * 0.006 + (tile.x * 0.1)) * 3;
-              overlay.moveTo(-tileWidth/4 + sway, -tileHeight/6);
-              overlay.lineTo(-tileWidth/8 + sway, 0);
-              overlay.lineTo(-tileWidth/4 + sway, tileHeight/6);
+              overlay.moveTo(-tileWidth / 4 + sway, -tileHeight / 6);
+              overlay.lineTo(-tileWidth / 8 + sway, 0);
+              overlay.lineTo(-tileWidth / 4 + sway, tileHeight / 6);
               overlay.stroke();
             }
           }
         }
       });
-      
-      lastScale = scale;
+
       isUpdating = false;
     };
 
-    const throttledUpdate = () => {
-      // Update will be handled by the ticker
-      updateVisibilityAndLOD();
+    updateVisibilityRef.current = updateVisibilityAndLOD;
+
+    const handleViewportChanged = () => {
+      updateVisibilityAndLOD({ overlayUpdate: false });
     };
 
-    // Listen to viewport events with throttling
-    viewport.on('zoomed', throttledUpdate);
-    viewport.on('moved', throttledUpdate);
-    // Global animation ticker using PIXI ticker
-    const tick = () => {
-      t += 16;
-      // Subtle pulse on selection overlay
+    viewport.on("zoomed", handleViewportChanged);
+    viewport.on("moved", handleViewportChanged);
+
+    const tick = (ticker: PIXI.Ticker) => {
+      const deltaMS = ticker.deltaMS;
+      selectionPulseTime += deltaMS;
+
       const sel = overlayManagerRef.current?.selectOverlay;
       if (sel && sel.visible) {
         const base = 0.35;
         const amp = 0.1;
         const w = 0.002;
-        sel.alpha = base + amp * (0.5 + 0.5 * Math.sin(t * w));
+        sel.alpha = base + amp * (0.5 + 0.5 * Math.sin(selectionPulseTime * w));
       }
-      throttledUpdate();
+
+      overlayAccumulator += deltaMS;
+      if (overlayAccumulator >= overlayUpdateInterval) {
+        const steps = Math.floor(overlayAccumulator / overlayUpdateInterval);
+        overlayAccumulator -= steps * overlayUpdateInterval;
+        overlayAnimationTime += steps * overlayUpdateInterval;
+        updateVisibilityAndLOD({ overlayUpdate: true, animationTime: overlayAnimationTime });
+      }
     };
-    
-    if (!isTickerActive) {
-      isTickerActive = true;
-      app.ticker.add(tick);
-    }
-    
-    // Initial update
-    updateVisibilityAndLOD();
+
+    isTickerActive = true;
+    app.ticker.add(tick);
+
+    // Initial update to populate overlay textures and visibility states
+    updateVisibilityAndLOD({ overlayUpdate: true, animationTime: overlayAnimationTime });
 
     return () => {
       if (isTickerActive && app?.ticker) {
         app.ticker.remove(tick);
         isTickerActive = false;
       }
-      viewport.off('zoomed', throttledUpdate);
-      viewport.off('moved', throttledUpdate);
+      viewport.off("zoomed", handleViewportChanged);
+      viewport.off("moved", handleViewportChanged);
+      if (updateVisibilityRef.current === updateVisibilityAndLOD) {
+        updateVisibilityRef.current = null;
+      }
     };
   }, [viewport, app, tileWidth, tileHeight]);
 

--- a/src/components/game/grid/TileRenderer.ts
+++ b/src/components/game/grid/TileRenderer.ts
@@ -193,12 +193,15 @@ export function createTileSprite(
   logger.debug(`[TILE_GRAPHICS] Created sprite for ${tileKey} using cached texture`);
 
   // Optional animated overlays per tile type
-  const overlay = new PIXI.Graphics();
-  overlay.zIndex = 5;
-  (overlay as unknown as { eventMode: string }).eventMode = "none";
-  overlay.position.set(worldX, worldY);
-  gridContainer.addChild(overlay);
-  logger.debug(`[TILE_GRAPHICS] Added overlay graphics to grid container for ${tileKey}`);
+  let overlay: PIXI.Graphics | undefined;
+  if (tileType === "water" || tileType === "forest") {
+    overlay = new PIXI.Graphics();
+    overlay.zIndex = 5;
+    (overlay as unknown as { eventMode: string }).eventMode = "none";
+    overlay.position.set(worldX, worldY);
+    gridContainer.addChild(overlay);
+    logger.debug(`[TILE_GRAPHICS] Added overlay graphics to grid container for ${tileKey}`);
+  }
 
   const createTime = performance.now() - startTime;
   logger.info(`[TILE_CREATE] Created tile ${tileKey} (${tileType}) in ${createTime.toFixed(2)}ms. Sprite ID: ${sprite.uid}`);

--- a/src/components/game/grid/TileRenderer.ts
+++ b/src/components/game/grid/TileRenderer.ts
@@ -18,6 +18,8 @@ export interface GridTile {
 const textureCache = new Map<string, PIXI.RenderTexture>();
 const MAX_CACHED_TEXTURES = 100;
 
+const ANIMATED_TILE_TYPES = new Set(["water", "forest"]);
+
 // Clean up texture cache when it gets too large
 function cleanupTextureCache() {
   if (textureCache.size > MAX_CACHED_TEXTURES) {
@@ -42,7 +44,7 @@ function getTextureCacheKey(tileType: string, tileWidth: number, tileHeight: num
   return `${tileType}-${tileWidth}x${tileHeight}`;
 }
 
-function createTileTexture(
+export function getTileTexture(
   tileType: string,
   tileWidth: number,
   tileHeight: number,
@@ -179,7 +181,7 @@ export function createTileSprite(
     throw new Error(`Renderer is required to create tile sprites. Missing for tile ${tileKey}`);
   }
 
-  const texture = createTileTexture(tileType, tileWidth, tileHeight, renderer, tileKey);
+  const texture = getTileTexture(tileType, tileWidth, tileHeight, renderer, tileKey);
   const sprite = new PIXI.Sprite(texture);
   sprite.anchor.set(0.5, 0.5);
   sprite.position.set(worldX, worldY);
@@ -194,13 +196,15 @@ export function createTileSprite(
 
   // Optional animated overlays per tile type
   let overlay: PIXI.Graphics | undefined;
-  if (tileType === "water" || tileType === "forest") {
+  if (ANIMATED_TILE_TYPES.has(tileType)) {
     overlay = new PIXI.Graphics();
     overlay.zIndex = 5;
     (overlay as unknown as { eventMode: string }).eventMode = "none";
     overlay.position.set(worldX, worldY);
     gridContainer.addChild(overlay);
     logger.debug(`[TILE_GRAPHICS] Added overlay graphics to grid container for ${tileKey}`);
+  } else {
+    logger.debug(`[TILE_GRAPHICS] Skipping overlay allocation for ${tileKey} (${tileType})`);
   }
 
   const createTime = performance.now() - startTime;


### PR DESCRIPTION
## Summary
- throttle isometric tile overlay updates so animations redraw every ~120ms while keeping selection pulsing smooth
- trigger overlay refreshes when tiles are created or retiled so the throttled overlays stay up to date
- instantiate overlay graphics only for water and forest tiles to avoid needless per-frame drawing on static terrain

## Testing
- NEXT_PUBLIC_SUPABASE_URL="http://localhost" NEXT_PUBLIC_SUPABASE_ANON_KEY="test" SUPABASE_URL="http://localhost" SUPABASE_SERVICE_ROLE_KEY="test" SUPABASE_JWT_SECRET="test" npm run build


------
https://chatgpt.com/codex/tasks/task_e_68c87393f17c83258ccd020b8f34b872