### PR TITLE
Refine logger typing and quest panel registration

### DIFF
--- a/src/components/game/hud/panels/ModularQuestPanel.tsx
+++ b/src/components/game/hud/panels/ModularQuestPanel.tsx
@@ -18,10 +18,6 @@ const QUESTS: Array<{ id: string; text: string }> = [
 ];
 
 export default function ModularQuestPanel({ completed, variant = 'default', collapsible = true }: ModularQuestPanelProps) {
-  // Count remaining to surface a smart title and auto-hide when done
-  const remaining = QUESTS.reduce((n, q) => n + (completed[q.id] ? 0 : 1), 0);
-  const next = QUESTS.find(q => !completed[q.id]);
-  if (remaining === 0) return null; // hide panel entirely when all early quests are done
   // Default to collapsed; users can peek as needed
   const [isCollapsed, setIsCollapsed] = useState(true);
 
@@ -36,6 +32,13 @@ export default function ModularQuestPanel({ completed, variant = 'default', coll
     component: ModularQuestPanel,
     props: { variant, collapsible }
   });
+
+  // Count remaining to surface a smart title and auto-hide when done
+  const remaining = QUESTS.reduce((n, q) => n + (completed[q.id] ? 0 : 1), 0);
+  if (remaining === 0) {
+    return null; // hide panel entirely when all early quests are done
+  }
+  const next = QUESTS.find(q => !completed[q.id]);
 
   const titleIcon = (
     <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/components/game/hud/types.ts
+++ b/src/components/game/hud/types.ts
@@ -23,6 +23,20 @@ export interface WorkforceInfo {
   needed: number;
 }
 
+export type NotificationActionKind =
+  | 'open-council'
+  | 'open-edicts'
+  | 'open-settings'
+  | 'focus-tile'
+  | 'navigate'
+  | (string & {});
+
+export interface NotificationAction {
+  kind: NotificationActionKind;
+  label?: string;
+  payload?: Record<string, unknown>;
+}
+
 export interface Notification {
   id: string;
   type: 'info' | 'warning' | 'error' | 'success';
@@ -31,11 +45,7 @@ export interface Notification {
   timestamp: number;
   persistent?: boolean;
   read?: boolean;
-  action?: {
-    kind: 'open-council' | 'open-edicts' | 'open-settings' | 'focus-tile' | 'navigate' | string;
-    label?: string;
-    payload?: any;
-  };
+  action?: NotificationAction;
 }
 
 export interface GameHUDProps {

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -8,28 +8,31 @@ const level = config.logLevel as log.LogLevelDesc;
 logger.setLevel(level);
 
 // Enhanced logger that also outputs to server console in development
+const shouldMirrorToConsole = () =>
+  config.nodeEnv === 'development' && typeof window === 'undefined';
+
 const enhancedLogger = {
-  debug: (message: string, ...args: any[]) => {
+  debug: (message: string, ...args: unknown[]) => {
     logger.debug(message, ...args);
-    if (config.nodeEnv === 'development' && typeof window === 'undefined') {
+    if (shouldMirrorToConsole()) {
       console.log(`[DEBUG] ${message}`, ...args);
     }
   },
-  info: (message: string, ...args: any[]) => {
+  info: (message: string, ...args: unknown[]) => {
     logger.info(message, ...args);
-    if (config.nodeEnv === 'development' && typeof window === 'undefined') {
+    if (shouldMirrorToConsole()) {
       console.log(`[INFO] ${message}`, ...args);
     }
   },
-  warn: (message: string, ...args: any[]) => {
+  warn: (message: string, ...args: unknown[]) => {
     logger.warn(message, ...args);
-    if (config.nodeEnv === 'development' && typeof window === 'undefined') {
+    if (shouldMirrorToConsole()) {
       console.warn(`[WARN] ${message}`, ...args);
     }
   },
-  error: (message: string, ...args: any[]) => {
+  error: (message: string, ...args: unknown[]) => {
     logger.error(message, ...args);
-    if (config.nodeEnv === 'development' && typeof window === 'undefined') {
+    if (shouldMirrorToConsole()) {
       console.error(`[ERROR] ${message}`, ...args);
     }
   }

--- a/src/state/useNotify.ts
+++ b/src/state/useNotify.ts
@@ -2,19 +2,27 @@ import { useCallback } from 'react';
 import { useAppDispatch } from './store';
 import { addNotification } from './slices/notifications';
 
+type NotificationPayload = Parameters<typeof addNotification>[0];
+
+type NotifyOptions = NotificationPayload & {
+  dedupeKey?: string;
+  dedupeMs?: number;
+};
+
 const __recentNotifications = new Map<string, number>();
 
 export function useNotify() {
   const dispatch = useAppDispatch();
-  return useCallback((n: { type: 'info' | 'warning' | 'error' | 'success'; title: string; message: string; persistent?: boolean; dedupeKey?: string; dedupeMs?: number }) => {
-    const key = n.dedupeKey ?? `${n.type}|${n.title}|${n.message}`;
-    const windowMs = typeof n.dedupeMs === 'number' ? n.dedupeMs : 30000;
+  return useCallback((notification: NotifyOptions) => {
+    const { dedupeKey, dedupeMs, ...payload } = notification;
+    const key = dedupeKey ?? `${payload.type}|${payload.title}|${payload.message}`;
+    const windowMs = typeof dedupeMs === 'number' ? dedupeMs : 30000;
     const now = Date.now();
     const last = __recentNotifications.get(key) ?? 0;
     if (now - last < windowMs) return;
     __recentNotifications.set(key, now);
     // Only dispatch allowed notification fields; do not include dedupe metadata
-    dispatch(addNotification({ type: n.type, title: n.title, message: n.message, persistent: n.persistent } as any));
+    dispatch(addNotification(payload));
   }, [dispatch]);
 }
 


### PR DESCRIPTION
## Summary
- replace logger helper varargs with `unknown[]` and centralize the console-mirroring check
- model notification action metadata with explicit types and remove the cast in `useNotify`
- ensure the quest HUD panel registers its hooks before any early return so it no longer violates the rules-of-hooks lint check

## Testing
- `npm run lint` *(fails: repository still contains extensive pre-existing lint violations outside the touched files)*
- `npm run test`
- `CI=1 npm run build` *(fails: build requires Supabase environment variables that are not available in the test container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8796ba5e48325a20c88a94300f795