### PR TITLE
chore: type play page server props

### DIFF
--- a/src/app/play/PlayClient.tsx
+++ b/src/app/play/PlayClient.tsx
@@ -1,9 +1,12 @@
 'use client';
 
+import type { ComponentProps } from 'react';
 import PlayPage from './PlayPageInternal';
 import { StoreProvider } from '@/state/store';
 
-export default function PlayClient(props: any) {
+type PlayClientProps = ComponentProps<typeof PlayPage>;
+
+export default function PlayClient(props: PlayClientProps) {
   return (
     <StoreProvider>
       <PlayPage {...props} />


### PR DESCRIPTION
## Summary
- derive the play page server types from the client component so the initial state and proposals no longer rely on `any`
- update the play client wrapper to accept typed props and pass them straight through to `PlayPage`

## Testing
- npm run lint *(fails: repository currently has hundreds of pre-existing lint violations unrelated to this change, primarily no-explicit-any across engine and game components)*
- npm run test
- npm run build *(fails: missing NEXT_PUBLIC_SUPABASE_URL/NEXT_PUBLIC_SUPABASE_ANON_KEY during data collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c8fbde4c748325a6e8e94631dff025