### PR TITLE
refactor: extract pixi event mode helpers

### DIFF
--- a/src/hooks/usePixiApplication.ts
+++ b/src/hooks/usePixiApplication.ts
@@ -3,6 +3,7 @@ import * as PIXI from "pixi.js";
 import { Viewport } from "pixi-viewport";
 import { useGameContext } from "@/components/game/GameContext";
 import logger from "@/lib/logger";
+import { ensureStaticEventMode } from "@/lib/pixi/eventMode";
 
 interface UsePixiApplicationOptions {
   width: number;
@@ -107,8 +108,8 @@ export function usePixiApplication({
           events: app.renderer.events,
         });
         // Ensure pointer events are processed in Pixi v7+/v8
-        (app.stage as any).eventMode = "static";
-        (viewport as any).eventMode = "static";
+        ensureStaticEventMode(app.stage);
+        ensureStaticEventMode(viewport);
 
         viewport.sortableChildren = true;
         app.stage.addChild(viewport);
@@ -194,8 +195,8 @@ export function usePixiApplication({
           events: app.renderer.events,
         });
         // Ensure pointer events are processed in Pixi v7+/v8
-        (app.stage as any).eventMode = "static";
-        (viewport as any).eventMode = "static";
+        ensureStaticEventMode(app.stage);
+        ensureStaticEventMode(viewport);
 
         viewport.sortableChildren = true;
         app.stage.addChild(viewport);
@@ -272,11 +273,11 @@ export function usePixiApplication({
   useEffect(() => {
     const applySize = () => {
       if (appRef.current && viewportRef.current) {
-        const renderer = appRef.current.renderer as any;
-        const curW = renderer?.width ?? 0;
-        const curH = renderer?.height ?? 0;
+        const renderer = appRef.current.renderer;
+        const curW = renderer.width;
+        const curH = renderer.height;
         if (curW !== width || curH !== height) {
-          appRef.current.renderer.resize(width, height);
+          renderer.resize(width, height);
           viewportRef.current.resize(width, height);
         }
       }

--- a/src/lib/pixi/eventMode.ts
+++ b/src/lib/pixi/eventMode.ts
@@ -1,0 +1,25 @@
+import type { Container, EventMode } from "pixi.js";
+
+export type EventEnabledContainer = Container & {
+  eventMode: EventMode;
+};
+
+const STATIC_EVENT_MODE: EventMode = "static";
+
+const hasEventMode = (
+  container: Container
+): container is EventEnabledContainer => "eventMode" in container;
+
+export const ensureStaticEventMode = (container: Container) => {
+  if (hasEventMode(container)) {
+    container.eventMode = STATIC_EVENT_MODE;
+    return;
+  }
+
+  Object.defineProperty(container, "eventMode", {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: STATIC_EVENT_MODE,
+  });
+};


### PR DESCRIPTION
## Summary
- extract Pixi event-mode typing and helper into a shared Pixi utility module
- update `usePixiApplication` to consume the helper and rely on typed renderer dimensions when resizing

## Testing
- npm run lint *(fails: repository has numerous existing lint errors in unrelated files)*
- npm run test
- CI=1 npm run build *(fails: missing NEXT_PUBLIC_SUPABASE_* env vars for `/api/debug`)*

------
https://chatgpt.com/codex/tasks/task_e_68c8fbd1e3248325be2346e41ecc7fd0