### PR TITLE
chore: type tick route state updates

### DIFF
--- a/src/app/api/state/tick/route.ts
+++ b/src/app/api/state/tick/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase/server'
-import { SupabaseUnitOfWork } from '@arcane/infrastructure/supabase'
-import { SIM_BUILDINGS } from '@engine'
-import { processTick } from '@engine'
 import { config } from '@/infrastructure/config'
+import { SupabaseUnitOfWork } from '@arcane/infrastructure/supabase'
+import { processTick, SIM_BUILDINGS } from '@engine'
+import type { GameStateUpdatePayload, EngineState } from './types'
 
 // Advance one cycle: delegate to engine and persist results
 export async function POST() {
@@ -15,35 +15,40 @@ export async function POST() {
 
   const accepted = await uow.proposals.listByState(state.id, ['accepted'])
 
-  const { state: nextState, crisis } = processTick(state as any, accepted ?? [], SIM_BUILDINGS)
+  const { state: nextState, crisis } = processTick(state, accepted, SIM_BUILDINGS)
+  const isoNow = new Date().toISOString()
+  const updatePayload: GameStateUpdatePayload = {
+    cycle: nextState.cycle,
+    max_cycle: nextState.max_cycle,
+    resources: nextState.resources,
+    workers: nextState.workers,
+    buildings: nextState.buildings ?? [],
+    routes: nextState.routes ?? [],
+    edicts: nextState.edicts ?? undefined,
+    updated_at: isoNow,
+    last_tick_at: isoNow,
+  }
 
-  let updated
+  let updated: EngineState = nextState
   try {
-    updated = await uow.gameStates.update(state.id, {
-      cycle: nextState.cycle,
-      max_cycle: nextState.max_cycle,
-      resources: nextState.resources,
-      workers: nextState.workers,
-      buildings: nextState.buildings ?? [],
-      routes: nextState.routes ?? [],
-      edicts: nextState.edicts ?? undefined,
-      updated_at: new Date().toISOString(),
-      last_tick_at: new Date().toISOString() as any,
-    })
+    updated = await uow.gameStates.update(state.id, updatePayload)
   } catch (upErr: unknown) {
     const message = upErr instanceof Error ? upErr.message : String(upErr)
     return NextResponse.json({ error: message }, { status: 500 })
   }
 
-  if ((accepted?.length ?? 0) > 0) {
+  if (accepted.length > 0) {
     await uow.proposals.updateMany(
-      accepted!.map(p => p.id),
+      accepted.map(p => p.id),
       { status: 'applied' },
     )
   }
 
   if (crisis) {
-    try { updated = await uow.gameStates.update(state.id, { auto_ticking: false } as any) } catch {}
+    const disableAutoTick: Partial<EngineState> = { auto_ticking: false }
+    try {
+      updated = await uow.gameStates.update(state.id, disableAutoTick)
+    } catch {}
   }
   return NextResponse.json({ state: updated, crisis })
 }

--- a/src/app/api/state/tick/types.ts
+++ b/src/app/api/state/tick/types.ts
@@ -1,0 +1,11 @@
+import type { GameState } from '@engine'
+
+export type EngineState = GameState
+
+export type GameStateUpdatePayload = Pick<
+  GameState,
+  'cycle' | 'max_cycle' | 'resources' | 'workers' | 'buildings' | 'routes' | 'edicts'
+> & {
+  updated_at: string
+  last_tick_at: string
+}


### PR DESCRIPTION
## Summary
- add an explicit engine state alias and strongly typed update payload to the tick route via shared type definitions
- reuse a single ISO timestamp for `updated_at` and `last_tick_at`, and type the crisis auto-tick update payload
- extract the tick route type aliases into `src/app/api/state/tick/types.ts`

## Testing
- `npm run lint` *(fails: existing lint violations across engine and UI files)*
- `npm run test`
- `CI=1 npm run build` *(fails: missing `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` in the build-time validation)*

------
https://chatgpt.com/codex/tasks/task_e_68c8fbd122648325a60829f212a890fb