### PR TITLE
Fix TileTooltip Pixi point type

### DIFF
--- a/src/components/game/TileTooltip.tsx
+++ b/src/components/game/TileTooltip.tsx
@@ -27,7 +27,8 @@ export default function TileTooltip({ hoverTile, selectedTile, previewTypeId, ti
   useEffect(() => {
     if (!viewport || !target) { setPos(null); return; }
     const { worldX, worldY } = gridToWorld(target.x, target.y, tileWidth, tileHeight);
-    const p = viewport.toGlobal({ x: worldX, y: worldY } as any);
+    const worldPoint = new PIXI.Point(worldX, worldY);
+    const p = viewport.toGlobal(worldPoint);
     setPos({ left: p.x + 12, top: p.y - 12 });
   }, [viewport, target?.x, target?.y, target?.tileType]);
 


### PR DESCRIPTION
## Summary
- instantiate a PIXI.Point before calling viewport.toGlobal in TileTooltip so the helper receives a typed Pixi object

## Testing
- npm run lint *(fails: repository has existing lint errors around no-explicit-any and missing hook deps)*
- npm run test
- CI=1 NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy SUPABASE_URL=http://localhost SUPABASE_SERVICE_ROLE_KEY=dummy npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8fbbd83a08325a6fa10d5d7529569