### PR TITLE
refactor: extract memory manager types

### DIFF
--- a/src/components/game/MemoryManager.types.ts
+++ b/src/components/game/MemoryManager.types.ts
@@ -1,0 +1,45 @@
+export interface MemoryStats {
+  totalTextures: number;
+  totalGeometries: number;
+  totalDrawCalls: number;
+  memoryUsage: number;
+  loadedChunks: number;
+  // Additional diagnostics
+  heapLimitMB?: number;
+  percentUsed?: number; // 0-100
+}
+
+export interface MemoryManagerProps {
+  maxMemoryMB?: number;
+  maxTextures?: number;
+  cleanupInterval?: number;
+  onMemoryWarning?: (stats: MemoryStats) => void;
+  onMemoryCleanup?: (freedMB: number) => void;
+  // New optional controls (backward-compatible)
+  warnAtPercent?: number; // warn when used/limit exceeds this percent
+  warningCooldownMs?: number; // minimum time between warnings
+}
+
+export interface PerformanceMemoryInfo {
+  usedJSHeapSize: number;
+  jsHeapSizeLimit: number;
+  totalJSHeapSize?: number;
+}
+
+export interface MemoryManagerAPI {
+  getStats: () => MemoryStats;
+  cleanup: () => Promise<number>;
+  checkUsage: () => boolean;
+}
+
+declare global {
+  interface Performance {
+    memory?: PerformanceMemoryInfo;
+  }
+
+  interface Window {
+    gc?: () => void;
+    memoryManager?: MemoryManagerAPI;
+  }
+}
+


### PR DESCRIPTION
## Summary
- move the memory manager type definitions into a dedicated `MemoryManager.types.ts` module that also applies the global browser augmentations
- consume the shared types within `MemoryManager.tsx` and re-export them to preserve the existing component API surface

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated engine and UI files)*
- npm run test
- npm run build *(fails: missing NEXT_PUBLIC_SUPABASE_* environment variables for /api/debug)*

------
https://chatgpt.com/codex/tasks/task_e_68c8fbb29af08325ac4bc8b93cb50710