### PR TITLE
refactor: type ambient particles

### DIFF
--- a/src/components/game/AmbientLayer.types.ts
+++ b/src/components/game/AmbientLayer.types.ts
@@ -1,0 +1,8 @@
+import type { Graphics } from "pixi.js";
+
+export interface ParticleProperties {
+  vy: number;
+  fade: number;
+}
+
+export type ParticleGraphic = Graphics & ParticleProperties;


### PR DESCRIPTION
## Summary
- define a `ParticleProperties` structure to carry `vy` and `fade`
- type ambient layer particle graphics and update animation to use typed fields
- move the particle graphics typings into `AmbientLayer.types.ts` for reuse outside the component

## Testing
- npm run lint *(fails: repository contains pre-existing lint errors unrelated to this change)*
- npm run test
- npm run build *(fails: missing required Supabase environment variables during Next.js data collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c8fbad989483259cec80693fa8a7a9