### PR TITLE
Improve typing in GameRenderer interactions

### DIFF
--- a/src/components/game/types.ts
+++ b/src/components/game/types.ts
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+
 export interface SimpleBuilding {
   id: string;
   typeId: string;
@@ -5,4 +7,23 @@ export interface SimpleBuilding {
   y: number;
   workers?: number;
   level?: number;
+}
+
+export interface GameRendererProps {
+  width?: number;
+  height?: number;
+  gridSize?: number;
+  tileTypes?: string[][];
+  onTileHover?: (x: number, y: number, tileType?: string) => void;
+  onTileClick?: (x: number, y: number, tileType?: string) => void;
+  children?: ReactNode;
+  useExternalProvider?: boolean;
+  enableEdgeScroll?: boolean;
+  onReset?: () => void;
+}
+
+export interface EdgeScrollState {
+  vx: number;
+  vy: number;
+  raf: number | null;
 }


### PR DESCRIPTION
## Summary
- guard keyboard handling by ensuring the event target is an HTMLElement before reacting to shortcuts
- use the Pixi application ticker from context to drive edge scroll animations instead of casting viewport.parent to any
- add start/stop helpers so the ticker subscription is cleaned up when the cursor leaves the viewport
- move GameRenderer prop and edge scroll state typings into the shared game types module rather than inline in the renderer

## Testing
- `npm run lint` *(fails: existing lint errors across engine, UI, and test files unrelated to this change)*
- `npm run test`
- `CI=1 npm run build` *(fails: missing NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY environment values for /api/debug)*

------
https://chatgpt.com/codex/tasks/task_e_68c8fbabeb848325b32447f974599710