### PR TITLE
refactor: extract seasonal layer types

### DIFF
--- a/src/components/game/SeasonalLayer.tsx
+++ b/src/components/game/SeasonalLayer.tsx
@@ -3,17 +3,15 @@
 import { useEffect, useRef } from "react";
 import * as PIXI from "pixi.js";
 import { useGameContext } from "./GameContext";
-
-type Season = 'spring' | 'summer' | 'autumn' | 'winter';
-
-interface SeasonalLayerProps {
-  season: Season;
-}
+import type {
+  ParticleGraphics,
+  SeasonalLayerProps,
+} from "./SeasonalLayer.types";
 
 export default function SeasonalLayer({ season }: SeasonalLayerProps) {
   const { app, viewport } = useGameContext();
   const layerRef = useRef<PIXI.Container | null>(null);
-  const flakesRef = useRef<PIXI.Graphics[]>([]);
+  const flakesRef = useRef<ParticleGraphics[]>([]);
 
   useEffect(() => {
     if (!app || !viewport) return;
@@ -32,47 +30,47 @@ export default function SeasonalLayer({ season }: SeasonalLayerProps) {
     flakesRef.current = [];
 
     // Minimal, tasteful effects per season
-    const tick = (ticker: PIXI.Ticker) => {
+    const tick = () => {
       const bounds = viewport.getVisibleBounds();
       if (season === 'winter') {
         // Snow: spawn gently falling flakes
         if (Math.random() < 0.15) {
-          const g = new PIXI.Graphics();
+          const g = new PIXI.Graphics() as ParticleGraphics;
           g.beginFill(0xffffff, 0.85);
           g.drawCircle(0, 0, 1.2);
           g.endFill();
           g.position.set(bounds.x + Math.random() * bounds.width, bounds.y - 10);
-          (g as any).__vy = 0.25 + Math.random() * 0.25;
-          (g as any).__vx = (Math.random() - 0.5) * 0.1;
-          (g as any).__fade = 0.0005;
+          g.vy = 0.25 + Math.random() * 0.25;
+          g.vx = (Math.random() - 0.5) * 0.1;
+          g.fade = 0.0005;
           layer!.addChild(g);
           flakesRef.current.push(g);
         }
       } else if (season === 'autumn') {
         // Leaves: slow drifting particles
         if (Math.random() < 0.1) {
-          const g = new PIXI.Graphics();
+          const g = new PIXI.Graphics() as ParticleGraphics;
           g.beginFill(0xf59e0b, 0.8);
           g.drawCircle(0, 0, 1.5);
           g.endFill();
           g.position.set(bounds.x - 10, bounds.y + Math.random() * bounds.height);
-          (g as any).__vy = (Math.random() - 0.5) * 0.05;
-          (g as any).__vx = 0.35 + Math.random() * 0.2;
-          (g as any).__fade = 0.0007;
+          g.vy = (Math.random() - 0.5) * 0.05;
+          g.vx = 0.35 + Math.random() * 0.2;
+          g.fade = 0.0007;
           layer!.addChild(g);
           flakesRef.current.push(g);
         }
       } else if (season === 'spring') {
         // Pollen motes: subtle rise
         if (Math.random() < 0.08) {
-          const g = new PIXI.Graphics();
+          const g = new PIXI.Graphics() as ParticleGraphics;
           g.beginFill(0xa7f3d0, 0.8);
           g.drawCircle(0, 0, 1.0);
           g.endFill();
           g.position.set(bounds.x + Math.random() * bounds.width, bounds.y + bounds.height + 10);
-          (g as any).__vy = -0.25 - Math.random() * 0.2;
-          (g as any).__vx = (Math.random() - 0.5) * 0.08;
-          (g as any).__fade = 0.0006;
+          g.vy = -0.25 - Math.random() * 0.2;
+          g.vx = (Math.random() - 0.5) * 0.08;
+          g.fade = 0.0006;
           layer!.addChild(g);
           flakesRef.current.push(g);
         }
@@ -82,9 +80,9 @@ export default function SeasonalLayer({ season }: SeasonalLayerProps) {
 
       // Animate
       flakesRef.current.forEach((g) => {
-        g.x += (g as any).__vx || 0;
-        g.y += (g as any).__vy || 0;
-        g.alpha = Math.max(0, g.alpha - ((g as any).__fade || 0));
+        g.x += g.vx;
+        g.y += g.vy;
+        g.alpha = Math.max(0, g.alpha - g.fade);
       });
       // Cleanup
       flakesRef.current = flakesRef.current.filter((g) => {
@@ -111,4 +109,4 @@ export default function SeasonalLayer({ season }: SeasonalLayerProps) {
   return null;
 }
 
-export type { SeasonalLayerProps };
+export type { SeasonalLayerProps } from "./SeasonalLayer.types";

--- a/src/components/game/SeasonalLayer.types.ts
+++ b/src/components/game/SeasonalLayer.types.ts
@@ -1,0 +1,13 @@
+import type { Graphics } from "pixi.js";
+
+export type Season = "spring" | "summer" | "autumn" | "winter";
+
+export interface SeasonalLayerProps {
+  season: Season;
+}
+
+export interface ParticleGraphics extends Graphics {
+  vx: number;
+  vy: number;
+  fade: number;
+}


### PR DESCRIPTION
## Summary
- move the seasonal particle types into a dedicated SeasonalLayer.types module
- update SeasonalLayer to import the shared ParticleGraphics and prop types

## Testing
- npm run lint *(fails: repository has numerous pre-existing lint errors)*
- npm run test
- CI=1 npm run build *(fails: missing Supabase environment variables for /api/debug route)*

------
https://chatgpt.com/codex/tasks/task_e_68c8fba71688832595725cde11304efd