### PR TITLE
Refine grid initialization callbacks

### DIFF
--- a/src/components/game/ChunkedIsometricGrid.tsx
+++ b/src/components/game/ChunkedIsometricGrid.tsx
@@ -60,6 +60,24 @@ export default function ChunkedIsometricGrid({
   const lastMemoryCleanupRef = useRef<number>(0);
   const memoryStatsRef = useRef({ totalSprites: 0, totalTextures: 0, totalContainers: 0 });
   const renderStatsRef = useRef({ chunksLoaded: 0, chunksUnloaded: 0, spritesCreated: 0, spritesDestroyed: 0 });
+  const onTileHoverRef = useRef(onTileHover);
+  const onTileClickRef = useRef(onTileClick);
+
+  useEffect(() => {
+    onTileHoverRef.current = onTileHover;
+  }, [onTileHover]);
+
+  useEffect(() => {
+    onTileClickRef.current = onTileClick;
+  }, [onTileClick]);
+
+  const handleTileHover = useCallback((x: number, y: number, tileType?: string) => {
+    onTileHoverRef.current?.(x, y, tileType);
+  }, []);
+
+  const handleTileClick = useCallback((x: number, y: number, tileType?: string) => {
+    onTileClickRef.current?.(x, y, tileType);
+  }, []);
 
   // Convert world coordinates to chunk coordinates (via inverse isometric transform)
   const worldToChunk = useCallback((worldX: number, worldY: number) => {
@@ -349,8 +367,8 @@ export default function ChunkedIsometricGrid({
 
   // Initialize world container
   useEffect(() => {
-    if (!viewport || isInitialized) return;
-    
+    if (!viewport || worldContainerRef.current) return;
+
     const worldContainer = new PIXI.Container();
     worldContainer.name = 'chunked-world';
     worldContainer.sortableChildren = true;
@@ -378,8 +396,8 @@ export default function ChunkedIsometricGrid({
         }
         return 'grass';
       },
-      onTileHover,
-      onTileClick,
+      onTileHover: handleTileHover,
+      onTileClick: handleTileClick,
     });
     
     // Set initial viewport position and zoom
@@ -451,9 +469,7 @@ export default function ChunkedIsometricGrid({
       // NOTE: Do not set state in cleanup to avoid triggering re-renders during effect teardown
       // setIsInitialized(false);
     };
-  // Intentionally exclude onTileHover/onTileClick and isInitialized to avoid re-init/cleanup loops
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [viewport, tileWidth, tileHeight, chunkSize]);
+  }, [viewport, tileWidth, tileHeight, chunkSize, handleTileHover, handleTileClick]);
 
   // Handle viewport changes with throttling
   useEffect(() => {


### PR DESCRIPTION
## Summary
- wrap the ChunkedIsometricGrid tile hover and click props in refs and forwarders so the overlay always invokes the latest callbacks
- gate world container initialization on the PIXI container ref and pass the stabilized handlers to the TileOverlay
- drop the eslint-disable directive now that the effect dependencies are safe to include

## Testing
- npm run lint *(fails: repository has pre-existing lint errors in unrelated files)*
- npm run test
- CI=1 npm run build *(fails: missing NEXT_PUBLIC_SUPABASE env configuration for health/debug API routes)*

------
https://chatgpt.com/codex/tasks/task_e_68c8fb7fb72c83259ae134cf85418cfe