### PR TITLE
Fix blank playground screen by restoring game canvas

### DIFF
--- a/src/components/game/GameRenderer.tsx
+++ b/src/components/game/GameRenderer.tsx
@@ -167,9 +167,21 @@ function GameRendererContent({
 
   return (
     <div ref={containerRef} className="relative w-full h-full bg-gray-900">
-      {/* Grid rendering is now handled by ChunkedIsometricGrid in PlayPageInternal */}
-      {/* Removed GameCanvas and IsometricGrid to prevent flickering from multiple overlapping grid systems */}
-      
+      <GameCanvas
+        width={dims.w}
+        height={dims.h}
+        onTileHover={onTileHover}
+        onTileClick={onTileClick}
+      />
+
+      {gridSize > 0 && (
+        <div className="absolute bottom-4 right-4 hidden sm:block pointer-events-auto">
+          <div className="bg-gray-900/80 border border-gray-700 rounded-lg shadow-lg p-2">
+            <MiniMap gridSize={gridSize} />
+          </div>
+        </div>
+      )}
+
       {showHelp && (
         <div className="absolute top-2 left-2 pointer-events-none">
           <div className="bg-gray-800/90 backdrop-blur-sm border border-gray-700 rounded-lg shadow-md px-3 py-2 text-[11px] sm:text-xs text-gray-200 max-w-xs pointer-events-none">


### PR DESCRIPTION
## Summary
- restore the PIXI game canvas in the playground renderer so the map and HUD can initialize again
- surface the minimap overlay when a grid size is available

## Testing
- `npm run lint` *(fails: existing lint violations in untouched files)*
- `npm run test`
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy-anon-key SUPABASE_URL=http://localhost:54321 SUPABASE_SERVICE_ROLE_KEY=dummy-service-role-key SUPABASE_JWT_SECRET=dummy-jwt-secret CI=1 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c9a9ac470483259f7ea38fb57d5138