### PR TITLE
Render special abilities in constellation tooltip

### DIFF
--- a/src/components/game/skills/ConstellationSkillTree.tsx
+++ b/src/components/game/skills/ConstellationSkillTree.tsx
@@ -14,6 +14,7 @@ import {
   drawParticles,
   drawConnections,
 } from './effects';
+import SkillTooltipContent from './SkillTooltipContent';
 
 export default function ConstellationSkillTree({ tree, unlocked, onUnlock, colorFor, focusNodeId, resources, onSelectNode }: ConstellationSkillTreeProps) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -930,15 +931,15 @@ export default function ConstellationSkillTree({ tree, unlocked, onUnlock, color
       
       {/* Enhanced Tooltip */}
       {tooltip.visible && tooltip.node && (
-        <div 
+        <div
           className={`absolute pointer-events-none z-50 max-w-sm ${
             tooltip.anchor === 'left' ? 'transform -translate-x-full' :
             tooltip.anchor === 'right' ? 'transform translate-x-0' :
             tooltip.anchor === 'top' ? 'transform -translate-y-full' :
             'transform translate-y-0'
           }`}
-          style={{ 
-            left: tooltip.x, 
+          style={{
+            left: tooltip.x,
             top: tooltip.y,
             opacity: tooltip.fadeIn,
             transform: `scale(${0.95 + tooltip.fadeIn * 0.05}) translateZ(0)`,
@@ -946,141 +947,17 @@ export default function ConstellationSkillTree({ tree, unlocked, onUnlock, color
             filter: 'drop-shadow(0 20px 25px rgba(0, 0, 0, 0.4))'
           }}
         >
-          <div className="relative bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 rounded-xl border border-gray-600/50 overflow-hidden">
-            {/* Subtle glow effect */}
-            <div 
-              className="absolute inset-0 rounded-xl opacity-20"
-              style={{ 
-                background: `radial-gradient(circle at 50% 0%, ${colorFor(tooltip.node.category)}40, transparent 70%)` 
-              }}
-            />
-            
-            {/* Content */}
-            <div className="relative p-5">
-              {/* Header */}
-              <div className="flex items-start gap-3 mb-4">
-                <div 
-                  className="w-4 h-4 rounded-full flex-shrink-0 mt-0.5 shadow-lg"
-                  style={{ 
-                    backgroundColor: colorFor(tooltip.node.category),
-                    boxShadow: `0 0 12px ${colorFor(tooltip.node.category)}60`
-                  }}
-                />
-                <div className="flex-1 min-w-0">
-                  <h3 className="text-white font-semibold text-base leading-tight mb-1">
-                    {tooltip.node.title}
-                  </h3>
-                  <div className="text-xs text-gray-400 font-medium uppercase tracking-wider">
-                    {tooltip.node.category}
-                  </div>
-                </div>
-              </div>
-              
-              {/* Description */}
-              <p className="text-gray-300 text-sm leading-relaxed mb-4 font-light">
-                {tooltip.node.description}
-              </p>
-          
-              {/* Effects */}
-              {tooltip.node.effects && tooltip.node.effects.length > 0 && (
-                <div className="mb-4 border-t border-gray-700/50 pt-4">
-                  <h4 className="text-yellow-400 text-sm font-semibold mb-3 flex items-center gap-2">
-                    <span className="w-2 h-2 bg-yellow-400 rounded-full"></span>
-                    Effects
-                  </h4>
-                  <div className="space-y-2">
-                    {tooltip.node.effects.map((effect, i) => {
-                      let effectText = '';
-                      let effectIcon = '⚡';
-                      switch (effect.kind) {
-                        case 'resource_multiplier':
-                          effectText = `+${((effect.factor - 1) * 100).toFixed(0)}% ${effect.resource}`;
-                          effectIcon = '💰';
-                          break;
-                        case 'building_multiplier':
-                          effectText = `+${((effect.factor - 1) * 100).toFixed(0)}% ${effect.typeId}`;
-                          effectIcon = '🏗️';
-                          break;
-                        case 'upkeep_delta':
-                          effectText = `${effect.grainPerWorkerDelta > 0 ? '+' : ''}${effect.grainPerWorkerDelta} grain per worker`;
-                          effectIcon = '🌾';
-                          break;
-                        case 'route_bonus':
-                          effectText = `+${effect.percent}% route efficiency`;
-                          effectIcon = '🛤️';
-                          break;
-                        case 'logistics_bonus':
-                          effectText = `+${effect.percent}% logistics`;
-                          effectIcon = '📦';
-                          break;
-                        case 'special_ability':
-                          effectText = `${effect.description} (Power: ${effect.power})`;
-                          effectIcon = '✨';
-                          break;
-                      }
-                      return (
-                        <div key={i} className="flex items-center gap-3 bg-gray-800/50 rounded-lg px-3 py-2 border border-gray-700/30">
-                          <span className="text-sm">{effectIcon}</span>
-                          <span className="text-green-400 text-sm font-medium flex-1">{effectText}</span>
-                        </div>
-                      );
-                    })}
-                  </div>
-                </div>
-              )}
-          
-          {tooltip.node.requires && tooltip.node.requires.length > 0 && (
-            <div className="mb-2">
-              <h4 className="text-gray-400 text-xs font-medium mb-1">Requirements:</h4>
-              {tooltip.node.requires.map(reqId => {
-                const reqNode = tree.nodes.find(n => n.id === reqId);
-                const isMet = unlocked[reqId];
-                return (
-                  <div key={reqId} className={`text-xs ${
-                    isMet ? 'text-green-400' : 'text-red-400'
-                  }`}>
-                    {isMet ? '✓' : '✗'} {reqNode?.title || reqId}
-                  </div>
-                );
-              })}
-            </div>
-          )}
-
-          {/* Lock reasons (exclusivity and extra conditions) */}
-          {(() => {
-            const { ok, reasons } = checkUnlock(tooltip.node!);
-            if (unlocked[tooltip.node!.id] || ok) return null;
-            return (
-              <div className="mb-2">
-                <h4 className="text-red-400 text-xs font-medium mb-1">Locked:</h4>
-                <ul className="list-disc list-inside">
-                  {reasons.map((r, i) => (
-                    <li key={i} className="text-xs text-red-300">{r}</li>
-                  ))}
-                </ul>
-              </div>
-            );
-          })()}
-          
-          {/* Status indicator with affordability */}
-          <div className="mt-3 pt-2 border-t border-gray-700">
-            {(() => {
-              const ok = checkUnlock(tooltip.node).ok;
-              const isUnl = unlocked[tooltip.node.id];
-              const affordable = canAfford(tooltip.node);
-              const cls = isUnl ? 'text-green-400' : ok ? (affordable ? 'text-yellow-400' : 'text-red-300') : 'text-red-400';
-              const text = isUnl ? '✓ Unlocked' : ok ? (affordable ? '⚡ Available' : '⚡ Available • insufficient funds') : '🔒 Locked';
-              return <div className={`text-xs font-medium ${cls}`}>{text}</div>;
-            })()}
-            <div className="text-xs text-gray-500 mt-1">
-              Category: {tooltip.node.category}
-            </div>
-          </div>
-            </div>
-          </div>
+          <SkillTooltipContent
+            node={tooltip.node}
+            tree={tree}
+            unlocked={unlocked}
+            colorFor={colorFor}
+            checkUnlock={checkUnlock}
+            canAfford={canAfford}
+          />
         </div>
       )}
-      
+
       {/* Enhanced Zoom Controls */}
       <div className="absolute top-4 right-4 flex flex-col gap-2 bg-gray-800/90 backdrop-blur-sm rounded-lg p-2 border border-gray-600">
         <button

--- a/src/components/game/skills/SkillTooltipContent.test.tsx
+++ b/src/components/game/skills/SkillTooltipContent.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import SkillTooltipContent from './SkillTooltipContent';
+import { rollSpecialAbility } from './specialAbilities';
+import type { SkillNode, SkillTree, SpecialAbility } from './types';
+
+describe('SkillTooltipContent', () => {
+  const baseNode: SkillNode = {
+    id: 'skill_test',
+    title: 'Test Node',
+    description: 'Proves that tooltip abilities render correctly.',
+    category: 'economic',
+    rarity: 'rare',
+    quality: 'epic',
+    tags: [],
+    cost: {},
+    baseCost: {},
+    effects: [],
+  };
+
+  const makeProps = (node: SkillNode) => {
+    const tree: SkillTree = { nodes: [node], edges: [] };
+    return {
+      tree,
+      unlocked: {},
+      colorFor: () => '#ffffff',
+      checkUnlock: () => ({ ok: true, reasons: [] }),
+      canAfford: () => true,
+    };
+  };
+
+  it('renders special ability details when provided', () => {
+    const ability = rollSpecialAbility('economic', 'epic', () => 0);
+    const node: SkillNode = { ...baseNode, specialAbility: ability ?? undefined };
+    const markup = renderToStaticMarkup(
+      <SkillTooltipContent
+        node={node}
+        {...makeProps(node)}
+      />,
+    );
+
+    expect(markup).toContain('Special Ability');
+    expect(markup).toContain(ability?.name ?? 'Golden Touch');
+    expect(markup).toContain('Power');
+  });
+
+  it('falls back to catalog flavor text when node ability omits optional fields', () => {
+    const ability = rollSpecialAbility('economic', 'legendary', () => 0);
+    const minimalAbility: SpecialAbility | undefined = ability
+      ? { id: ability.id, name: ability.name, description: ability.description, power: ability.power, quality: ability.quality }
+      : undefined;
+    const node: SkillNode = { ...baseNode, specialAbility: minimalAbility };
+
+    const markup = renderToStaticMarkup(
+      <SkillTooltipContent
+        node={node}
+        {...makeProps(node)}
+      />,
+    );
+
+    expect(markup).toContain('Treasurers whisper of ledgers');
+  });
+});

--- a/src/components/game/skills/SkillTooltipContent.tsx
+++ b/src/components/game/skills/SkillTooltipContent.tsx
@@ -1,0 +1,220 @@
+import React from 'react';
+import { resolveSpecialAbility } from './specialAbilities';
+import type { SkillNode, SkillTree } from './types';
+
+type UnlockCheckResult = { ok: boolean; reasons: string[] };
+
+interface SkillTooltipContentProps {
+  node: SkillNode;
+  tree: SkillTree;
+  unlocked: Record<string, boolean>;
+  colorFor: (category: SkillNode['category']) => string;
+  checkUnlock: (node: SkillNode) => UnlockCheckResult;
+  canAfford: (node: SkillNode) => boolean;
+}
+
+const formatPower = (power: number): string => {
+  const rounded = Number.isInteger(power) ? power.toString() : power.toFixed(2);
+  return rounded.replace(/\.00$/, '');
+};
+
+export default function SkillTooltipContent({
+  node,
+  tree,
+  unlocked,
+  colorFor,
+  checkUnlock,
+  canAfford,
+}: SkillTooltipContentProps) {
+  const accent = colorFor(node.category);
+  const ability = resolveSpecialAbility(node.specialAbility);
+  const unlockState = checkUnlock(node);
+  const isUnlocked = Boolean(unlocked[node.id]);
+  const affordable = canAfford(node);
+
+  return (
+    <div className="relative bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 rounded-xl border border-gray-600/50 overflow-hidden">
+      <div
+        className="absolute inset-0 rounded-xl opacity-20"
+        style={{
+          background: `radial-gradient(circle at 50% 0%, ${accent}40, transparent 70%)`,
+        }}
+      />
+
+      <div className="relative p-5">
+        <div className="flex items-start gap-3 mb-4">
+          <div
+            className="w-4 h-4 rounded-full flex-shrink-0 mt-0.5 shadow-lg"
+            style={{
+              backgroundColor: accent,
+              boxShadow: `0 0 12px ${accent}60`,
+            }}
+          />
+          <div className="flex-1 min-w-0">
+            <h3 className="text-white font-semibold text-base leading-tight mb-1">
+              {node.title}
+            </h3>
+            <div className="text-xs text-gray-400 font-medium uppercase tracking-wider">
+              {node.category}
+            </div>
+          </div>
+        </div>
+
+        <p className="text-gray-300 text-sm leading-relaxed mb-4 font-light">
+          {node.description}
+        </p>
+
+        {ability && (
+          <div className="mb-4 border-t border-gray-700/50 pt-4">
+            <h4 className="text-indigo-300 text-sm font-semibold mb-3 flex items-center gap-2">
+              <span className="text-lg" aria-hidden="true">✨</span>
+              Special Ability
+            </h4>
+            <div className="bg-gray-800/50 rounded-lg border border-indigo-500/20 px-3 py-3">
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex-1 min-w-0">
+                  <div className="text-white text-sm font-semibold truncate" title={ability.name}>
+                    {ability.name}
+                  </div>
+                  <p className="text-gray-300 text-sm mt-1 leading-relaxed">
+                    {ability.description}
+                  </p>
+                  {ability.flavor && (
+                    <p className="text-xs italic text-indigo-200/80 mt-2">
+                      “{ability.flavor}”
+                    </p>
+                  )}
+                </div>
+                <div className="flex flex-col items-end text-xs text-indigo-200 gap-1">
+                  <span className="uppercase tracking-wide font-semibold">
+                    Power {formatPower(ability.power)}
+                  </span>
+                  <span className="px-2 py-0.5 rounded-full bg-indigo-500/20 border border-indigo-400/40 text-[10px] uppercase tracking-wider">
+                    {ability.quality}
+                  </span>
+                </div>
+              </div>
+              {(ability.duration || ability.cooldown) && (
+                <div className="flex flex-wrap gap-2 mt-3 text-[11px] text-indigo-200/80">
+                  {ability.duration && (
+                    <span className="px-2 py-0.5 rounded-full border border-indigo-400/30 bg-indigo-500/10">
+                      Duration: {ability.duration}
+                    </span>
+                  )}
+                  {ability.cooldown && (
+                    <span className="px-2 py-0.5 rounded-full border border-indigo-400/30 bg-indigo-500/10">
+                      Cooldown: {ability.cooldown}
+                    </span>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
+        {node.effects && node.effects.length > 0 && (
+          <div
+            className={`mb-4 pt-4 ${ability ? 'border-t border-gray-700/30' : 'border-t border-gray-700/50'}`}
+          >
+            <h4 className="text-yellow-400 text-sm font-semibold mb-3 flex items-center gap-2">
+              <span className="w-2 h-2 bg-yellow-400 rounded-full" />
+              Effects
+            </h4>
+            <div className="space-y-2">
+              {node.effects.map((effect, i) => {
+                let effectText = '';
+                let effectIcon = '⚡';
+                switch (effect.kind) {
+                  case 'resource_multiplier':
+                    effectText = `+${((effect.factor - 1) * 100).toFixed(0)}% ${effect.resource}`;
+                    effectIcon = '💰';
+                    break;
+                  case 'building_multiplier':
+                    effectText = `+${((effect.factor - 1) * 100).toFixed(0)}% ${effect.typeId}`;
+                    effectIcon = '🏗️';
+                    break;
+                  case 'upkeep_delta':
+                    effectText = `${effect.grainPerWorkerDelta > 0 ? '+' : ''}${effect.grainPerWorkerDelta} grain per worker`;
+                    effectIcon = '🌾';
+                    break;
+                  case 'route_bonus':
+                    effectText = `+${effect.percent}% route efficiency`;
+                    effectIcon = '🛤️';
+                    break;
+                  case 'logistics_bonus':
+                    effectText = `+${effect.percent}% logistics`;
+                    effectIcon = '📦';
+                    break;
+                  case 'special_ability':
+                    effectText = `${effect.description} (Power: ${effect.power})`;
+                    effectIcon = '✨';
+                    break;
+                }
+                return (
+                  <div key={`${node.id}-effect-${i}`} className="flex items-center gap-3 bg-gray-800/50 rounded-lg px-3 py-2 border border-gray-700/30">
+                    <span className="text-sm">{effectIcon}</span>
+                    <span className="text-green-400 text-sm font-medium flex-1">{effectText}</span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {node.requires && node.requires.length > 0 && (
+          <div className="mb-2">
+            <h4 className="text-gray-400 text-xs font-medium mb-1">Requirements:</h4>
+            {node.requires.map(reqId => {
+              const reqNode = tree.nodes.find(n => n.id === reqId);
+              const isMet = unlocked[reqId];
+              return (
+                <div
+                  key={reqId}
+                  className={`text-xs ${isMet ? 'text-green-400' : 'text-red-400'}`}
+                >
+                  {isMet ? '✓' : '✗'} {reqNode?.title || reqId}
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {!isUnlocked && !unlockState.ok && unlockState.reasons.length > 0 && (
+          <div className="mb-2">
+            <h4 className="text-red-400 text-xs font-medium mb-1">Locked:</h4>
+            <ul className="list-disc list-inside">
+              {unlockState.reasons.map((reason, index) => (
+                <li key={`${node.id}-lock-${index}`} className="text-xs text-red-300">
+                  {reason}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <div className="mt-3 pt-2 border-t border-gray-700">
+          <div
+            className={`text-xs font-medium ${
+              isUnlocked
+                ? 'text-green-400'
+                : unlockState.ok
+                  ? affordable
+                    ? 'text-yellow-400'
+                    : 'text-red-300'
+                  : 'text-red-400'
+            }`}
+          >
+            {isUnlocked
+              ? '✓ Unlocked'
+              : unlockState.ok
+                ? affordable
+                  ? '⚡ Available'
+                  : '⚡ Available • insufficient funds'
+                : '🔒 Locked'}
+          </div>
+          <div className="text-xs text-gray-500 mt-1">Category: {node.category}</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/game/skills/generate.ts
+++ b/src/components/game/skills/generate.ts
@@ -7,6 +7,7 @@ import type {
   UnlockCondition,
   SpecialAbility,
 } from './types';
+import { rollSpecialAbility } from './specialAbilities';
 
 // Simple seeded RNG (mulberry32)
 function mulberry32(a: number) {
@@ -106,38 +107,8 @@ export function generateSkillTree(seed = 42, tiers: number = 8): SkillTree {
     }
   };
 
-  const createSpecialAbility = (quality: NodeQuality, category: SkillNode['category']): SpecialAbility | undefined => {
-    if (quality === 'common') return undefined;
-    
-    const abilities: Record<SkillNode['category'], SpecialAbility[]> = {
-      economic: [
-        { id: 'golden_touch', name: 'Golden Touch', description: 'Double coin generation for 5 minutes', power: 2.0, quality },
-        { id: 'market_insight', name: 'Market Insight', description: 'Reveal optimal trade routes', power: 1.5, quality }
-      ],
-      military: [
-        { id: 'battle_fury', name: 'Battle Fury', description: 'Reduce all military costs by 50%', power: 0.5, quality },
-        { id: 'fortress_shield', name: 'Fortress Shield', description: 'Immunity to raids for 10 minutes', power: 0.0, quality }
-      ],
-      mystical: [
-        { id: 'mana_storm', name: 'Mana Storm', description: 'Triple mana generation for 3 minutes', power: 3.0, quality },
-        { id: 'arcane_mastery', name: 'Arcane Mastery', description: 'Unlock hidden mystical nodes', power: 1.0, quality }
-      ],
-      infrastructure: [
-        { id: 'rapid_construction', name: 'Rapid Construction', description: 'Instant building completion', power: 1.0, quality },
-        { id: 'efficiency_boost', name: 'Efficiency Boost', description: 'All buildings produce 50% more', power: 1.5, quality }
-      ],
-      diplomatic: [
-        { id: 'silver_tongue', name: 'Silver Tongue', description: 'Double favor from all sources', power: 2.0, quality },
-        { id: 'peace_treaty', name: 'Peace Treaty', description: 'Eliminate all diplomatic penalties', power: 1.0, quality }
-      ],
-      social: [
-        { id: 'festival_spirit', name: 'Festival Spirit', description: 'Boost all resource generation by 25%', power: 1.25, quality },
-        { id: 'unity_bond', name: 'Unity Bond', description: 'Reduce all costs by 30%', power: 0.7, quality }
-      ]
-    };
-    
-    return pick(rng, abilities[category]);
-  };
+  const createSpecialAbility = (quality: NodeQuality, category: SkillNode['category']): SpecialAbility | undefined =>
+    rollSpecialAbility(category, quality, rng);
 
   // Generate hierarchical tiers with optimized connectivity
   let prevTier: string[] = [];
@@ -450,18 +421,8 @@ export function expandSkillTree(tree: SkillTree, seed: number, moreTiers: number
     const cost = { coin: Math.round(baseCost.coin! * progressiveMultiplier), mana: Math.round(baseCost.mana! * progressiveMultiplier), favor: Math.round(baseCost.favor! * progressiveMultiplier) };
     return { cost, baseCost };
   };
-  const createSpecialAbility = (quality: NodeQuality, category: SkillNode['category']): SpecialAbility | undefined => {
-    if (quality === 'common') return undefined;
-    const abilities: Record<SkillNode['category'], SpecialAbility[]> = {
-      economic: [ { id: 'golden_touch', name: 'Golden Touch', description: 'Double coin generation for 5 minutes', power: 2.0, quality } ],
-      military: [ { id: 'battle_fury', name: 'Battle Fury', description: 'Reduce all military costs by 50%', power: 0.5, quality } ],
-      mystical: [ { id: 'mana_storm', name: 'Mana Storm', description: 'Triple mana generation for 3 minutes', power: 3.0, quality } ],
-      infrastructure: [ { id: 'rapid_construction', name: 'Rapid Construction', description: 'Instant building completion', power: 1.0, quality } ],
-      diplomatic: [ { id: 'silver_tongue', name: 'Silver Tongue', description: 'Double favor from all sources', power: 2.0, quality } ],
-      social: [ { id: 'festival_spirit', name: 'Festival Spirit', description: 'Boost all resource generation by 25%', power: 1.25, quality } ],
-    };
-    return pick(abilities[category]);
-  };
+  const createSpecialAbility = (quality: NodeQuality, category: SkillNode['category']): SpecialAbility | undefined =>
+    rollSpecialAbility(category, quality, rng);
   const makeEffects = (cat: SkillNode['category']): SkillEffect[] => {
     switch (cat) {
       case 'economic': return rng() < 0.5 ? [{ kind: 'resource_multiplier', resource: 'coin', factor: 1.06 + rng() * 0.08 }] : [{ kind: 'route_bonus', percent: 5 + Math.floor(rng() * 10) }];

--- a/src/components/game/skills/specialAbilities.ts
+++ b/src/components/game/skills/specialAbilities.ts
@@ -1,0 +1,181 @@
+import type { NodeQuality, SkillNode, SpecialAbility } from './types';
+
+export interface SpecialAbilityContent {
+  id: string;
+  name: string;
+  description: string;
+  power: number;
+  flavor?: string;
+  duration?: string;
+  cooldown?: string;
+}
+
+const SPECIAL_ABILITIES: Record<SkillNode['category'], SpecialAbilityContent[]> = {
+  economic: [
+    {
+      id: 'golden_touch',
+      name: 'Golden Touch',
+      description: 'Doubles coin generation from all economic buildings for a short time.',
+      power: 2,
+      flavor: 'Treasurers whisper of ledgers that ink themselves in radiant gold.',
+      duration: '5 minutes',
+      cooldown: 'Once per cycle',
+    },
+    {
+      id: 'market_insight',
+      name: 'Market Insight',
+      description: 'Reveals optimal trade routes and grants bonus tariffs while active.',
+      power: 1.5,
+      flavor: 'Scribes chart phantom caravans that never miss a profit.',
+      duration: '3 minutes',
+      cooldown: 'Twice per cycle',
+    },
+  ],
+  military: [
+    {
+      id: 'battle_fury',
+      name: 'Battle Fury',
+      description: 'Halves military upkeep and rallies defenders with renewed vigor.',
+      power: 0.5,
+      flavor: 'Wardens carve runes into shields that burn like sunrise.',
+      duration: '4 minutes',
+      cooldown: 'Once per cycle',
+    },
+    {
+      id: 'fortress_shield',
+      name: 'Fortress Shield',
+      description: 'Projects a barrier that nullifies raids and border incursions temporarily.',
+      power: 0,
+      flavor: 'Citadel walls hum as an astral shell seals every gate.',
+      duration: '10 minutes',
+      cooldown: 'Once per two cycles',
+    },
+  ],
+  mystical: [
+    {
+      id: 'mana_storm',
+      name: 'Mana Storm',
+      description: 'Triples mana generation and awakens latent ley currents.',
+      power: 3,
+      flavor: 'Ley lines arc overhead like chained lightning made patient.',
+      duration: '3 minutes',
+      cooldown: 'Once per cycle',
+    },
+    {
+      id: 'arcane_mastery',
+      name: 'Arcane Mastery',
+      description: 'Reveals hidden mystical nodes and grants a scrying boon.',
+      power: 1,
+      flavor: 'Mystics taste the ozone tang of secrets clawing into the light.',
+      duration: 'Until next unlock',
+      cooldown: 'Thrice per cycle',
+    },
+  ],
+  infrastructure: [
+    {
+      id: 'rapid_construction',
+      name: 'Rapid Construction',
+      description: 'Completes all queued infrastructure instantly at no extra cost.',
+      power: 1,
+      flavor: 'Builder crews move as if tomorrow already happened.',
+      duration: 'Instant',
+      cooldown: 'Once per cycle',
+    },
+    {
+      id: 'efficiency_boost',
+      name: 'Efficiency Boost',
+      description: 'Increases all building output substantially while the boon persists.',
+      power: 1.5,
+      flavor: 'Gearworks spin with a bright, orderly hymn.',
+      duration: '6 minutes',
+      cooldown: 'Twice per cycle',
+    },
+  ],
+  diplomatic: [
+    {
+      id: 'silver_tongue',
+      name: 'Silver Tongue',
+      description: 'Doubles favor gains from treaties, festivals, and emissaries.',
+      power: 2,
+      flavor: 'Envoys speak in mirrored phrases that charm every hall.',
+      duration: '5 minutes',
+      cooldown: 'Once per cycle',
+    },
+    {
+      id: 'peace_treaty',
+      name: 'Peace Treaty',
+      description: 'Eliminates all diplomatic penalties and unrest from foreign agents temporarily.',
+      power: 1,
+      flavor: 'Scrolls seal themselves with wax that never cools.',
+      duration: '8 minutes',
+      cooldown: 'Once per two cycles',
+    },
+  ],
+  social: [
+    {
+      id: 'festival_spirit',
+      name: 'Festival Spirit',
+      description: 'Boosts all resource generation across the city as celebrations erupt.',
+      power: 1.25,
+      flavor: 'Lanterns bloom in the streets, warming grain stores and hearts alike.',
+      duration: '4 minutes',
+      cooldown: 'Twice per cycle',
+    },
+    {
+      id: 'unity_bond',
+      name: 'Unity Bond',
+      description: 'Reduces every cost by invoking collective guild stewardship.',
+      power: 0.7,
+      flavor: 'Councilors clasp hands as silver threads stitch every guild crest.',
+      duration: '5 minutes',
+      cooldown: 'Once per cycle',
+    },
+  ],
+};
+
+const SPECIAL_ABILITIES_BY_ID = new Map<string, SpecialAbilityContent>();
+for (const list of Object.values(SPECIAL_ABILITIES)) {
+  for (const ability of list) {
+    SPECIAL_ABILITIES_BY_ID.set(ability.id, ability);
+  }
+}
+
+export const specialAbilityCatalog = SPECIAL_ABILITIES;
+
+export function rollSpecialAbility(
+  category: SkillNode['category'],
+  quality: NodeQuality,
+  rng: () => number,
+): SpecialAbility | undefined {
+  if (quality === 'common') return undefined;
+  const options = SPECIAL_ABILITIES[category];
+  if (!options || options.length === 0) return undefined;
+  const selection = options[Math.floor(rng() * options.length)];
+  return {
+    ...selection,
+    quality,
+  };
+}
+
+export function resolveSpecialAbility(
+  ability: SpecialAbility | undefined | null,
+): (SpecialAbility & SpecialAbilityContent) | undefined {
+  if (!ability) return undefined;
+  const catalogEntry = SPECIAL_ABILITIES_BY_ID.get(ability.id);
+  if (!catalogEntry) {
+    return ability;
+  }
+  return {
+    ...catalogEntry,
+    ...ability,
+    description: ability.description || catalogEntry.description,
+    flavor: ability.flavor ?? catalogEntry.flavor,
+    duration: ability.duration ?? catalogEntry.duration,
+    cooldown: ability.cooldown ?? catalogEntry.cooldown,
+    quality: ability.quality,
+  };
+}
+
+export function getSpecialAbilityContent(id: string): SpecialAbilityContent | undefined {
+  return SPECIAL_ABILITIES_BY_ID.get(id);
+}

--- a/src/components/game/skills/types.ts
+++ b/src/components/game/skills/types.ts
@@ -14,6 +14,9 @@ export interface SpecialAbility {
   description: string;
   power: number;
   quality: NodeQuality;
+  flavor?: string;
+  duration?: string;
+  cooldown?: string;
 }
 
 export interface SkillNode {


### PR DESCRIPTION
## Summary
- centralize the special ability catalog and helpers so the generator and UI share consistent metadata
- swap the inline tooltip markup for a dedicated `SkillTooltipContent` component that surfaces ability power, flavor, and duration alongside standard effects
- add a focused unit test to lock in the special-ability section of the tooltip

## Testing
- npm run lint *(fails: pre-existing lint errors across engine and HUD files)*
- npm run test
- npm run build *(fails: missing NEXT_PUBLIC_SUPABASE env when collecting /api/debug page data)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b0ebe9c0832584914d349119d756