### PR TITLE
Align mini map with actual map dimensions

### DIFF
--- a/src/components/game/hud/PanelComposer.tsx
+++ b/src/components/game/hud/PanelComposer.tsx
@@ -4,7 +4,7 @@ import { useHUDLayoutPresets } from './HUDLayoutPresets';
 import { ModularResourcePanel } from './panels/ModularResourcePanel';
 import { TimeControlPanel } from '../TimeControlPanel';
 import { ModularActionPanel } from './panels/ModularActionPanel';
-import { ModularMiniMapPanel } from './panels/ModularMiniMapPanel';
+import { ModularMiniMapPanel, type MiniMapDescriptor } from './panels/ModularMiniMapPanel';
 import { ModularSkillTreePanel } from './panels/ModularSkillTreePanel';
 import CityManagementPanel, {
   CityStats,
@@ -65,6 +65,7 @@ export interface PanelComposerProps {
   };
   onGameAction: (action: string, data?: unknown) => void;
   className?: string;
+  map?: MiniMapDescriptor;
 }
 
 export function PanelComposer({
@@ -72,6 +73,7 @@ export function PanelComposer({
   gameData,
   onGameAction,
   cityManagement,
+  map,
   className = '',
 }: PanelComposerProps) {
   const { currentPreset } = useHUDLayoutPresets();
@@ -144,7 +146,7 @@ export function PanelComposer({
         <div className="mt-2" />
         <TimeControlPanel className="w-full" />
         <div className="mt-2" />
-        <ModularMiniMapPanel gridSize={20} />
+        <ModularMiniMapPanel map={map} />
         <div className="mt-2" />
         <ModularActionPanel
           onOpenCouncil={() => onGameAction('open-council')}


### PR DESCRIPTION
## Summary
- add an optional map descriptor to the HUD panel composer so callers can forward real map sizing metadata to the mini map panel
- normalize the mini map panel’s configuration so registration, recentering, and follow-selection logic use the provided grid and tile dimensions
- provide the play page’s actual grid size and tile constants to the HUD, reusing them for the click dispatch so the mini map matches the rendered field

## Testing
- npm run lint *(fails: repository already has numerous lint errors such as @typescript-eslint/no-explicit-any in engine packages)*
- npm run test
- npm run build *(fails: Next.js build requires NEXT_PUBLIC_SUPABASE_URL for /api/debug route)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b2f30ee88325a9b4d9d8336a5f1c