### PR TITLE
Extract hook for skill tree frontier expansion

### DIFF
--- a/src/components/game/skills/useSkillTreeFrontierExpansion.ts
+++ b/src/components/game/skills/useSkillTreeFrontierExpansion.ts
@@ -1,0 +1,67 @@
+import { useEffect, useRef, type Dispatch, type SetStateAction } from 'react';
+import { expandSkillTree } from './generate';
+import type { SkillTree } from './types';
+
+interface UseSkillTreeFrontierExpansionOptions {
+  tree: SkillTree;
+  selectedNodeId: string | null;
+  seed: number;
+  setTree: Dispatch<SetStateAction<SkillTree>>;
+  tiersToAdd?: number;
+  frontierBuffer?: number;
+}
+
+export function useSkillTreeFrontierExpansion({
+  tree,
+  selectedNodeId,
+  seed,
+  setTree,
+  tiersToAdd = 4,
+  frontierBuffer = 2,
+}: UseSkillTreeFrontierExpansionOptions) {
+  const lastExpandedMaxTierRef = useRef<number | null>(null);
+  const layoutMaxTier = tree.layout?.maxTier ?? null;
+
+  useEffect(() => {
+    if (!selectedNodeId || layoutMaxTier === null) return;
+
+    const selected = tree.nodes.find(n => n.id === selectedNodeId);
+    if (!selected || typeof selected.tier !== 'number') return;
+
+    const nearFrontier = selected.tier >= layoutMaxTier - frontierBuffer;
+    if (!nearFrontier) return;
+
+    if (lastExpandedMaxTierRef.current === layoutMaxTier) return;
+    lastExpandedMaxTierRef.current = layoutMaxTier;
+
+    setTree(prev => {
+      if (!prev.layout) return prev;
+
+      const layoutClone = {
+        ...prev.layout,
+        tiers: { ...prev.layout.tiers },
+        categoryDistribution: Object.fromEntries(
+          Object.entries(prev.layout.categoryDistribution).map(([key, value]) => [key, [...value]])
+        ) as Record<string, number[]>,
+        maxTier: typeof prev.layout.maxTier === 'number' ? prev.layout.maxTier : 0,
+      };
+
+      return expandSkillTree(
+        {
+          ...prev,
+          nodes: [...prev.nodes],
+          edges: [...prev.edges],
+          layout: layoutClone,
+        },
+        seed,
+        tiersToAdd,
+      );
+    });
+  }, [selectedNodeId, layoutMaxTier, tree.nodes, seed, frontierBuffer, tiersToAdd, setTree]);
+
+  useEffect(() => {
+    if (layoutMaxTier === null) {
+      lastExpandedMaxTierRef.current = null;
+    }
+  }, [layoutMaxTier]);
+}


### PR DESCRIPTION
## Summary
- extract the frontier detection and expansion logic into a dedicated `useSkillTreeFrontierExpansion` hook that immutably clones the tree and guards duplicate triggers
- consume the new hook inside `SkillTreeModal` to replace the inline effect and keep the component leaner

## Testing
- `npm run lint` *(fails: existing lint errors in unrelated files)*
- `npm run test`
- `CI=1 NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=test SUPABASE_URL=http://localhost SUPABASE_SERVICE_ROLE_KEY=test SUPABASE_JWT_SECRET=test npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c9b0ea96288325ad0d48e4fb81398a