### PR TITLE
Align HUD speed payload with PlayPage

### DIFF
--- a/src/app/play/PlayPageInternal.tsx
+++ b/src/app/play/PlayPageInternal.tsx
@@ -54,7 +54,8 @@ import type { GameResources, GameTime } from '@/components/game/hud/types';
 import type { CategoryType } from '@arcane/ui';
 import { simulationSystem, EnhancedGameState } from '@engine'
 import { VisualIndicator } from '@engine';
-import { TimeSystem, timeSystem, TIME_SPEEDS, type TimeSpeed, GameTime as SystemGameTime } from '@engine';
+import { TimeSystem, timeSystem, TIME_SPEEDS, GameTime as SystemGameTime } from '@engine';
+import { intervalMsToTimeSpeed, sanitizeIntervalMs } from './timeSpeedUtils';
 
 type BuildTypeId = keyof typeof SIM_BUILDINGS;
 
@@ -1739,23 +1740,28 @@ export default function PlayPage({ initialState = null, initialProposals = [] }:
               }
               if (action === 'set-speed') {
                 if (!state) return;
-                // Map speed payload to TIME_SPEEDS constants
-                const speedMap: Record<string, TimeSpeed> = { 
-                  '1': TIME_SPEEDS.NORMAL, 
-                  '2': TIME_SPEEDS.FAST, 
-                  '3': TIME_SPEEDS.VERY_FAST,
-                  '4': TIME_SPEEDS.ULTRA_FAST,
-                  '5': TIME_SPEEDS.HYPER_SPEED
-                };
-                const speed = speedMap[payload?.speed] || TIME_SPEEDS.NORMAL;
-                timeSystem.setSpeed(speed);
-                // Keep backward compatibility with server - faster speeds need shorter intervals
-                const ms = speed === TIME_SPEEDS.NORMAL ? 12000 : 
-                          speed === TIME_SPEEDS.FAST ? 6000 : 
-                          speed === TIME_SPEEDS.VERY_FAST ? 3000 :
-                          speed === TIME_SPEEDS.ULTRA_FAST ? 1500 : 600;
-                void fetch('/api/state', { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ id: state.id, tick_interval_ms: ms }) });
-                setState(prev => prev ? { ...prev, tick_interval_ms: ms } as any : prev);
+                const rawPayload = payload && typeof payload === 'object' ? payload : null;
+                const requestedMs = rawPayload && 'intervalMs' in rawPayload
+                  ? (rawPayload as { intervalMs?: unknown }).intervalMs
+                  : rawPayload && 'ms' in rawPayload
+                    ? (rawPayload as { ms?: unknown }).ms
+                    : null;
+                const sanitizedMs = sanitizeIntervalMs(requestedMs);
+                if (sanitizedMs == null) {
+                  logger.warn('Ignoring invalid speed payload', payload);
+                  return;
+                }
+
+                const nextSpeed = intervalMsToTimeSpeed(sanitizedMs);
+                timeSystem.setSpeed(nextSpeed);
+
+                setState(prev => (prev ? { ...prev, tick_interval_ms: sanitizedMs } as any : prev));
+
+                void fetch('/api/state', {
+                  method: 'PATCH',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({ id: state.id, tick_interval_ms: sanitizedMs })
+                });
               }
               if (action === 'open-council') setIsCouncilOpen(true);
               if (action === 'open-edicts') setIsEdictsOpen(true);

--- a/src/app/play/__tests__/timeSpeedUtils.test.tsx
+++ b/src/app/play/__tests__/timeSpeedUtils.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { describe, expect, it, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+
+import ModularActionPanel from '../../../components/game/hud/panels/ModularActionPanel';
+import { HUDLayoutProvider } from '../../../components/game/hud/HUDLayoutSystem';
+import { HUDPanelRegistryProvider } from '../../../components/game/hud/HUDPanelRegistry';
+import { intervalMsToTimeSpeed, sanitizeIntervalMs } from '../timeSpeedUtils';
+import { TIME_SPEEDS } from '@engine';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const originalInnerWidth = window.innerWidth;
+const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+
+beforeAll(() => {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: 1440,
+  });
+
+  if (!globalThis.requestAnimationFrame) {
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      return setTimeout(() => cb(performance.now()), 0) as unknown as number;
+    }) as typeof globalThis.requestAnimationFrame;
+  }
+
+  if (!globalThis.cancelAnimationFrame) {
+    globalThis.cancelAnimationFrame = ((id: number) => {
+      clearTimeout(id);
+    }) as typeof globalThis.cancelAnimationFrame;
+  }
+});
+
+afterAll(() => {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: originalInnerWidth,
+  });
+
+  Object.defineProperty(globalThis, 'requestAnimationFrame', {
+    configurable: true,
+    writable: true,
+    value: originalRequestAnimationFrame,
+  });
+
+  Object.defineProperty(globalThis, 'cancelAnimationFrame', {
+    configurable: true,
+    writable: true,
+    value: originalCancelAnimationFrame,
+  });
+});
+
+describe('timeSpeedUtils', () => {
+  it('sanitizes interval milliseconds from various inputs', () => {
+    expect(sanitizeIntervalMs(60000.4)).toBe(60000);
+    expect(sanitizeIntervalMs('45000')).toBe(45000);
+    expect(sanitizeIntervalMs(0)).toBeNull();
+    expect(sanitizeIntervalMs(-10)).toBeNull();
+    expect(sanitizeIntervalMs(Number.NaN)).toBeNull();
+  });
+
+  it('maps intervals to the nearest TimeSpeed tier', () => {
+    expect(intervalMsToTimeSpeed(120000)).toBe(TIME_SPEEDS.NORMAL);
+    expect(intervalMsToTimeSpeed(60000)).toBe(TIME_SPEEDS.NORMAL);
+    expect(intervalMsToTimeSpeed(30000)).toBe(TIME_SPEEDS.FAST);
+    expect(intervalMsToTimeSpeed(15000)).toBe(TIME_SPEEDS.VERY_FAST);
+    expect(intervalMsToTimeSpeed(7000)).toBe(TIME_SPEEDS.ULTRA_FAST);
+    expect(intervalMsToTimeSpeed(2000)).toBe(TIME_SPEEDS.HYPER_SPEED);
+    expect(intervalMsToTimeSpeed(-1)).toBe(TIME_SPEEDS.NORMAL);
+  });
+});
+
+describe('ModularActionPanel speed controls', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let currentInterval = 60000;
+  const recorded: number[] = [];
+
+  const handleChange = (ms: number) => {
+    recorded.push(ms);
+    currentInterval = ms;
+  };
+
+  const renderPanel = () => {
+    root.render(
+      <HUDLayoutProvider layoutPreset="compact">
+        <HUDPanelRegistryProvider>
+          <ModularActionPanel intervalMs={currentInterval} onChangeIntervalMs={handleChange} />
+        </HUDPanelRegistryProvider>
+      </HUDLayoutProvider>,
+    );
+  };
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    currentInterval = 60000;
+    recorded.length = 0;
+    act(renderPanel);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('cycles through all preset intervals when the speed chip is clicked', () => {
+    const expected = [30000, 15000, 120000, 60000];
+
+    for (let i = 0; i < expected.length; i += 1) {
+      const chip = container.querySelector('button[aria-label="Cycle simulation speed"]');
+      expect(chip).toBeTruthy();
+      act(() => {
+        chip!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+      act(renderPanel);
+    }
+
+    expect(recorded).toEqual(expected);
+  });
+});

--- a/src/app/play/timeSpeedUtils.ts
+++ b/src/app/play/timeSpeedUtils.ts
@@ -1,0 +1,44 @@
+import { TIME_SPEEDS, type TimeSpeed } from '@engine';
+
+const BASE_INTERVAL_MS = 60000;
+
+const SPEED_RATIO_TARGETS: Array<{ speed: TimeSpeed; ratio: number }> = [
+  { speed: TIME_SPEEDS.NORMAL, ratio: 1 },
+  { speed: TIME_SPEEDS.FAST, ratio: 2 },
+  { speed: TIME_SPEEDS.VERY_FAST, ratio: 4 },
+  { speed: TIME_SPEEDS.ULTRA_FAST, ratio: 8 },
+  { speed: TIME_SPEEDS.HYPER_SPEED, ratio: 20 },
+];
+
+export function sanitizeIntervalMs(value: unknown): number | null {
+  const numeric = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(numeric)) {
+    return null;
+  }
+  const rounded = Math.round(numeric);
+  if (rounded <= 0) {
+    return null;
+  }
+  return rounded;
+}
+
+export function intervalMsToTimeSpeed(intervalMs: number): TimeSpeed {
+  if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
+    return TIME_SPEEDS.NORMAL;
+  }
+
+  const ratio = BASE_INTERVAL_MS / intervalMs;
+
+  let closest = SPEED_RATIO_TARGETS[0];
+  let smallestDelta = Number.POSITIVE_INFINITY;
+
+  for (const candidate of SPEED_RATIO_TARGETS) {
+    const delta = Math.abs(candidate.ratio - ratio);
+    if (delta < smallestDelta) {
+      smallestDelta = delta;
+      closest = candidate;
+    }
+  }
+
+  return closest.speed;
+}

--- a/src/components/game/hud/PanelComposer.tsx
+++ b/src/components/game/hud/PanelComposer.tsx
@@ -152,7 +152,9 @@ export function PanelComposer({
           onOpenOmens={() => onGameAction('open-omens')}
           onOpenSettings={() => onGameAction('open-settings')}
           intervalMs={gameData.time.intervalMs}
-          onChangeIntervalMs={(ms) => onGameAction('set-speed', { ms })}
+          onChangeIntervalMs={(ms) =>
+            onGameAction('set-speed', { intervalMs: ms, ms })
+          }
           variant={currentPreset.panelVariants['action-panel'] || 'default'}
         />
         <div className="mt-2" />


### PR DESCRIPTION
## Summary
- update the HUD speed chip to send the intervalMs payload expected by the play page
- sanitize and translate the set-speed action in PlayPageInternal using a shared helper before persisting the requested tick interval
- add a reusable interval-to-speed utility with regression tests that cover both the helper and the action panel cycling behaviour

## Testing
- `npm run lint` *(fails: repository contains pre-existing lint errors outside the touched files)*
- `npx eslint src/app/play/timeSpeedUtils.ts src/app/play/__tests__/timeSpeedUtils.test.tsx src/components/game/hud/PanelComposer.tsx`
- `npm run test`
- `npm run build` *(fails: missing NEXT_PUBLIC_SUPABASE_URL configuration for /api/debug during data collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b168ea8483258edb4eea60730285