### PR TITLE
Refactor HUD time control to use instance callbacks

### DIFF
--- a/src/components/game/hud/IntegratedHUDSystem.tsx
+++ b/src/components/game/hud/IntegratedHUDSystem.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import HUDProviders from './providers';
 import { PanelComposer, PanelComposerProps } from './PanelComposer';
+import { TimeSystem, TIME_SPEEDS, type TimeSpeed } from '@engine';
 
 export interface IntegratedHUDSystemProps extends PanelComposerProps {
   defaultPreset?: string;
@@ -21,7 +22,14 @@ export default IntegratedHUDSystem;
 
 // Example component for demo purposes
 export function HUDSystemExample() {
-  const mockGameData = {
+  const timeSystemRef = useRef<TimeSystem | null>(null);
+  if (!timeSystemRef.current) {
+    timeSystemRef.current = new TimeSystem();
+    timeSystemRef.current.start();
+  }
+  const timeSystem = timeSystemRef.current;
+
+  const [mockGameData, setMockGameData] = useState(() => ({
     resources: {
       grain: 100,
       coin: 50,
@@ -30,7 +38,7 @@ export function HUDSystemExample() {
       wood: 75,
       planks: 30,
       unrest: 5,
-      threat: 2
+      threat: 2,
     },
     resourceChanges: {
       grain: 2,
@@ -40,28 +48,126 @@ export function HUDSystemExample() {
       wood: 1,
       planks: 0,
       unrest: 0,
-      threat: 0
+      threat: 0,
     },
     workforce: {
       total: 100,
       idle: 20,
-      needed: 10
+      needed: 10,
     },
     time: {
       cycle: 1,
       season: 'Spring',
       timeRemaining: 30,
-      isPaused: false
+      isPaused: false,
+      intervalMs: 60000,
+    },
+  }));
+
+  const lastActiveSpeedRef = useRef<TimeSpeed>(
+    timeSystem?.isPaused() ? TIME_SPEEDS.NORMAL : timeSystem?.getCurrentSpeed() ?? TIME_SPEEDS.NORMAL,
+  );
+
+  const speedValues = useMemo(() => new Set<number>(Object.values(TIME_SPEEDS)), []);
+
+  useEffect(() => {
+    return () => {
+      timeSystemRef.current?.destroy();
+    };
+  }, []);
+
+  const setTimeState = (updates: Partial<typeof mockGameData.time>) => {
+    setMockGameData(prev => ({
+      ...prev,
+      time: {
+        ...prev.time,
+        ...updates,
+      },
+    }));
+  };
+
+  const getIntervalForSpeed = (speed: TimeSpeed): number => {
+    switch (speed) {
+      case TIME_SPEEDS.FAST:
+        return 6000;
+      case TIME_SPEEDS.VERY_FAST:
+        return 3000;
+      case TIME_SPEEDS.ULTRA_FAST:
+        return 1500;
+      case TIME_SPEEDS.HYPER_SPEED:
+        return 600;
+      default:
+        return 12000;
     }
   };
 
+  const parseSpeed = (value: unknown): TimeSpeed | null => {
+    if (typeof value === 'number' && speedValues.has(value)) {
+      return value as TimeSpeed;
+    }
+    if (typeof value === 'string') {
+      const numeric = Number(value);
+      if (!Number.isNaN(numeric) && speedValues.has(numeric)) {
+        return numeric as TimeSpeed;
+      }
+    }
+    return null;
+  };
+
   const handleGameAction = (action: string, data?: unknown) => {
+    if (!timeSystem) {
+      return;
+    }
+
+    const ensureActiveSpeed = () => {
+      const current = timeSystem.getCurrentSpeed();
+      if (current !== TIME_SPEEDS.PAUSED) {
+        lastActiveSpeedRef.current = current;
+      }
+    };
+
+    if (action === 'pause') {
+      ensureActiveSpeed();
+      timeSystem.setSpeed(TIME_SPEEDS.PAUSED);
+      setTimeState({ isPaused: true });
+      return;
+    }
+
+    if (action === 'resume') {
+      const resumeSpeed = lastActiveSpeedRef.current ?? TIME_SPEEDS.NORMAL;
+      timeSystem.setSpeed(resumeSpeed);
+      setTimeState({ isPaused: false, intervalMs: getIntervalForSpeed(resumeSpeed) });
+      return;
+    }
+
+    if (action === 'set-speed') {
+      const requested = parseSpeed((data as { speed?: unknown } | undefined)?.speed);
+      if (requested == null) {
+        return;
+      }
+      if (requested === TIME_SPEEDS.PAUSED) {
+        ensureActiveSpeed();
+        timeSystem.setSpeed(TIME_SPEEDS.PAUSED);
+        setTimeState({ isPaused: true });
+        return;
+      }
+      lastActiveSpeedRef.current = requested;
+      timeSystem.setSpeed(requested);
+      setTimeState({ isPaused: false, intervalMs: getIntervalForSpeed(requested) });
+      return;
+    }
+
     console.log('Game action:', action, data);
   };
+
+  if (!timeSystem) {
+    return null;
+  }
 
   return (
     <IntegratedHUDSystem
       defaultPreset="default"
+      timeSystem={timeSystem}
       gameData={mockGameData}
       onGameAction={handleGameAction}
       className="w-full h-screen"

--- a/src/components/game/hud/PanelComposer.tsx
+++ b/src/components/game/hud/PanelComposer.tsx
@@ -12,6 +12,7 @@ import CityManagementPanel, {
   ZoneType,
   ServiceType,
 } from '../CityManagementPanel';
+import type { TimeSystem, TimeSpeed } from '@engine';
 
 export interface PanelComposerProps {
   children?: ReactNode;
@@ -65,6 +66,7 @@ export interface PanelComposerProps {
   };
   onGameAction: (action: string, data?: unknown) => void;
   className?: string;
+  timeSystem: TimeSystem;
 }
 
 export function PanelComposer({
@@ -72,6 +74,7 @@ export function PanelComposer({
   gameData,
   onGameAction,
   cityManagement,
+  timeSystem,
   className = '',
 }: PanelComposerProps) {
   const { currentPreset } = useHUDLayoutPresets();
@@ -142,7 +145,13 @@ export function PanelComposer({
           />
         )}
         <div className="mt-2" />
-        <TimeControlPanel className="w-full" />
+        <TimeControlPanel
+          className="w-full"
+          timeSystem={timeSystem}
+          onPause={() => onGameAction('pause')}
+          onResume={() => onGameAction('resume')}
+          onSetSpeed={(speed: TimeSpeed) => onGameAction('set-speed', { speed })}
+        />
         <div className="mt-2" />
         <ModularMiniMapPanel gridSize={20} />
         <div className="mt-2" />


### PR DESCRIPTION
## Summary
- refactor `TimeControlPanel` to consume a provided `TimeSystem` instance and surface pause/resume/speed callbacks
- update the HUD composer and integrated HUD example to forward the active time system and relay user actions through the existing onGameAction contract
- wire `PlayPageInternal` to manage its local `TimeSystem`, translating HUD events into simulation changes and persisted tick interval updates

## Testing
- `npm run lint` *(fails: repository already contains hundreds of pre-existing lint errors in engine and HUD modules)*
- `npm run test`
- `npm run build` *(fails: Next.js build requires NEXT_PUBLIC_SUPABASE_URL / related env for /api/debug route)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b16b55dc83258d1432a433b09cd8