### PR TITLE
Fix skill unlock cap enforcement

### DIFF
--- a/src/components/game/hud/panels/ModularSkillTreePanel.tsx
+++ b/src/components/game/hud/panels/ModularSkillTreePanel.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { ResponsivePanel, ResponsiveButton } from '../ResponsiveHUDPanels';
 import { useHUDPanel } from '../HUDPanelRegistry';
 import { generateSkillTree } from '../../skills/generate';
 import type { SkillNode } from '../../skills/types';
+import { collectUnlockBlockers } from '../../skills/unlock';
 import SkillTreeModal from '../../skills/SkillTreeModal';
 
 interface ModularSkillTreePanelProps {
@@ -46,35 +47,10 @@ export function ModularSkillTreePanel({ seed = 12345, onUnlock, variant = 'compa
     try { localStorage.setItem('ad_skills_unlocked', JSON.stringify(unlocked)); } catch {}
   }, [unlocked]);
 
-  const canUnlock = (n: SkillNode) => {
-    // prerequisites
-    if ((n.requires || []).some(r => !unlocked[r])) return false;
-    // exclusivity
-    if (n.exclusiveGroup) {
-      const taken = tree.nodes.find(x => x.exclusiveGroup === n.exclusiveGroup && x.id !== n.id && unlocked[x.id]);
-      if (taken) return false;
-    }
-    // extra conditions
-    if (n.unlockConditions && n.unlockConditions.length) {
-      const unlockedIds = Object.keys(unlocked).filter(k => unlocked[k]);
-      const byCat: Record<SkillNode['category'], number> = { economic:0,military:0,mystical:0,infrastructure:0,diplomatic:0,social:0 };
-      unlockedIds.forEach(id => {
-        const node = tree.nodes.find(nn => nn.id === id);
-        if (node) byCat[node.category] = (byCat[node.category] || 0) + 1;
-      });
-      const highestTier = unlockedIds.reduce((m, id) => {
-        const node = tree.nodes.find(nn => nn.id === id);
-        return node && typeof node.tier === 'number' ? Math.max(m, node.tier) : m;
-      }, -1);
-      for (const cond of n.unlockConditions) {
-        if (cond.type === 'min_unlocked' && unlockedIds.length < cond.value) return false;
-        if (cond.type === 'category_unlocked_at_least' && (byCat[cond.category] || 0) < cond.value) return false;
-        if (cond.type === 'max_unlocked_in_category' && (byCat[cond.category] || 0) > cond.value) return false;
-        if (cond.type === 'tier_before_required' && highestTier < cond.tier) return false;
-      }
-    }
-    return true;
-  };
+  const canUnlock = useCallback(
+    (n: SkillNode) => collectUnlockBlockers({ node: n, unlocked, nodes: tree.nodes }).length === 0,
+    [tree, unlocked],
+  );
 
   const handleUnlock = (n: SkillNode) => {
     if (!canUnlock(n)) return;
@@ -82,7 +58,10 @@ export function ModularSkillTreePanel({ seed = 12345, onUnlock, variant = 'compa
     setUnlocked(prev => ({ ...prev, [n.id]: true }));
   };
 
-  const available = useMemo(() => tree.nodes.filter(n => canUnlock(n) && !unlocked[n.id]), [tree, unlocked]);
+  const available = useMemo(
+    () => tree.nodes.filter(n => canUnlock(n) && !unlocked[n.id]),
+    [tree, unlocked, canUnlock],
+  );
   const unlockedCount = useMemo(() => Object.values(unlocked).filter(Boolean).length, [unlocked]);
   const filtered = useMemo(() => {
     const base = available.filter(n => categoryFilter[n.category]);

--- a/src/components/game/skills/ConstellationSkillTree.tsx
+++ b/src/components/game/skills/ConstellationSkillTree.tsx
@@ -15,6 +15,7 @@ import {
   drawConnections,
 } from './effects';
 import SkillTooltipContent from './SkillTooltipContent';
+import { collectUnlockBlockers } from './unlock';
 
 export default function ConstellationSkillTree({ tree, unlocked, onUnlock, colorFor, focusNodeId, resources, onSelectNode }: ConstellationSkillTreeProps) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -170,35 +171,7 @@ export default function ConstellationSkillTree({ tree, unlocked, onUnlock, color
 
   // Unified unlock check with exclusivity and additional conditions
   const checkUnlock = useCallback((node: SkillNode) => {
-    const reasons: string[] = [];
-    if (node.requires && node.requires.length > 0) {
-      node.requires.forEach((reqId) => {
-        if (!unlocked[reqId]) {
-          const title = tree.nodes.find(n => n.id === reqId)?.title || reqId;
-          reasons.push(`Requires: ${title}`);
-        }
-      });
-    }
-    if (node.exclusiveGroup) {
-      const group = node.exclusiveGroup;
-      const taken = tree.nodes.find(
-        n => n.exclusiveGroup === group && n.id !== node.id && unlocked[n.id],
-      );
-      if (taken) reasons.push(`Path chosen: ${taken.title}`);
-    }
-    if (node.unlockConditions && node.unlockConditions.length > 0) {
-      const unlockConditions = node.unlockConditions;
-      const unlockedIds = Object.keys(unlocked).filter(k => unlocked[k]);
-      const byCat: Record<SkillNode['category'], number> = { economic:0,military:0,mystical:0,infrastructure:0,diplomatic:0,social:0 };
-      unlockedIds.forEach(id => { const n = tree.nodes.find(nn => nn.id === id); if (n) byCat[n.category] = (byCat[n.category]||0)+1; });
-      const highestTier = unlockedIds.reduce((m, id) => { const n = tree.nodes.find(nn => nn.id === id); return n && typeof n.tier === 'number' ? Math.max(m, n.tier) : m; }, -1);
-      unlockConditions.forEach(cond => {
-        if (cond.type === 'min_unlocked' && unlockedIds.length < cond.value) reasons.push(`Unlock at least ${cond.value} skills`);
-        if (cond.type === 'category_unlocked_at_least' && (byCat[cond.category]||0) < cond.value) reasons.push(`Unlock ${cond.value} ${cond.category} skills`);
-        if (cond.type === 'max_unlocked_in_category' && (byCat[cond.category]||0) > cond.value) reasons.push(`Too many in ${cond.category}: max ${cond.value}`);
-        if (cond.type === 'tier_before_required' && highestTier < cond.tier) reasons.push(`Reach tier ${cond.tier} first`);
-      });
-    }
+    const reasons = collectUnlockBlockers({ node, unlocked, nodes: tree.nodes });
     return { ok: reasons.length === 0, reasons };
   }, [tree.nodes, unlocked]);
 

--- a/src/components/game/skills/unlock.test.ts
+++ b/src/components/game/skills/unlock.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { collectUnlockBlockers } from './unlock';
+import type { SkillNode } from './types';
+
+const makeNode = (id: string, overrides: Partial<SkillNode> = {}): SkillNode => ({
+  id,
+  title: `Node ${id}`,
+  description: 'Test node',
+  category: overrides.category ?? 'mystical',
+  rarity: overrides.rarity ?? 'common',
+  quality: overrides.quality ?? 'common',
+  tags: overrides.tags ?? [],
+  cost: overrides.cost ?? {},
+  baseCost: overrides.baseCost ?? {},
+  effects: overrides.effects ?? [],
+  requires: overrides.requires,
+  tier: overrides.tier,
+  importance: overrides.importance,
+  unlockCount: overrides.unlockCount,
+  isRevealed: overrides.isRevealed,
+  specialAbility: overrides.specialAbility,
+  statMultiplier: overrides.statMultiplier,
+  exclusiveGroup: overrides.exclusiveGroup,
+  unlockConditions: overrides.unlockConditions,
+});
+
+describe('collectUnlockBlockers', () => {
+  it('blocks unlock when category max is already reached', () => {
+    const unlockedNodes = Array.from({ length: 6 }, (_, index) => makeNode(`mystic_${index}`));
+    const targetNode = makeNode('target', {
+      unlockConditions: [
+        { type: 'max_unlocked_in_category', category: 'mystical', value: 6 },
+      ],
+    });
+    const nodes: SkillNode[] = [...unlockedNodes, targetNode];
+    const unlockedState = unlockedNodes.reduce<Record<string, boolean>>((acc, node) => {
+      acc[node.id] = true;
+      return acc;
+    }, {});
+
+    const reasons = collectUnlockBlockers({ node: targetNode, unlocked: unlockedState, nodes });
+
+    expect(reasons).toContain('Too many in mystical: max 6');
+    expect(reasons.length).toBe(1);
+  });
+});

--- a/src/components/game/skills/unlock.ts
+++ b/src/components/game/skills/unlock.ts
@@ -1,0 +1,96 @@
+import type { SkillNode } from './types';
+
+export interface UnlockCheckContext {
+  node: SkillNode;
+  unlocked: Record<string, boolean>;
+  nodes: SkillNode[];
+}
+
+const CATEGORY_KEYS: SkillNode['category'][] = [
+  'economic',
+  'military',
+  'mystical',
+  'infrastructure',
+  'diplomatic',
+  'social',
+];
+
+export function collectUnlockBlockers({ node, unlocked, nodes }: UnlockCheckContext): string[] {
+  const reasons: string[] = [];
+  const nodeMap = new Map(nodes.map((n) => [n.id, n] as const));
+
+  if (node.requires && node.requires.length > 0) {
+    node.requires.forEach((reqId) => {
+      if (!unlocked[reqId]) {
+        const title = nodeMap.get(reqId)?.title || reqId;
+        reasons.push(`Requires: ${title}`);
+      }
+    });
+  }
+
+  if (node.exclusiveGroup) {
+    const taken = nodes.find(
+      (n) => n.exclusiveGroup === node.exclusiveGroup && n.id !== node.id && unlocked[n.id],
+    );
+    if (taken) {
+      reasons.push(`Path chosen: ${taken.title}`);
+    }
+  }
+
+  if (node.unlockConditions && node.unlockConditions.length > 0) {
+    const unlockedIds = Object.keys(unlocked).filter((id) => unlocked[id]);
+    const byCategory: Record<SkillNode['category'], number> = CATEGORY_KEYS.reduce(
+      (acc, category) => {
+        acc[category] = 0;
+        return acc;
+      },
+      {} as Record<SkillNode['category'], number>,
+    );
+
+    unlockedIds.forEach((id) => {
+      const unlockedNode = nodeMap.get(id);
+      if (unlockedNode) {
+        byCategory[unlockedNode.category] = (byCategory[unlockedNode.category] || 0) + 1;
+      }
+    });
+
+    const highestTier = unlockedIds.reduce((maxTier, id) => {
+      const unlockedNode = nodeMap.get(id);
+      if (unlockedNode && typeof unlockedNode.tier === 'number' && Number.isFinite(unlockedNode.tier)) {
+        return Math.max(maxTier, unlockedNode.tier);
+      }
+      return maxTier;
+    }, -1);
+
+    node.unlockConditions.forEach((cond) => {
+      switch (cond.type) {
+        case 'min_unlocked':
+          if (unlockedIds.length < cond.value) {
+            reasons.push(`Unlock at least ${cond.value} skills`);
+          }
+          break;
+        case 'category_unlocked_at_least': {
+          const count = byCategory[cond.category] || 0;
+          if (count < cond.value) {
+            reasons.push(`Unlock ${cond.value} ${cond.category} skills`);
+          }
+          break;
+        }
+        case 'max_unlocked_in_category': {
+          const count = byCategory[cond.category] || 0;
+          if (count >= cond.value) {
+            reasons.push(`Too many in ${cond.category}: max ${cond.value}`);
+          }
+          break;
+        }
+        case 'tier_before_required':
+          if (highestTier < cond.tier) {
+            reasons.push(`Reach tier ${cond.tier} first`);
+          }
+          break;
+      }
+    });
+  }
+
+  return reasons;
+}


### PR DESCRIPTION
## Summary
- add a shared `collectUnlockBlockers` helper and update both skill tree UIs to use it
- switch the `max_unlocked_in_category` guard to use `>=` so caps block the next unlock and surface the correct tooltip text
- cover the helper with a unit test that asserts hitting the cap rejects the unlock with the expected message

## Testing
- npm run lint *(fails: repository contains numerous existing lint errors in unrelated files)*
- npm run test
- CI=1 npm run build *(fails: missing NEXT_PUBLIC_SUPABASE_URL for /api/debug route)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b6828a4483258e1b5fe0f59695a1