### PR TITLE
Thread persisted skill unlock attempt through HUD skill tree

### DIFF
--- a/src/components/game/hud/PanelComposer.tsx
+++ b/src/components/game/hud/PanelComposer.tsx
@@ -12,6 +12,12 @@ import CityManagementPanel, {
   ZoneType,
   ServiceType,
 } from '../CityManagementPanel';
+import type { SkillNode } from '../skills/types';
+import type { Notification } from './types';
+
+type NotifyFn = (
+  notification: Omit<Notification, 'id' | 'timestamp'> & { id?: string; dedupeKey?: string; dedupeMs?: number }
+) => void;
 
 export interface PanelComposerProps {
   children?: ReactNode;
@@ -65,6 +71,11 @@ export interface PanelComposerProps {
   };
   onGameAction: (action: string, data?: unknown) => void;
   className?: string;
+  skills?: {
+    unlockedIds: string[];
+    attemptUnlock?: (node: SkillNode) => Promise<boolean>;
+    notify?: NotifyFn;
+  };
 }
 
 export function PanelComposer({
@@ -73,6 +84,7 @@ export function PanelComposer({
   onGameAction,
   cityManagement,
   className = '',
+  skills,
 }: PanelComposerProps) {
   const { currentPreset } = useHUDLayoutPresets();
 
@@ -162,6 +174,9 @@ export function PanelComposer({
             mana: gameData.resources.mana,
             favor: gameData.resources.favor,
           }}
+          unlockedIds={skills?.unlockedIds ?? []}
+          attemptUnlock={skills?.attemptUnlock}
+          notify={skills?.notify}
         />
         <div className="mt-2" />
         {children}

--- a/src/components/game/skills/types.ts
+++ b/src/components/game/skills/types.ts
@@ -90,10 +90,17 @@ export interface SkillTree {
 
 export type Vec2 = { x: number; y: number };
 
+export type SkillUnlockError =
+  | { type: 'requirements'; reasons: string[] }
+  | { type: 'cost' }
+  | { type: 'server'; message?: string };
+
 export interface ConstellationSkillTreeProps {
   tree: SkillTree;
   unlocked: Record<string, boolean>;
-  onUnlock: (node: SkillNode) => void;
+  attemptUnlock?: (node: SkillNode) => Promise<boolean>;
+  onUnlock?: (node: SkillNode) => void;
+  onUnlockError?: (node: SkillNode, error: SkillUnlockError) => void;
   colorFor: (category: SkillNode['category']) => string;
   focusNodeId?: string;
   resources?: { coin?: number; mana?: number; favor?: number };


### PR DESCRIPTION
## Summary
- add a persisted `attemptUnlock` flow in `PlayPageInternal` that deducts resources, patches Supabase state, and notifies on success
- pass the new callback and unlocked skill ids through `PanelComposer` into the modular skill tree and modal components
- gate skill unlock interactions on prerequisites and affordability, surfacing error toasts/messages when unlocks fail instead of mutating local state

## Testing
- npm run lint *(fails: existing eslint errors across engine/UI packages)*
- npm run test
- npm run build *(fails: Next.js build needs NEXT_PUBLIC_SUPABASE_URL env for /api/debug)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b0e8037c8325b46d0472e677eb83