### PR TITLE
Refine simulation pause controls

### DIFF
--- a/src/app/play/__tests__/simulationControls.test.ts
+++ b/src/app/play/__tests__/simulationControls.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest';
+import { TIME_SPEEDS } from '@engine';
+import { pauseSimulation, resumeSimulation } from '../simulationControls';
+
+describe('simulationControls', () => {
+  it('pauses the simulation and updates Supabase when a state id is present', () => {
+    const setIsPaused = vi.fn();
+    const controller = { setSpeed: vi.fn() };
+    const fetchImpl = vi.fn();
+
+    pauseSimulation({
+      stateId: 'state-123',
+      setIsPaused,
+      controller,
+      fetchImpl,
+    });
+
+    expect(controller.setSpeed).toHaveBeenCalledWith(TIME_SPEEDS.PAUSED);
+    expect(setIsPaused).toHaveBeenCalledWith(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(url).toBe('/api/state');
+    expect(init).toMatchObject({
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const body = JSON.parse(String(init?.body));
+    expect(body).toEqual({ id: 'state-123', auto_ticking: false });
+  });
+
+  it('does not patch Supabase when pausing without a state id', () => {
+    const setIsPaused = vi.fn();
+    const controller = { setSpeed: vi.fn() };
+    const fetchImpl = vi.fn();
+
+    pauseSimulation({ setIsPaused, controller, fetchImpl });
+
+    expect(controller.setSpeed).toHaveBeenCalledWith(TIME_SPEEDS.PAUSED);
+    expect(setIsPaused).toHaveBeenCalledWith(true);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('resumes the simulation and updates Supabase when a state id is present', () => {
+    const setIsPaused = vi.fn();
+    const controller = { setSpeed: vi.fn() };
+    const fetchImpl = vi.fn();
+
+    resumeSimulation({
+      stateId: 'state-456',
+      setIsPaused,
+      controller,
+      fetchImpl,
+    });
+
+    expect(controller.setSpeed).toHaveBeenCalledWith(TIME_SPEEDS.NORMAL);
+    expect(setIsPaused).toHaveBeenCalledWith(false);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(url).toBe('/api/state');
+    expect(init).toMatchObject({
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const body = JSON.parse(String(init?.body));
+    expect(body.id).toBe('state-456');
+    expect(body.auto_ticking).toBe(true);
+    expect(typeof body.last_tick_at).toBe('string');
+    expect(new Date(body.last_tick_at).toString()).not.toBe('Invalid Date');
+  });
+
+  it('does not patch Supabase when resuming without a state id', () => {
+    const setIsPaused = vi.fn();
+    const controller = { setSpeed: vi.fn() };
+    const fetchImpl = vi.fn();
+
+    resumeSimulation({ setIsPaused, controller, fetchImpl });
+
+    expect(controller.setSpeed).toHaveBeenCalledWith(TIME_SPEEDS.NORMAL);
+    expect(setIsPaused).toHaveBeenCalledWith(false);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/play/simulationControls.ts
+++ b/src/app/play/simulationControls.ts
@@ -1,0 +1,53 @@
+import type { Dispatch, SetStateAction } from 'react';
+import { timeSystem, TIME_SPEEDS } from '@engine';
+
+const JSON_HEADERS: Readonly<Record<string, string>> = {
+  'Content-Type': 'application/json',
+};
+
+export type SimulationControlOptions = {
+  stateId?: string | null;
+  setIsPaused: Dispatch<SetStateAction<boolean>>;
+  controller?: Pick<typeof timeSystem, 'setSpeed'>;
+  fetchImpl?: typeof fetch;
+};
+
+export function pauseSimulation({
+  stateId,
+  setIsPaused,
+  controller = timeSystem,
+  fetchImpl = fetch,
+}: SimulationControlOptions): void {
+  controller.setSpeed(TIME_SPEEDS.PAUSED);
+  setIsPaused(true);
+
+  if (!stateId) return;
+
+  void fetchImpl('/api/state', {
+    method: 'PATCH',
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ id: stateId, auto_ticking: false }),
+  });
+}
+
+export function resumeSimulation({
+  stateId,
+  setIsPaused,
+  controller = timeSystem,
+  fetchImpl = fetch,
+}: SimulationControlOptions): void {
+  controller.setSpeed(TIME_SPEEDS.NORMAL);
+  setIsPaused(false);
+
+  if (!stateId) return;
+
+  void fetchImpl('/api/state', {
+    method: 'PATCH',
+    headers: JSON_HEADERS,
+    body: JSON.stringify({
+      id: stateId,
+      auto_ticking: true,
+      last_tick_at: new Date().toISOString(),
+    }),
+  });
+}


### PR DESCRIPTION
## Summary
- factor simulation pause/resume behavior into reusable helpers that update the time system, paused state, and Supabase
- hook city management simulation toggle and game actions into the shared pause/resume helpers
- add unit coverage for the helpers to confirm Supabase patches and time control updates

## Testing
- npm run lint *(fails: existing lint errors throughout engine/UI packages)*
- npm run test
- npm run build *(fails: missing NEXT_PUBLIC_SUPABASE_URL for /api/debug route)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b6c2fe44832596ccede0bb222719