### PR TITLE
Refactor PlayPage map logic into reusable hooks

### DIFF
--- a/src/app/play/hooks/useActionPanelCounts.ts
+++ b/src/app/play/hooks/useActionPanelCounts.ts
@@ -1,0 +1,25 @@
+import { useMemo } from 'react';
+import type { OmenReading, Proposal } from '../types';
+
+export interface ActionPanelCounts {
+  pendingCouncil: number;
+  pendingOmens: number;
+}
+
+export function useActionPanelCounts(proposals: Proposal[], omenReadings: OmenReading[]): ActionPanelCounts {
+  const pendingCouncil = useMemo(
+    () =>
+      proposals.reduce(
+        (count, proposal) => count + ((proposal.status ?? 'pending') === 'pending' ? 1 : 0),
+        0
+      ),
+    [proposals]
+  );
+
+  const pendingOmens = useMemo(() => omenReadings.length, [omenReadings]);
+
+  return {
+    pendingCouncil,
+    pendingOmens,
+  };
+}

--- a/src/app/play/hooks/usePlayMap.ts
+++ b/src/app/play/hooks/usePlayMap.ts
@@ -1,0 +1,274 @@
+import { useCallback, useEffect, useState } from 'react';
+import logger from '@/lib/logger';
+
+interface UsePlayMapOptions {
+  initialMapSize?: number | null;
+  onPersistMapSize?: (size: number) => Promise<void> | void;
+}
+
+export interface PlayMapController {
+  tileTypes: string[][];
+  gridSize: number | null;
+  setGridSize: React.Dispatch<React.SetStateAction<number | null>>;
+  mapSizeModalOpen: boolean;
+  setMapSizeModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  pendingMapSize: number;
+  setPendingMapSize: React.Dispatch<React.SetStateAction<number>>;
+  confirmMapSize: () => Promise<void>;
+  ensureCapacityAround: (x: number, y: number, margin?: number) => void;
+  revealUnknownTiles: (centerX: number, centerY: number, radius?: number) => Promise<void>;
+  citizensCount: number;
+  setCitizensCount: React.Dispatch<React.SetStateAction<number>>;
+  citizensSeed: number;
+  setCitizensSeed: React.Dispatch<React.SetStateAction<number>>;
+}
+
+function clampMapSize(size: number | null | undefined): number {
+  if (size == null || Number.isNaN(size)) {
+    return 32;
+  }
+  return Math.max(8, Math.min(48, size));
+}
+
+export function usePlayMap({ initialMapSize, onPersistMapSize }: UsePlayMapOptions): PlayMapController {
+  const normalizedInitialSize = initialMapSize != null ? clampMapSize(initialMapSize) : null;
+
+  const [tileTypes, setTileTypes] = useState<string[][]>([]);
+  const [gridSize, setGridSize] = useState<number | null>(() => {
+    if (normalizedInitialSize != null) {
+      logger.debug('Initial gridSize from initialMapSize:', normalizedInitialSize);
+      return normalizedInitialSize;
+    }
+
+    if (typeof window !== 'undefined') {
+      try {
+        const stored = window.localStorage.getItem('ad_map_size');
+        if (stored) {
+          const parsed = clampMapSize(Number(stored));
+          logger.debug('Initial gridSize from localStorage:', parsed);
+          return parsed;
+        }
+      } catch (err) {
+        logger.error('Error reading gridSize from localStorage:', err);
+      }
+    }
+
+    logger.debug('Initial gridSize fallback to default: 32');
+    return 32;
+  });
+
+  const [mapSizeModalOpen, setMapSizeModalOpen] = useState(true);
+  const [pendingMapSize, setPendingMapSize] = useState<number>(() => {
+    if (normalizedInitialSize != null) {
+      return normalizedInitialSize;
+    }
+
+    if (typeof window !== 'undefined') {
+      const stored = window.localStorage.getItem('ad_map_size');
+      if (stored) {
+        return clampMapSize(Number(stored));
+      }
+    }
+
+    return 32;
+  });
+
+  const [citizensCount, setCitizensCount] = useState<number>(8);
+  const [citizensSeed, setCitizensSeed] = useState<number>(() => Math.floor(Math.random() * 1e6));
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    if (normalizedInitialSize != null) {
+      setPendingMapSize(normalizedInitialSize);
+      setMapSizeModalOpen(false);
+      return;
+    }
+
+    try {
+      const saved = window.localStorage.getItem('ad_map_size');
+      if (saved) {
+        const parsed = clampMapSize(Number(saved));
+        logger.debug('usePlayMap: applying saved map size from localStorage:', parsed);
+        setGridSize(parsed);
+        setPendingMapSize(parsed);
+        setMapSizeModalOpen(false);
+      } else {
+        window.localStorage.setItem('ad_map_size', String(pendingMapSize));
+        setMapSizeModalOpen(false);
+      }
+    } catch (err) {
+      logger.error('usePlayMap: failed to read map size from localStorage:', err);
+      setMapSizeModalOpen(false);
+    }
+  }, [normalizedInitialSize, pendingMapSize]);
+
+  useEffect(() => {
+    if (gridSize == null) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadMap = async () => {
+      try {
+        const url = `/api/map?size=${gridSize}`;
+        logger.debug('usePlayMap: fetching map data from', url);
+        const res = await fetch(url);
+        if (!res.ok) {
+          throw new Error(`Failed to load map (${res.status})`);
+        }
+        const data = await res.json();
+        if (!cancelled) {
+          setTileTypes(data.map ?? []);
+        }
+      } catch (err) {
+        logger.error('usePlayMap: error loading map data:', err);
+      }
+    };
+
+    void loadMap();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [gridSize]);
+
+  useEffect(() => {
+    if (tileTypes.length > 0) {
+      try {
+        void fetch(`/api/debug-log?message=TILETYPES_STATE_UPDATED&length=${tileTypes.length}`);
+      } catch (err) {
+        logger.warn('usePlayMap: failed to send debug log for tileTypes update:', err);
+      }
+    } else {
+      try {
+        void fetch('/api/debug-log?message=TILETYPES_STILL_EMPTY');
+      } catch (err) {
+        logger.warn('usePlayMap: failed to send debug log for empty tileTypes:', err);
+      }
+    }
+  }, [tileTypes]);
+
+  const fetchChunk = useCallback(
+    async (chunkX: number, chunkY: number, chunkSize: number = 16): Promise<string[][] | null> => {
+      try {
+        const response = await fetch(
+          `/api/map/chunk?x=${chunkX}&y=${chunkY}&size=${chunkSize}&seed=${citizensSeed}`
+        );
+        if (!response.ok) {
+          return null;
+        }
+        const data = await response.json();
+        return data.tiles as string[][];
+      } catch (error) {
+        logger.warn('usePlayMap: failed to fetch chunk:', error);
+        return null;
+      }
+    },
+    [citizensSeed]
+  );
+
+  const ensureCapacityAround = useCallback((x: number, y: number, margin: number = 2) => {
+    setTileTypes((prev) => {
+      const rows = prev.length;
+      const cols = rows > 0 ? prev[0].length : 0;
+      const needRows = Math.max(rows, y + 1 + margin);
+      const needCols = Math.max(cols, x + 1 + margin);
+      if (needRows === rows && needCols === cols) return prev;
+      const next: string[][] = new Array(needRows);
+      for (let r = 0; r < needRows; r++) {
+        next[r] = new Array(needCols);
+        for (let c = 0; c < needCols; c++) {
+          const val = r < rows && c < (prev[r]?.length ?? 0) ? prev[r][c] : 'unknown';
+          next[r][c] = val || 'unknown';
+        }
+      }
+      return next;
+    });
+  }, []);
+
+  const revealUnknownTiles = useCallback(
+    async (centerX: number, centerY: number, radius: number = 8) => {
+      const chunkSize = 16;
+      const chunksToFetch = new Set<string>();
+
+      for (let dy = -radius; dy <= radius; dy++) {
+        for (let dx = -radius; dx <= radius; dx++) {
+          const tx = centerX + dx;
+          const ty = centerY + dy;
+          if (tx < 0 || ty < 0) continue;
+
+          const chunkX = Math.floor(tx / chunkSize);
+          const chunkY = Math.floor(ty / chunkSize);
+          chunksToFetch.add(`${chunkX},${chunkY}`);
+        }
+      }
+
+      for (const chunkKey of chunksToFetch) {
+        const [chunkX, chunkY] = chunkKey.split(',').map(Number);
+        const chunkData = await fetchChunk(chunkX, chunkY, chunkSize);
+        if (!chunkData) continue;
+
+        setTileTypes((prev) => {
+          const next = prev.map((row) => [...row]);
+          const startX = chunkX * chunkSize;
+          const startY = chunkY * chunkSize;
+
+          for (let cy = 0; cy < chunkData.length; cy++) {
+            for (let cx = 0; cx < chunkData[cy].length; cx++) {
+              const worldX = startX + cx;
+              const worldY = startY + cy;
+
+              if (worldY >= 0 && worldY < next.length && worldX >= 0 && worldX < next[worldY].length) {
+                if (next[worldY][worldX] === 'unknown') {
+                  next[worldY][worldX] = chunkData[cy][cx];
+                }
+              }
+            }
+          }
+
+          return next;
+        });
+      }
+    },
+    [fetchChunk]
+  );
+
+  const confirmMapSize = useCallback(async () => {
+    const normalized = clampMapSize(Number(pendingMapSize));
+    setGridSize(normalized);
+    try {
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem('ad_map_size', String(normalized));
+      }
+    } catch (err) {
+      logger.warn('usePlayMap: failed to store map size:', err);
+    }
+
+    setMapSizeModalOpen(false);
+
+    if (onPersistMapSize) {
+      await onPersistMapSize(normalized);
+    }
+  }, [pendingMapSize, onPersistMapSize]);
+
+  return {
+    tileTypes,
+    gridSize,
+    setGridSize,
+    mapSizeModalOpen,
+    setMapSizeModalOpen,
+    pendingMapSize,
+    setPendingMapSize,
+    confirmMapSize,
+    ensureCapacityAround,
+    revealUnknownTiles,
+    citizensCount,
+    setCitizensCount,
+    citizensSeed,
+    setCitizensSeed,
+  };
+}

--- a/src/app/play/types.ts
+++ b/src/app/play/types.ts
@@ -1,0 +1,64 @@
+export interface StoredBuilding {
+  id: string;
+  typeId: string;
+  x: number;
+  y: number;
+  level: number;
+  workers: number;
+  traits?: {
+    waterAdj?: number;
+    mountainAdj?: number;
+    forestAdj?: number;
+  };
+}
+
+export interface TradeRoute {
+  id: string;
+  fromId: string;
+  toId: string;
+  length: number;
+}
+
+export interface GameState {
+  id: string;
+  cycle: number;
+  resources: Record<string, number>;
+  workers: number;
+  buildings: StoredBuilding[];
+  routes?: TradeRoute[];
+  edicts?: Record<string, number>;
+  map_size?: number;
+  tick_interval_ms?: number;
+  auto_ticking?: boolean;
+  roads?: Array<{ x: number; y: number }>;
+  citizens_count?: number;
+  citizens_seed?: number;
+}
+
+export interface Proposal {
+  id: string;
+  guild: string;
+  title: string;
+  description: string;
+  status: "pending" | "accepted" | "rejected" | "applied";
+  predicted_delta: Record<string, number>;
+}
+
+export interface SeasonalEvent {
+  id: string;
+  name: string;
+  description: string;
+  cycle: number;
+}
+
+export interface OmenReading {
+  id: string;
+  text: string;
+  type: string;
+  cycle: number;
+}
+
+export interface PlayPageProps {
+  initialState?: GameState | null;
+  initialProposals?: Proposal[];
+}

--- a/src/components/game/hud/PanelComposer.tsx
+++ b/src/components/game/hud/PanelComposer.tsx
@@ -13,6 +13,13 @@ import CityManagementPanel, {
   ServiceType,
 } from '../CityManagementPanel';
 
+export interface ActionPanelCounts {
+  pendingCouncil?: number;
+  pendingEdicts?: number;
+  pendingOmens?: number;
+  pendingSettings?: number;
+}
+
 export interface PanelComposerProps {
   children?: ReactNode;
   gameData: {
@@ -65,6 +72,7 @@ export interface PanelComposerProps {
   };
   onGameAction: (action: string, data?: unknown) => void;
   className?: string;
+  actionPanelCounts?: ActionPanelCounts;
 }
 
 export function PanelComposer({
@@ -73,6 +81,7 @@ export function PanelComposer({
   onGameAction,
   cityManagement,
   className = '',
+  actionPanelCounts,
 }: PanelComposerProps) {
   const { currentPreset } = useHUDLayoutPresets();
 
@@ -154,6 +163,10 @@ export function PanelComposer({
           intervalMs={gameData.time.intervalMs}
           onChangeIntervalMs={(ms) => onGameAction('set-speed', { ms })}
           variant={currentPreset.panelVariants['action-panel'] || 'default'}
+          pendingCouncil={actionPanelCounts?.pendingCouncil}
+          pendingEdicts={actionPanelCounts?.pendingEdicts}
+          pendingOmens={actionPanelCounts?.pendingOmens}
+          pendingSettings={actionPanelCounts?.pendingSettings}
         />
         <div className="mt-2" />
         <ModularSkillTreePanel

--- a/src/components/game/hud/panels/ModularActionPanel.tsx
+++ b/src/components/game/hud/panels/ModularActionPanel.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { ResponsivePanel, ResponsiveButton, ResponsiveStack, ResponsiveIcon } from '../ResponsiveHUDPanels';
 import { useHUDPanel } from '../HUDPanelRegistry';
 
-interface ModularActionPanelProps {
+export interface ModularActionPanelProps {
   onOpenCouncil?: () => void;
   onOpenEdicts?: () => void;
   onOpenOmens?: () => void;
@@ -11,6 +11,10 @@ interface ModularActionPanelProps {
   onChangeIntervalMs?: (ms: number) => void;
   variant?: 'default' | 'compact' | 'minimal';
   collapsible?: boolean;
+  pendingCouncil?: number;
+  pendingEdicts?: number;
+  pendingOmens?: number;
+  pendingSettings?: number;
 }
 
 interface ActionItemProps {
@@ -105,15 +109,19 @@ const actionIcons = {
   )
 };
 
-export function ModularActionPanel({ 
-  onOpenCouncil, 
-  onOpenEdicts, 
-  onOpenOmens, 
-  onOpenSettings, 
+export function ModularActionPanel({
+  onOpenCouncil,
+  onOpenEdicts,
+  onOpenOmens,
+  onOpenSettings,
   intervalMs,
   onChangeIntervalMs,
   variant = 'default',
-  collapsible = true 
+  collapsible = true,
+  pendingCouncil,
+  pendingEdicts,
+  pendingOmens,
+  pendingSettings,
 }: ModularActionPanelProps) {
   const [isCollapsed, setIsCollapsed] = useState(false);
   
@@ -145,27 +153,11 @@ export function ModularActionPanel({
     </svg>
   );
 
-  // Mock data for demonstration - in real app this would come from game state
-  const getActionBadge = (action: string) => {
-    switch (action) {
-      case 'council':
-        return 3; // Number of pending proposals
-      case 'edicts':
-        return undefined; // No pending edicts
-      case 'omens':
-        return 1; // New omen available
-      case 'settings':
-        return undefined; // No notifications
-      default:
-        return undefined;
-    }
-  };
-
   const actions = [
-    { label: 'Council', onClick: onOpenCouncil, icon: actionIcons.council, key: 'council' },
-    { label: 'Edicts', onClick: onOpenEdicts, icon: actionIcons.edicts, key: 'edicts' },
-    { label: 'Omens', onClick: onOpenOmens, icon: actionIcons.omens, key: 'omens' },
-    { label: 'Settings', onClick: onOpenSettings, icon: actionIcons.settings, key: 'settings' }
+    { label: 'Council', onClick: onOpenCouncil, icon: actionIcons.council, key: 'council', badge: pendingCouncil },
+    { label: 'Edicts', onClick: onOpenEdicts, icon: actionIcons.edicts, key: 'edicts', badge: pendingEdicts },
+    { label: 'Omens', onClick: onOpenOmens, icon: actionIcons.omens, key: 'omens', badge: pendingOmens },
+    { label: 'Settings', onClick: onOpenSettings, icon: actionIcons.settings, key: 'settings', badge: pendingSettings }
   ];
 
   return (
@@ -221,7 +213,7 @@ export function ModularActionPanel({
             onClick={action.onClick}
             icon={action.icon}
             variant={variant}
-            badge={getActionBadge(action.key)}
+            badge={action.badge}
           />
         ))}
       </ResponsiveStack>

--- a/src/components/game/hud/panels/__tests__/ModularActionPanel.test.tsx
+++ b/src/components/game/hud/panels/__tests__/ModularActionPanel.test.tsx
@@ -1,0 +1,79 @@
+import React, { act, type ComponentProps } from 'react';
+import { beforeAll, beforeEach, afterEach, describe, expect, it } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { ModularActionPanel } from '../ModularActionPanel';
+import { HUDLayoutProvider } from '../../HUDLayoutSystem';
+import { HUDPanelRegistryProvider } from '../../HUDPanelRegistry';
+
+describe('ModularActionPanel', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  const renderPanel = (props: Partial<ComponentProps<typeof ModularActionPanel>> = {}) => {
+    act(() => {
+      root.render(
+        <HUDLayoutProvider layoutPreset="compact">
+          <HUDPanelRegistryProvider>
+            <ModularActionPanel {...props} />
+          </HUDPanelRegistryProvider>
+        </HUDLayoutProvider>
+      );
+    });
+  };
+
+  const getBadgeValue = (label: string) => {
+    const button = Array.from(container.querySelectorAll('button')).find(btn =>
+      btn.textContent?.includes(label)
+    );
+    const badge = button?.querySelector<HTMLSpanElement>('span.bg-red-500');
+    return badge?.textContent ?? undefined;
+  };
+
+  beforeAll(() => {
+    const globals = globalThis as typeof globalThis & {
+      requestAnimationFrame?: typeof globalThis.requestAnimationFrame;
+      cancelAnimationFrame?: typeof globalThis.cancelAnimationFrame;
+      IS_REACT_ACT_ENVIRONMENT?: boolean;
+    };
+
+    globals.IS_REACT_ACT_ENVIRONMENT = true;
+
+    if (!globals.requestAnimationFrame) {
+      globals.requestAnimationFrame = (callback: FrameRequestCallback) => (
+        setTimeout(() => callback(performance.now()), 0) as unknown as number
+      );
+    }
+    if (!globals.cancelAnimationFrame) {
+      globals.cancelAnimationFrame = (handle: number) => {
+        clearTimeout(handle);
+      };
+    }
+  });
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('displays and updates action badges based on provided counts', () => {
+    renderPanel({ pendingCouncil: 3, pendingOmens: 1 });
+
+    expect(getBadgeValue('Council')).toBe('3');
+    expect(getBadgeValue('Omens')).toBe('1');
+    expect(getBadgeValue('Edicts')).toBeUndefined();
+
+    renderPanel({ pendingCouncil: 1, pendingOmens: 0 });
+
+    expect(getBadgeValue('Council')).toBe('1');
+    expect(getBadgeValue('Omens')).toBeUndefined();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,9 +13,15 @@ export default defineConfig({
   },
   test: {
     environment: 'node',
-    environmentMatchGlobs: [[
-      'src/state/**/*.test.{ts,tsx}',
-      'jsdom',
-    ]],
+    environmentMatchGlobs: [
+      [
+        'src/state/**/*.test.{ts,tsx}',
+        'jsdom',
+      ],
+      [
+        'src/components/**/*.test.{ts,tsx}',
+        'jsdom',
+      ],
+    ],
   },
 });


### PR DESCRIPTION
## Summary
- extract shared PlayPage types into a dedicated module and replace local interface declarations
- introduce a `usePlayMap` hook that centralizes grid, tile reveal, map size modal, and citizen settings state and wire it through `PlayPageInternal`
- add a `useActionPanelCounts` helper and use it to feed the HUD action badges from live proposal and omen data

## Testing
- npm run lint *(fails: repository has extensive pre-existing lint violations outside the touched files)*
- npm run test
- npm run build *(fails: Next.js build requires NEXT_PUBLIC_SUPABASE_URL/nextPublicSupabaseUrl configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b169e3f4832582aae28a393b66f6