### PR TITLE
Inject time system into HUD time controls

### DIFF
--- a/src/app/play/__tests__/timeSpeedUtils.test.tsx
+++ b/src/app/play/__tests__/timeSpeedUtils.test.tsx
@@ -7,7 +7,7 @@ import { createRoot, type Root } from 'react-dom/client';
 import ModularActionPanel from '../../../components/game/hud/panels/ModularActionPanel';
 import { HUDLayoutProvider } from '../../../components/game/hud/HUDLayoutSystem';
 import { HUDPanelRegistryProvider } from '../../../components/game/hud/HUDPanelRegistry';
-import { intervalMsToTimeSpeed, sanitizeIntervalMs } from '../timeSpeedUtils';
+import { intervalMsToTimeSpeed, sanitizeIntervalMs, timeSpeedToIntervalMs } from '../timeSpeedUtils';
 import { TIME_SPEEDS } from '@engine';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -73,6 +73,15 @@ describe('timeSpeedUtils', () => {
     expect(intervalMsToTimeSpeed(7000)).toBe(TIME_SPEEDS.ULTRA_FAST);
     expect(intervalMsToTimeSpeed(2000)).toBe(TIME_SPEEDS.HYPER_SPEED);
     expect(intervalMsToTimeSpeed(-1)).toBe(TIME_SPEEDS.NORMAL);
+  });
+
+  it('maps TimeSpeed tiers to canonical intervals', () => {
+    expect(timeSpeedToIntervalMs(TIME_SPEEDS.PAUSED)).toBe(60000);
+    expect(timeSpeedToIntervalMs(TIME_SPEEDS.NORMAL)).toBe(60000);
+    expect(timeSpeedToIntervalMs(TIME_SPEEDS.FAST)).toBe(30000);
+    expect(timeSpeedToIntervalMs(TIME_SPEEDS.VERY_FAST)).toBe(15000);
+    expect(timeSpeedToIntervalMs(TIME_SPEEDS.ULTRA_FAST)).toBe(7500);
+    expect(timeSpeedToIntervalMs(TIME_SPEEDS.HYPER_SPEED)).toBe(3000);
   });
 });
 

--- a/src/app/play/timeSpeedUtils.ts
+++ b/src/app/play/timeSpeedUtils.ts
@@ -42,3 +42,15 @@ export function intervalMsToTimeSpeed(intervalMs: number): TimeSpeed {
 
   return closest.speed;
 }
+
+export function timeSpeedToIntervalMs(speed: TimeSpeed): number {
+  const target = SPEED_RATIO_TARGETS.find(candidate => candidate.speed === speed);
+  if (!target || !Number.isFinite(target.ratio) || target.ratio <= 0) {
+    return BASE_INTERVAL_MS;
+  }
+  const interval = BASE_INTERVAL_MS / target.ratio;
+  if (!Number.isFinite(interval) || interval <= 0) {
+    return BASE_INTERVAL_MS;
+  }
+  return Math.max(1, Math.round(interval));
+}

--- a/src/components/game/TimeControlPanel.tsx
+++ b/src/components/game/TimeControlPanel.tsx
@@ -1,22 +1,34 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
-import { timeSystem, TIME_SPEEDS, TimeOfDay, type GameTime, type TimeSpeed } from '@engine';
+import { TIME_SPEEDS, TimeOfDay, type GameTime, type TimeSpeed, type TimeSystem } from '@engine';
 import { faPlay, faPause, faForward, faClock, faSun, faMoon, faCloudSun } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 interface TimeControlPanelProps {
   className?: string;
+  timeSystem: TimeSystem;
+  onPause: () => void;
+  onResume: () => void;
+  onSetSpeed: (speed: TimeSpeed) => void;
 }
 
-export const TimeControlPanel: React.FC<TimeControlPanelProps> = ({ className = '' }) => {
+export const TimeControlPanel: React.FC<TimeControlPanelProps> = ({
+  className = '',
+  timeSystem,
+  onPause,
+  onResume,
+  onSetSpeed,
+}) => {
   const [currentTime, setCurrentTime] = useState<GameTime>(timeSystem.getCurrentTime());
   const [currentSpeed, setCurrentSpeed] = useState<TimeSpeed>(timeSystem.getCurrentSpeed());
   const [isPaused, setIsPaused] = useState<boolean>(timeSystem.isPaused());
 
   useEffect(() => {
-    // Start the time system
-    timeSystem.start();
+    // Sync with the latest time system snapshot
+    setCurrentTime(timeSystem.getCurrentTime());
+    setCurrentSpeed(timeSystem.getCurrentSpeed());
+    setIsPaused(timeSystem.isPaused());
 
     // Listen for time updates
     const handleTimeUpdate = (time: GameTime) => {
@@ -41,7 +53,7 @@ export const TimeControlPanel: React.FC<TimeControlPanelProps> = ({ className = 
       timeSystem.off('speed-changed', handleSpeedChange);
       timeSystem.off('pause-toggled', handlePauseToggle);
     };
-  }, []);
+  }, [timeSystem]);
 
   // Get time of day icon
   const getTimeOfDayIcon = (timeOfDay: string) => {
@@ -94,12 +106,16 @@ export const TimeControlPanel: React.FC<TimeControlPanelProps> = ({ className = 
 
   // Handle speed change
   const handleSpeedChange = (speed: TimeSpeed) => {
-    timeSystem.setSpeed(speed);
+    onSetSpeed(speed);
   };
 
   // Handle pause toggle
   const handlePauseToggle = () => {
-    timeSystem.togglePause();
+    if (isPaused) {
+      onResume();
+    } else {
+      onPause();
+    }
   };
 
   // Calculate day progress for visual indicator

--- a/src/components/game/hud/PanelComposer.tsx
+++ b/src/components/game/hud/PanelComposer.tsx
@@ -3,6 +3,7 @@ import { HUDContainer, HUDZone } from './HUDLayoutSystem';
 import { useHUDLayoutPresets } from './HUDLayoutPresets';
 import { ModularResourcePanel } from './panels/ModularResourcePanel';
 import { TimeControlPanel } from '../TimeControlPanel';
+import type { TimeSystem, TimeSpeed } from '@engine';
 import { ModularActionPanel } from './panels/ModularActionPanel';
 import { ModularMiniMapPanel, type MiniMapDescriptor } from './panels/ModularMiniMapPanel';
 import { ModularSkillTreePanel } from './panels/ModularSkillTreePanel';
@@ -66,6 +67,7 @@ export interface PanelComposerProps {
   onGameAction: (action: string, data?: unknown) => void;
   className?: string;
   map?: MiniMapDescriptor;
+  timeSystem: TimeSystem;
 }
 
 export function PanelComposer({
@@ -75,6 +77,7 @@ export function PanelComposer({
   cityManagement,
   map,
   className = '',
+  timeSystem,
 }: PanelComposerProps) {
   const { currentPreset } = useHUDLayoutPresets();
 
@@ -144,7 +147,13 @@ export function PanelComposer({
           />
         )}
         <div className="mt-2" />
-        <TimeControlPanel className="w-full" />
+        <TimeControlPanel
+          className="w-full"
+          timeSystem={timeSystem}
+          onPause={() => onGameAction('pause')}
+          onResume={() => onGameAction('resume')}
+          onSetSpeed={(speed: TimeSpeed) => onGameAction('set-speed', { speed })}
+        />
         <div className="mt-2" />
         <ModularMiniMapPanel map={map} />
         <div className="mt-2" />


### PR DESCRIPTION
## Summary
- inject the active `TimeSystem` into the time control panel so pause/resume/speed actions emit via `onGameAction`
- update the play page to reuse its managed `TimeSystem`, persist tick interval changes, and resume with the saved speed
- add a helper to convert `TimeSpeed` to server intervals and expand the existing tests

## Testing
- `npm run lint` *(fails: repository contains pre-existing lint errors unrelated to these changes)*
- `npm run test`
- `CI=1 npm run build` *(fails: Next.js build expects Supabase env vars for /api/debug Zod schema)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b744d20c8325a8eb7ca2fcd555f3