### PR TITLE
Synchronize skill unlocks with server state

### DIFF
--- a/src/app/play/PlayPageInternal.tsx
+++ b/src/app/play/PlayPageInternal.tsx
@@ -30,6 +30,7 @@ import { createSupabaseBrowserClient } from '@/lib/supabase/browser';
 import { generateSkillTree } from '@/components/game/skills/generate';
 import { accumulateEffects } from '@/components/game/skills/progression';
 import type { SkillNode } from '@/components/game/skills/types';
+import { sanitizeSkillList, readSkillCache, recordToSkillList, writeSkillCache } from '@/components/game/skills/storage';
 import TileTooltip from '@/components/game/TileTooltip';
 import SettingsPanel from '@/components/game/SettingsPanel';
 import type { AssignLine } from '@/components/game/AssignmentLinesLayer';
@@ -62,6 +63,9 @@ type BuildTypeId = keyof typeof SIM_BUILDINGS;
 const ISO_TILE_WIDTH = 64;
 const ISO_TILE_HEIGHT = 32;
 
+const arraysEqual = (a: string[], b: string[]) =>
+  a.length === b.length && a.every((value, index) => value === b[index]);
+
 
 
 interface StoredBuilding {
@@ -83,6 +87,9 @@ interface GameState {
   routes?: TradeRoute[];
   edicts?: Record<string, number>;
   map_size?: number;
+  skills?: string[];
+  skill_tree_seed?: number;
+  pinned_skill_targets?: string[];
 }
 
 interface TradeRoute {
@@ -422,9 +429,21 @@ export default function PlayPage({ initialState = null, initialProposals = [] }:
   };
 
   const [unlockedSkillIds, setUnlockedSkillIds] = useState<string[]>(() => {
+    const skillsFromProps = Array.isArray(initialState?.skills)
+      ? sanitizeSkillList(initialState?.skills)
+      : null;
+
+    if (skillsFromProps !== null) {
+      return skillsFromProps;
+    }
+
     if (typeof window === 'undefined') return [];
-    try { return Object.keys(JSON.parse(localStorage.getItem('ad_skills_unlocked') || '{}')).filter(k => JSON.parse(localStorage.getItem('ad_skills_unlocked') || '{}')[k]); } catch { return []; }
+
+    return recordToSkillList(readSkillCache());
   });
+  useEffect(() => {
+    writeSkillCache(unlockedSkillIds);
+  }, [unlockedSkillIds]);
   useEffect(() => {
     logger.debug('localStorage useEffect running, window defined:', typeof window !== 'undefined');
     if (typeof window === 'undefined') return;
@@ -524,14 +543,16 @@ export default function PlayPage({ initialState = null, initialProposals = [] }:
       await saveState({ resources: newResServer, buildings: placedBuildings, routes, workers: state?.workers, skills: nextSkills } as any);
       setUnlockedSkillIds(nextSkills);
       notify({ type: 'success', title: 'Skill Unlocked', message: n.title })
-      try {
-        const prev = JSON.parse(localStorage.getItem('ad_skills_unlocked') || '{}');
-        prev[n.id] = true; localStorage.setItem('ad_skills_unlocked', JSON.stringify(prev));
-      } catch {}
     };
     window.addEventListener('ad_unlock_skill', onUnlock as any);
     return () => window.removeEventListener('ad_unlock_skill', onUnlock as any);
   }, [state, unlockedSkillIds]);
+  const syncSkillsFromServer = useCallback((value: unknown) => {
+    if (!Array.isArray(value)) return;
+
+    const normalized = sanitizeSkillList(value);
+    setUnlockedSkillIds(prev => (arraysEqual(prev, normalized) ? prev : normalized));
+  }, [setUnlockedSkillIds]);
   const [selectedTile, setSelectedTile] = useState<{ x: number; y: number; tileType?: string } | null>(null);
   const [hoverTile, setHoverTile] = useState<{ x: number; y: number; tileType?: string } | null>(null);
   const [previewTypeId, setPreviewTypeId] = useState<BuildTypeId | null>(null);
@@ -562,10 +583,10 @@ export default function PlayPage({ initialState = null, initialProposals = [] }:
     return () => clearInterval(cleanup);
   }, []);
 
-  const saveState = useCallback(async (partial: { resources?: Record<string, number>; workers?: number; buildings?: StoredBuilding[]; routes?: TradeRoute[]; roads?: Array<{x:number;y:number}>; edicts?: Record<string, number>; map_size?: number }) => {
+  const saveState = useCallback(async (partial: { resources?: Record<string, number>; workers?: number; buildings?: StoredBuilding[]; routes?: TradeRoute[]; roads?: Array<{x:number;y:number}>; edicts?: Record<string, number>; map_size?: number; skills?: string[] }) => {
     if (!state) return;
     try {
-      const body: { id: string; resources?: Record<string, number>; workers?: number; buildings?: StoredBuilding[]; routes?: TradeRoute[]; roads?: Array<{x:number;y:number}>; edicts?: Record<string, number>; map_size?: number } = { id: state.id };
+      const body: { id: string; resources?: Record<string, number>; workers?: number; buildings?: StoredBuilding[]; routes?: TradeRoute[]; roads?: Array<{x:number;y:number}>; edicts?: Record<string, number>; map_size?: number; skills?: string[] } = { id: state.id };
       if (partial.resources) body.resources = partial.resources;
       if (typeof partial.workers === 'number') body.workers = partial.workers;
       if (partial.buildings) body.buildings = partial.buildings;
@@ -573,6 +594,7 @@ export default function PlayPage({ initialState = null, initialProposals = [] }:
       if (partial.roads) body.roads = partial.roads;
       if (partial.edicts) body.edicts = partial.edicts;
       if (typeof partial.map_size === 'number') body.map_size = partial.map_size;
+      if (partial.skills !== undefined) body.skills = partial.skills;
       const res = await fetch('/api/state', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
@@ -980,7 +1002,22 @@ export default function PlayPage({ initialState = null, initialProposals = [] }:
       }
       throw new Error(msg);
     }
-    setState({ ...json, workers: json.workers ?? 0, buildings: json.buildings ?? [], routes: (json as any).routes ?? [], roads: (json as any).roads ?? [], citizens_seed: (json as any).citizens_seed, citizens_count: (json as any).citizens_count });
+    const rawSkills = (json as any).skills;
+    const sanitizedSkills = Array.isArray(rawSkills) ? sanitizeSkillList(rawSkills) : undefined;
+
+    setState({
+      ...json,
+      workers: json.workers ?? 0,
+      buildings: json.buildings ?? [],
+      routes: (json as any).routes ?? [],
+      roads: (json as any).roads ?? [],
+      citizens_seed: (json as any).citizens_seed,
+      citizens_count: (json as any).citizens_count,
+      ...(sanitizedSkills !== undefined ? { skills: sanitizedSkills } : {}),
+    });
+    if (sanitizedSkills !== undefined) {
+      syncSkillsFromServer(sanitizedSkills);
+    }
     try { setIsPaused(!(json as any).auto_ticking); } catch {}
     try { setRoads(((json as any).roads as Array<{x:number;y:number}>) ?? []); } catch {}
     try { if ((json as any).citizens_count) setCitizensCount((json as any).citizens_count); } catch {}
@@ -995,7 +1032,7 @@ export default function PlayPage({ initialState = null, initialProposals = [] }:
         setMapSizeModalOpen(false);
       }
     } catch {}
-  }, []);
+  }, [syncSkillsFromServer]);
 
   const fetchProposals = useCallback(async () => {
     const res = await fetch("/api/proposals");
@@ -1023,6 +1060,11 @@ export default function PlayPage({ initialState = null, initialProposals = [] }:
       const json = await res.json();
       if (!res.ok) throw new Error(json.error || "Failed to tick");
       const serverState: GameState = { ...json.state, workers: json.state.workers ?? 0, buildings: json.state.buildings ?? [] };
+      const tickSkills = Array.isArray((json.state as any)?.skills) ? sanitizeSkillList((json.state as any).skills) : undefined;
+      if (tickSkills !== undefined) {
+        serverState.skills = tickSkills;
+        syncSkillsFromServer(tickSkills);
+      }
       setState(serverState);
       const assigned = serverState.buildings.reduce((sum, b) => sum + (b.workers || 0), 0);
       const simRes: SimResources = {
@@ -1068,7 +1110,7 @@ export default function PlayPage({ initialState = null, initialProposals = [] }:
     } finally {
       setLoading(false);
     }
-  }, [fetchProposals]);
+  }, [fetchProposals, syncSkillsFromServer]);
 
   // Council actions
   const generate = useCallback(async () => {
@@ -1202,7 +1244,12 @@ export default function PlayPage({ initialState = null, initialProposals = [] }:
       .on('postgres_changes', { event: '*', schema: 'public', table: 'game_state' }, (payload: { new?: unknown }) => {
         const next = payload?.new as GameState | undefined;
         if (next && typeof next === 'object') {
-          setState(next);
+          const realtimeSkills = Array.isArray((next as any).skills) ? sanitizeSkillList((next as any).skills) : undefined;
+          const patchedNext = realtimeSkills !== undefined ? { ...next, skills: realtimeSkills } : next;
+          setState(patchedNext as GameState);
+          if (realtimeSkills !== undefined) {
+            syncSkillsFromServer(realtimeSkills);
+          }
           try { setIsPaused(!(next as any).auto_ticking); } catch {}
           const assigned = (next.buildings || []).reduce((sum, b) => sum + (b.workers || 0), 0);
           setPlacedBuildings(next.buildings || []);
@@ -1226,7 +1273,7 @@ export default function PlayPage({ initialState = null, initialProposals = [] }:
       .subscribe();
 
     return () => { if (client && channel) client.removeChannel(channel); };
-  }, [fetchState, fetchProposals]);
+  }, [fetchState, fetchProposals, syncSkillsFromServer]);
 
   useEffect(() => {
     if (acceptedNotice) {
@@ -1281,6 +1328,8 @@ export default function PlayPage({ initialState = null, initialProposals = [] }:
     threat: state.resources.threat || 0
   };
 
+  const skillTreeSeed = typeof state?.skill_tree_seed === 'number' ? state.skill_tree_seed : 12345;
+
   const currentTime = timeSystem.getCurrentTime();
   const gameTime: GameTime = { 
     cycle: Math.floor(currentTime.totalMinutes / 60), // Convert to legacy cycle for HUD compatibility
@@ -1324,7 +1373,7 @@ export default function PlayPage({ initialState = null, initialProposals = [] }:
     if (!simResources) {
       return { grain: 0, wood: 0, planks: 0, coin: 0, mana: 0, favor: 0, unrest: 0, threat: 0 } as any;
     }
-    const tree = generateSkillTree(12345);
+    const tree = generateSkillTree(skillTreeSeed);
     const unlocked = tree.nodes.filter(n => unlockedSkillIds.includes(n.id));
     const acc = accumulateEffects(unlocked);
     const { updated } = projectCycleDeltas(simResources, placedBuildings, routes, SIM_BUILDINGS, {
@@ -1346,7 +1395,7 @@ export default function PlayPage({ initialState = null, initialProposals = [] }:
       unrest: 0,
       threat: 0,
     } as any;
-  }, [simResources, placedBuildings, routes, totalWorkers, edicts, unlockedSkillIds]);
+  }, [simResources, placedBuildings, routes, totalWorkers, edicts, unlockedSkillIds, skillTreeSeed]);
 
   // Shared PIXI context for Game + HUD (so HUD panels can access viewport)
   const [pixiApp, setPixiApp] = useState<PIXI.Application | null>(null);
@@ -2071,7 +2120,7 @@ export default function PlayPage({ initialState = null, initialProposals = [] }:
               tutorialFree={tutorialFree}
               onConsumeTutorialFree={(typeId) => setTutorialFree(prev => ({ ...prev, [typeId]: Math.max(0, (prev[typeId] || 0) - 1) }))}
               onTutorialProgress={(evt) => { if (evt.type === 'openedCouncil' && onboardingStep === 4) setOnboardingStep(5); }}
-              allowFineSawmill={(accumulateEffects(generateSkillTree(12345).nodes.filter(n => unlockedSkillIds.includes(n.id))).bldMul['sawmill'] ?? 1) > 1}
+              allowFineSawmill={(accumulateEffects(generateSkillTree(skillTreeSeed).nodes.filter(n => unlockedSkillIds.includes(n.id))).bldMul['sawmill'] ?? 1) > 1}
               onSetRecipe={async (buildingId, recipe) => {
                 const idx = placedBuildings.findIndex(b => b.id === buildingId);
                 if (idx === -1) return;

--- a/src/components/game/skills/storage.ts
+++ b/src/components/game/skills/storage.ts
@@ -1,0 +1,86 @@
+export function sanitizeSkillList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const entry of value) {
+    if (typeof entry === 'string' && !seen.has(entry)) {
+      seen.add(entry);
+      result.push(entry);
+    }
+  }
+
+  return result;
+}
+
+export function skillsListToRecord(skills: string[]): Record<string, boolean> {
+  return skills.reduce<Record<string, boolean>>((acc, id) => {
+    if (typeof id === 'string' && !(id in acc)) {
+      acc[id] = true;
+    }
+    return acc;
+  }, {});
+}
+
+export function recordToSkillList(record: Record<string, boolean>): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const [key, value] of Object.entries(record)) {
+    if (value && typeof key === 'string' && !seen.has(key)) {
+      seen.add(key);
+      result.push(key);
+    }
+  }
+
+  return result;
+}
+
+export function readSkillCache(): Record<string, boolean> {
+  if (typeof window === 'undefined') {
+    return {};
+  }
+
+  try {
+    const raw = window.localStorage.getItem('ad_skills_unlocked');
+    if (!raw) {
+      return {};
+    }
+
+    const parsed = JSON.parse(raw);
+
+    if (Array.isArray(parsed)) {
+      return skillsListToRecord(sanitizeSkillList(parsed));
+    }
+
+    if (parsed && typeof parsed === 'object') {
+      const result: Record<string, boolean> = {};
+      for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+        if (typeof key === 'string' && Boolean(value)) {
+          result[key] = true;
+        }
+      }
+      return result;
+    }
+  } catch {
+    // Ignore malformed cache data
+  }
+
+  return {};
+}
+
+export function writeSkillCache(skills: string[]): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    const payload = skillsListToRecord(skills);
+    window.localStorage.setItem('ad_skills_unlocked', JSON.stringify(payload));
+  } catch {
+    // Ignore storage write errors (quota, privacy settings, etc.)
+  }
+}


### PR DESCRIPTION
## Summary
- synchronize the play page skill state with data from `/api/state`, persist updates via the patch API, and reuse the server skill tree seed for simulations
- fetch authoritative skill unlocks and tree seed when opening the skill tree modal or panel, falling back to the cached list only if the server response lacks data
- add shared helpers for reading and writing the cached skill unlock list

## Testing
- npm run lint *(fails: existing repository lint violations in engine and related packages)*
- npm run test
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9ba1529188325a1189c0393cd26a9