### PR TITLE
Include selected node in skill plan cost

### DIFF
--- a/src/components/game/skills/SkillTreeModal.tsx
+++ b/src/components/game/skills/SkillTreeModal.tsx
@@ -63,28 +63,32 @@ export default function SkillTreeModal({ isOpen, onClose, resources }: SkillTree
   }, [tree, unlocked]);
 
   const plannedPath = useMemo(() => selectedNodeId ? computePathTo(selectedNodeId) : [], [selectedNodeId, computePathTo]);
+  const plannedNodes = useMemo(() => {
+    if (!selectedNodeId) return plannedPath;
+    const target = tree.nodes.find(n => n.id === selectedNodeId);
+    if (!target) return plannedPath;
+    return [...plannedPath, target];
+  }, [selectedNodeId, plannedPath, tree]);
   const plannedCost = useMemo(() => {
-    return plannedPath.reduce<{ coin: number; mana: number; favor: number }>((acc, n) => ({
+    return plannedNodes.reduce<{ coin: number; mana: number; favor: number }>((acc, n) => ({
       coin: acc.coin + (n.cost.coin || 0),
       mana: acc.mana + (n.cost.mana || 0),
       favor: acc.favor + (n.cost.favor || 0)
     }), { coin: 0, mana: 0, favor: 0 });
-  }, [plannedPath]);
+  }, [plannedNodes]);
 
   // Simulate spend: find failing step id given current resources
   const failingNodeId = useMemo(() => {
-    if (!resources || !selectedNodeId) return null;
-    const target = tree.nodes.find(n => n.id === selectedNodeId);
-    const path = [...plannedPath, ...(target ? [target] : [])];
+    if (!resources || plannedNodes.length === 0) return null;
     let coin = resources.coin || 0, mana = resources.mana || 0, favor = resources.favor || 0;
-    for (const n of path) {
+    for (const n of plannedNodes) {
       const c: { coin?: number; mana?: number; favor?: number } = n.cost || {};
       const needCoin = c.coin || 0, needMana = c.mana || 0, needFavor = c.favor || 0;
       if (coin < needCoin || mana < needMana || favor < needFavor) return n.id;
       coin -= needCoin; mana -= needMana; favor -= needFavor;
     }
     return null;
-  }, [resources, selectedNodeId, plannedPath, tree.nodes]);
+  }, [resources, plannedNodes]);
 
   // Load state and pinned targets on open
   useEffect(() => {
@@ -177,14 +181,17 @@ export default function SkillTreeModal({ isOpen, onClose, resources }: SkillTree
                   )}
                 </div>
                 {/* Path cost summary */}
-                {selectedNodeId && plannedPath.length > 0 && (
+                {plannedNodes.length > 0 && (
                   <div className="hidden md:flex items-center gap-2 text-xs bg-gray-800/70 border border-gray-700 rounded px-2 py-1 text-gray-200">
-                    <span>Path: {plannedPath.length} steps</span>
+                    <span>Unlock plan: {plannedNodes.length} {plannedNodes.length === 1 ? 'node' : 'nodes'}</span>
+                    {plannedPath.length > 0 && (
+                      <span>• prerequisites: {plannedPath.length}</span>
+                    )}
                     <span>• 🜚 {plannedCost.coin}</span>
                     <span>• ✨ {plannedCost.mana}</span>
                     <span>• ☼ {plannedCost.favor}</span>
                     {failingNodeId && (
-                      <span className="text-red-300">• fails at step: {plannedPath.findIndex(n => n.id === failingNodeId) + 1}</span>
+                      <span className="text-red-300">• fails at step: {plannedNodes.findIndex(n => n.id === failingNodeId) + 1}</span>
                     )}
                   </div>
                 )}


### PR DESCRIPTION
## Summary
- include the selected skill in the planned unlock calculation so the cost and failure simulation cover the full chain
- clarify the header summary to show total nodes, prerequisite count, and combined costs for the planned unlock

## Testing
- npm run lint
- npm run test
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9bd3298508325b3f115151435a269