### PR TITLE
Wire omen panel to simulation events

### DIFF
--- a/src/components/game/omen/types.ts
+++ b/src/components/game/omen/types.ts
@@ -1,9 +1,17 @@
+import type { ActiveEvent, EventImpact } from '@engine';
+
+type EventSeason = 'spring' | 'summer' | 'autumn' | 'winter';
+type EventDisplayType = 'blessing' | 'curse' | 'neutral' | 'crisis';
+type EventSeverity = ActiveEvent['severity'];
+type EventIcon = ActiveEvent['iconType'];
+type EventSourceType = ActiveEvent['type'];
+
 export interface SeasonalEvent {
   id: string;
   name: string;
   description: string;
-  type: 'blessing' | 'curse' | 'neutral' | 'crisis';
-  season: 'spring' | 'summer' | 'autumn' | 'winter';
+  type: EventDisplayType;
+  season: EventSeason;
   cycleOffset: number; // cycles from now
   probability: number; // 0-100
   effects: {
@@ -12,6 +20,17 @@ export interface SeasonalEvent {
   }[];
   duration?: number; // cycles, if ongoing
   isRevealed: boolean; // false for hidden/uncertain events
+  severity: EventSeverity;
+  iconType: EventIcon;
+  color: string;
+  animationType: ActiveEvent['animationType'];
+  startCycle: number;
+  endCycle: number;
+  isActive: boolean;
+  sourceEventType: EventSourceType;
+  impact: EventImpact;
+  responses?: ActiveEvent['responses'];
+  triggers?: ActiveEvent['triggers'];
 }
 
 export interface OmenReading {
@@ -21,4 +40,8 @@ export interface OmenReading {
   confidence: number; // 0-100
   revealedAt: number; // cycle when this was revealed
   events: string[]; // event IDs this reading hints at
+  relatedEventType?: EventSourceType;
+  severity?: EventSeverity;
+  iconType?: EventIcon;
+  color?: string;
 }


### PR DESCRIPTION
## Summary
- map simulation active events into structured SeasonalEvent and OmenReading data with helper formatters and real omen state management
- surface the current season from the time system, provide a stub omen reading action, and render the omen modal with live data
- expand omen type definitions to include severity, visuals, impact metadata, and related event details

## Testing
- `npm run lint` *(fails: existing lint errors across engine and UI packages)*
- `npm run test`
- `CI=1 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c9bbad3ca88325aa3da100f3f65ba1