### PR TITLE
Guard skill unlock listener until state is ready

### DIFF
--- a/src/app/play/PlayPageInternal.tsx
+++ b/src/app/play/PlayPageInternal.tsx
@@ -121,6 +121,35 @@ interface PlayPageProps {
   initialProposals?: Proposal[];
 }
 
+type SkillUnlockNotification = Pick<Notification, 'type' | 'title' | 'message'> & {
+  dedupeKey?: string;
+  dedupeMs?: number;
+};
+
+export function ensureStateForSkillUnlock(
+  state: GameState | null | undefined,
+  skill: SkillNode,
+  notify?: (notification: SkillUnlockNotification) => void,
+): state is GameState {
+  if (state) {
+    return true;
+  }
+
+  const skillLabel = skill?.title || skill?.id || 'this skill';
+  const skillId = skill?.id || 'unknown';
+  logger.warn(`Received skill unlock "${skillId}" before state hydration`);
+  if (notify) {
+    notify({
+      type: 'warning',
+      title: 'Syncing game data',
+      message: `Please wait for your city to finish loading, then try unlocking ${skillLabel} again.`,
+      dedupeKey: `skill-unlock-${skillId}-deferred`,
+      dedupeMs: 5000,
+    });
+  }
+  return false;
+}
+
 export default function PlayPage({ initialState = null, initialProposals = [] }: PlayPageProps) {
   logger.debug('🚀 PlayPage component mounting/rendering');
   const generateId = useIdGenerator();
@@ -523,16 +552,19 @@ export default function PlayPage({ initialState = null, initialProposals = [] }:
     const onUnlock = async (e: any) => {
       const n = e.detail as SkillNode;
       if (unlockedSkillIds.includes(n.id)) return;
+      if (!ensureStateForSkillUnlock(state, n, notify)) {
+        return;
+      }
       const needed = { coin: n.cost.coin || 0, mana: n.cost.mana || 0, favor: n.cost.favor || 0 } as Record<string, number>;
-      const have = { coin: state?.resources.coin || 0, mana: state?.resources.mana || 0, favor: state?.resources.favor || 0 } as Record<string, number>;
+      const have = { coin: state.resources.coin || 0, mana: state.resources.mana || 0, favor: state.resources.favor || 0 } as Record<string, number>;
       if (have.coin < needed.coin || have.mana < needed.mana || have.favor < needed.favor) return;
-      const newResServer = { ...state!.resources } as Record<string, number>;
+      const newResServer = { ...state.resources } as Record<string, number>;
       newResServer.coin = Math.max(0, newResServer.coin - needed.coin);
       newResServer.mana = Math.max(0, newResServer.mana - needed.mana);
       newResServer.favor = Math.max(0, newResServer.favor - needed.favor);
       const nextSkills = [...unlockedSkillIds, n.id];
       setState(prev => prev ? { ...prev, resources: newResServer, skills: nextSkills as any } : prev);
-      await saveState({ resources: newResServer, buildings: placedBuildings, routes, workers: state?.workers, skills: nextSkills } as any);
+      await saveState({ resources: newResServer, buildings: placedBuildings, routes, workers: state.workers, skills: nextSkills } as any);
       setUnlockedSkillIds(nextSkills);
       notify({ type: 'success', title: 'Skill Unlocked', message: n.title })
       try {

--- a/src/app/play/__tests__/PlayPageInternal.unlock.test.ts
+++ b/src/app/play/__tests__/PlayPageInternal.unlock.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { ensureStateForSkillUnlock } from '../PlayPageInternal';
+import logger from '@/lib/logger';
+import type { SkillNode } from '@/components/game/skills/types';
+
+describe('ensureStateForSkillUnlock', () => {
+  const skill: SkillNode = {
+    id: 'test-skill',
+    title: 'Test Skill',
+    description: 'A skill used for testing.',
+    category: 'mystical',
+    rarity: 'common',
+    quality: 'common',
+    tags: [],
+    cost: {},
+    baseCost: {},
+    effects: [],
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('warns and notifies when the state has not hydrated yet', () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const notify = vi.fn();
+
+    const result = ensureStateForSkillUnlock(null, skill, notify);
+
+    expect(result).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith('Received skill unlock "test-skill" before state hydration');
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'warning',
+        title: 'Syncing game data',
+      }),
+    );
+  });
+
+  it('allows unlock processing when state is present', () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const notify = vi.fn();
+
+    const hydratedState = {
+      id: 'state-1',
+      cycle: 1,
+      resources: { coin: 0, mana: 0, favor: 0 },
+      workers: 0,
+      buildings: [],
+    };
+
+    const result = ensureStateForSkillUnlock(hydratedState, skill, notify);
+
+    expect(result).toBe(true);
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalled();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,8 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 export default defineConfig({
   resolve: {
     alias: {
+      '@/utils/performance': resolve(__dirname, 'packages/utils/performance'),
+      '@': resolve(__dirname, 'src'),
       '@arcane/ui': resolve(__dirname, 'packages/ui/src'),
       '@engine': resolve(__dirname, 'packages/engine/src'),
     },


### PR DESCRIPTION
## Summary
- add a reusable guard that logs and notifies when a skill unlock arrives before the game state hydrates
- bail out of the unlock listener when hydration has not finished so we avoid dereferencing null state
- cover the guard with a unit test and ensure Vitest can resolve the repo's alias map

## Testing
- npm run lint
- npm run test
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9bd3c581c83258bd971d0c58c163d