### PR TITLE
Handle skill special ability modifiers

### DIFF
--- a/src/app/play/PlayPageInternal.tsx
+++ b/src/app/play/PlayPageInternal.tsx
@@ -1323,6 +1323,11 @@ export default function PlayPage({ initialState = null, initialProposals = [] }:
         resourceOutputMultiplier: acc.resMul as any,
         buildingOutputMultiplier: acc.bldMul,
         upkeepGrainPerWorkerDelta: acc.upkeepDelta,
+        globalBuildingOutputMultiplier: acc.globalBuildingMultiplier,
+        globalResourceOutputMultiplier: acc.globalResourceMultiplier,
+        routeCoinOutputMultiplier: acc.routeCoinMultiplier,
+        patrolCoinUpkeepMultiplier: acc.patrolCoinUpkeepMultiplier,
+        buildingInputMultiplier: acc.buildingInputMultiplier,
       }
     });
     return {

--- a/src/components/game/skills/progression.test.ts
+++ b/src/components/game/skills/progression.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { accumulateEffects } from './progression';
+import type { SkillNode } from './types';
+
+const makeNode = (id: string, overrides: Partial<SkillNode> = {}): SkillNode => ({
+  id,
+  title: overrides.title ?? `Node ${id}`,
+  description: overrides.description ?? 'Test node',
+  category: overrides.category ?? 'economic',
+  rarity: overrides.rarity ?? 'rare',
+  quality: overrides.quality ?? 'epic',
+  tags: overrides.tags ?? [],
+  cost: overrides.cost ?? {},
+  baseCost: overrides.baseCost ?? {},
+  effects: overrides.effects ?? [],
+  requires: overrides.requires,
+  tier: overrides.tier,
+  importance: overrides.importance,
+  unlockCount: overrides.unlockCount,
+  isRevealed: overrides.isRevealed,
+  specialAbility: overrides.specialAbility,
+  statMultiplier: overrides.statMultiplier,
+  exclusiveGroup: overrides.exclusiveGroup,
+  unlockConditions: overrides.unlockConditions,
+});
+
+describe('accumulateEffects special abilities', () => {
+  it('boosts mana production with mana storm', () => {
+    const node = makeNode('mana', {
+      category: 'mystical',
+      quality: 'legendary',
+      specialAbility: {
+        id: 'mana_storm',
+        name: 'Mana Storm',
+        description: 'Triples mana generation.',
+        power: 3,
+        quality: 'legendary',
+      },
+    });
+    const acc = accumulateEffects([node]);
+    expect(acc.resMul.mana).toBeCloseTo(3, 5);
+    expect(acc.globalResourceMultiplier).toBeCloseTo(1 + 0.05 * 3, 5);
+  });
+
+  it('doubles economic building output with golden touch', () => {
+    const node = makeNode('gold', {
+      category: 'economic',
+      quality: 'legendary',
+      specialAbility: {
+        id: 'golden_touch',
+        name: 'Golden Touch',
+        description: 'Doubles coin generation from economic buildings.',
+        power: 2,
+        quality: 'legendary',
+      },
+    });
+    const acc = accumulateEffects([node]);
+    expect(acc.bldMul.trade_post).toBeCloseTo(2, 5);
+    expect(acc.bldMul.automation_workshop).toBeCloseTo(2, 5);
+  });
+
+  it('improves routes through market insight', () => {
+    const node = makeNode('routes', {
+      category: 'economic',
+      specialAbility: {
+        id: 'market_insight',
+        name: 'Market Insight',
+        description: 'Improves tariffs and routes.',
+        power: 1.5,
+        quality: 'epic',
+      },
+    });
+    const acc = accumulateEffects([node]);
+    expect(acc.routeCoinMultiplier).toBeCloseTo(1.5, 5);
+    expect(acc.bldMul.trade_post).toBeGreaterThan(1);
+  });
+
+  it('reduces input costs with unity bond', () => {
+    const node = makeNode('unity', {
+      category: 'social',
+      specialAbility: {
+        id: 'unity_bond',
+        name: 'Unity Bond',
+        description: 'Reduces costs across the board.',
+        power: 0.7,
+        quality: 'epic',
+      },
+    });
+    const acc = accumulateEffects([node]);
+    expect(acc.buildingInputMultiplier).toBeCloseTo(0.7, 5);
+    expect(acc.upkeepDelta).toBeLessThan(0);
+  });
+});

--- a/src/lib/__tests__/gameContext.test.ts
+++ b/src/lib/__tests__/gameContext.test.ts
@@ -26,6 +26,11 @@ describe('buildGameContext', () => {
         resource_multipliers: {},
         building_multipliers: {},
         upkeep_grain_per_worker_delta: 0,
+        global_building_output_multiplier: 1,
+        global_resource_output_multiplier: 1,
+        route_coin_output_multiplier: 1,
+        patrol_coin_upkeep_multiplier: 1,
+        building_input_multiplier: 1,
       },
     })
   })
@@ -41,6 +46,11 @@ describe('buildGameContext', () => {
       resource_multipliers: expected.resMul,
       building_multipliers: expected.bldMul,
       upkeep_grain_per_worker_delta: expected.upkeepDelta,
+      global_building_output_multiplier: expected.globalBuildingMultiplier,
+      global_resource_output_multiplier: expected.globalResourceMultiplier,
+      route_coin_output_multiplier: expected.routeCoinMultiplier,
+      patrol_coin_upkeep_multiplier: expected.patrolCoinUpkeepMultiplier,
+      building_input_multiplier: expected.buildingInputMultiplier,
     })
   })
 })

--- a/src/lib/gameContext.ts
+++ b/src/lib/gameContext.ts
@@ -19,6 +19,11 @@ export interface GameContext {
     resource_multipliers: Record<string, number>
     building_multipliers: Record<string, number>
     upkeep_grain_per_worker_delta: number
+    global_building_output_multiplier: number
+    global_resource_output_multiplier: number
+    route_coin_output_multiplier: number
+    patrol_coin_upkeep_multiplier: number
+    building_input_multiplier: number
   }
 }
 
@@ -53,6 +58,11 @@ export function buildGameContext(state: unknown): GameContext {
     resource_multipliers: {},
     building_multipliers: {},
     upkeep_grain_per_worker_delta: 0,
+    global_building_output_multiplier: 1,
+    global_resource_output_multiplier: 1,
+    route_coin_output_multiplier: 1,
+    patrol_coin_upkeep_multiplier: 1,
+    building_input_multiplier: 1,
   }
   const skills: string[] = Array.isArray(stateObj.skills) ? stateObj.skills : []
   if (skills.length > 0) {
@@ -64,6 +74,11 @@ export function buildGameContext(state: unknown): GameContext {
         resource_multipliers: acc.resMul,
         building_multipliers: acc.bldMul,
         upkeep_grain_per_worker_delta: acc.upkeepDelta,
+        global_building_output_multiplier: acc.globalBuildingMultiplier,
+        global_resource_output_multiplier: acc.globalResourceMultiplier,
+        route_coin_output_multiplier: acc.routeCoinMultiplier,
+        patrol_coin_upkeep_multiplier: acc.patrolCoinUpkeepMultiplier,
+        building_input_multiplier: acc.buildingInputMultiplier,
       }
     } catch {
       // ignore skill tree errors


### PR DESCRIPTION
## Summary
- map skill special abilities to passive production modifiers and expose them via `accumulateEffects`
- update cycle projection, game context, and the play page to consume the new modifiers
- add tests covering special ability modifiers and the new production modifier behaviors

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9bd6e836c8325bde8eee2d474c2d5