### PR TITLE
feat: add interactive omen responses

### DIFF
--- a/src/components/game/OmenPanel.tsx
+++ b/src/components/game/OmenPanel.tsx
@@ -17,6 +17,8 @@ export interface OmenPanelProps {
   canRequestReading: boolean;
   readingCost: number;
   currentMana: number;
+  onRespondToEvent?: (eventId: string, responseId: string) => void | Promise<void>;
+  respondingTo?: { eventId: string; responseId: string } | null;
 }
 
 const TimelineView: React.FC<{
@@ -77,7 +79,9 @@ export const OmenPanel: React.FC<OmenPanelProps> = ({
   onRequestReading,
   canRequestReading,
   readingCost,
-  currentMana
+  currentMana,
+  onRespondToEvent,
+  respondingTo
 }) => {
   const revealedEvents = upcomingEvents.filter(e => e.isRevealed);
   const hiddenEvents = upcomingEvents.filter(e => !e.isRevealed);
@@ -163,7 +167,13 @@ export const OmenPanel: React.FC<OmenPanelProps> = ({
                     </h3>
                     <div className="grid gap-4">
                       {imminentEvents.map(event => (
-                        <EventCard key={event.id} event={event} currentCycle={currentCycle} />
+                        <EventCard
+                          key={event.id}
+                          event={event}
+                          currentCycle={currentCycle}
+                          onRespond={onRespondToEvent}
+                          pendingResponse={respondingTo}
+                        />
                       ))}
                     </div>
                   </div>
@@ -178,7 +188,13 @@ export const OmenPanel: React.FC<OmenPanelProps> = ({
                         .filter(e => !imminentEvents.some(ie => ie.id === e.id))
                         .slice(0, 6)
                         .map(event => (
-                          <EventCard key={event.id} event={event} currentCycle={currentCycle} />
+                          <EventCard
+                            key={event.id}
+                            event={event}
+                            currentCycle={currentCycle}
+                            onRespond={onRespondToEvent}
+                            pendingResponse={respondingTo}
+                          />
                         ))}
                     </div>
                   </div>
@@ -190,7 +206,13 @@ export const OmenPanel: React.FC<OmenPanelProps> = ({
                     <h3 className="text-lg font-semibold text-gray-400 mb-4">❓ Mysterious Portents</h3>
                     <div className="grid gap-4">
                       {hiddenEvents.slice(0, 3).map(event => (
-                        <EventCard key={event.id} event={event} currentCycle={currentCycle} />
+                        <EventCard
+                          key={event.id}
+                          event={event}
+                          currentCycle={currentCycle}
+                          onRespond={onRespondToEvent}
+                          pendingResponse={respondingTo}
+                        />
                       ))}
                     </div>
                   </div>

--- a/src/components/game/omen/EventCard.tsx
+++ b/src/components/game/omen/EventCard.tsx
@@ -5,12 +5,43 @@ import { EventTypeIcon, SeasonIcon } from './icons';
 interface EventCardProps {
   event: SeasonalEvent;
   currentCycle: number;
+  onRespond?: (eventId: string, responseId: string) => void | Promise<void>;
+  pendingResponse?: { eventId: string; responseId: string } | null;
 }
 
-const EventCard: React.FC<EventCardProps> = ({ event, currentCycle }) => {
+const formatResourceKey = (key: string) => {
+  switch (key) {
+    case 'grain': return 'Grain';
+    case 'coin': return 'Coin';
+    case 'mana': return 'Mana';
+    case 'favor': return 'Favor';
+    case 'wood': return 'Wood';
+    case 'planks': return 'Planks';
+    case 'workers': return 'Workers';
+    case 'happiness': return 'Happiness';
+    case 'stress': return 'Stress';
+    case 'motivation': return 'Motivation';
+    case 'conditionChange': return 'Condition';
+    case 'efficiencyMultiplier': return 'Efficiency';
+    case 'maintenanceCostMultiplier': return 'Maintenance';
+    case 'growthRate': return 'Growth Rate';
+    case 'tradeMultiplier': return 'Trade';
+    case 'wageMultiplier': return 'Wages';
+    default:
+      return key.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase());
+  }
+};
+
+const EventCard: React.FC<EventCardProps> = ({
+  event,
+  currentCycle,
+  onRespond,
+  pendingResponse,
+}) => {
   const targetCycle = currentCycle + event.cycleOffset;
   const isImminent = event.cycleOffset <= 3;
   const isDistant = event.cycleOffset > 10;
+  const pendingResponseId = pendingResponse?.eventId === event.id ? pendingResponse?.responseId : null;
 
   const getTypeColor = (type: SeasonalEvent['type']) => {
     switch (type) {
@@ -18,8 +49,8 @@ const EventCard: React.FC<EventCardProps> = ({ event, currentCycle }) => {
       case 'curse': return 'border-rose-700/60 bg-rose-900/20';
       case 'crisis': return 'border-amber-700/60 bg-amber-900/20';
       default: return 'border-gray-700 bg-gray-900/20';
-    }
-  };
+      }
+    };
 
   const getProbabilityColor = (probability: number) => {
     if (probability >= 80) return 'text-rose-400';
@@ -88,6 +119,77 @@ const EventCard: React.FC<EventCardProps> = ({ event, currentCycle }) => {
       {event.duration && event.duration > 1 && (
         <div className="mt-2 text-xs text-gray-400">
           Duration: {event.duration} cycles
+        </div>
+      )}
+
+      {/* Response options */}
+      {event.responses && event.responses.length > 0 && (
+        <div className="mt-4 space-y-3">
+          <div className="text-xs uppercase tracking-wide text-gray-400">Possible Responses</div>
+          {event.responses.map((response) => {
+            const costEntries = Object.entries(response.cost || {}).filter(([, value]) => (value ?? 0) > 0);
+            const isPending = pendingResponseId === response.id;
+            const isDisabled = !onRespond || isPending || !response.isAffordable;
+
+            return (
+              <div
+                key={response.id}
+                className="border border-gray-700/70 bg-gray-900/30 rounded-md p-3 space-y-2"
+              >
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                  <div>
+                    <div className="text-sm font-medium text-gray-100">{response.label}</div>
+                    {response.description && (
+                      <p className="text-xs text-gray-400 mt-1">
+                        {response.description}
+                      </p>
+                    )}
+                  </div>
+                  <button
+                    type="button"
+                    className={`self-start text-xs px-3 py-1.5 rounded border transition-colors ${
+                      isDisabled
+                        ? 'border-gray-700 text-gray-500 cursor-not-allowed'
+                        : 'border-blue-500/60 text-blue-300 hover:bg-blue-500/10'
+                    }`}
+                    onClick={() => { if (!isDisabled) void onRespond?.(event.id, response.id); }}
+                    disabled={isDisabled}
+                  >
+                    {isPending ? 'Applying…' : 'Select Response'}
+                  </button>
+                </div>
+
+                {costEntries.length > 0 && (
+                  <div className="flex flex-wrap gap-2">
+                    {costEntries.map(([resource, amount]) => (
+                      <span
+                        key={`${response.id}-cost-${resource}`}
+                        className={`text-[11px] px-2 py-1 rounded-full border ${
+                          response.isAffordable ? 'border-amber-500/50 text-amber-200 bg-amber-900/20' : 'border-rose-500/50 text-rose-200 bg-rose-900/10'
+                        }`}
+                      >
+                        {formatResourceKey(resource)} −{Math.abs(Number(amount ?? 0))}
+                      </span>
+                    ))}
+                  </div>
+                )}
+
+                {response.effectHints.length > 0 && (
+                  <ul className="text-xs text-blue-200 space-y-1 list-disc list-inside">
+                    {response.effectHints.map((hint, idx) => (
+                      <li key={`${response.id}-effect-${idx}`}>{hint}</li>
+                    ))}
+                  </ul>
+                )}
+
+                {!response.isAffordable && response.missingResources.length > 0 && (
+                  <div className="text-xs text-rose-300">
+                    Requires more: {response.missingResources.map(formatResourceKey).join(', ')}
+                  </div>
+                )}
+              </div>
+            );
+          })}
         </div>
       )}
     </div>

--- a/src/components/game/omen/types.ts
+++ b/src/components/game/omen/types.ts
@@ -1,3 +1,16 @@
+import type { EventImpact } from '@engine';
+
+export interface SeasonalEventResponse {
+  id: string;
+  label: string;
+  description: string;
+  cost: Partial<Record<string, number>>;
+  effect?: Partial<EventImpact>;
+  effectHints: string[];
+  isAffordable: boolean;
+  missingResources: string[];
+}
+
 export interface SeasonalEvent {
   id: string;
   name: string;
@@ -12,6 +25,7 @@ export interface SeasonalEvent {
   }[];
   duration?: number; // cycles, if ongoing
   isRevealed: boolean; // false for hidden/uncertain events
+  responses?: SeasonalEventResponse[];
 }
 
 export interface OmenReading {


### PR DESCRIPTION
## Summary
- surface active event response options in the omen panel with cost and effect hints
- wire PlayPage to translate engine events, handle response actions, update resources, and refresh the event list
- extend omen event types so response metadata flows cleanly from the simulation layer to the UI

## Testing
- npm run lint *(fails: repository contains numerous pre-existing lint/type errors across engine and UI files)*
- npm run test
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9bbadf5048325bc7249b908888ca5