### PR TITLE
Add leyline drawing controls and inspector

### DIFF
--- a/apps/web/features/leylines/LeylineSystem.tsx
+++ b/apps/web/features/leylines/LeylineSystem.tsx
@@ -19,6 +19,7 @@ export interface LeylineSystemProps {
   onLeylineSelect?: (leyline: Leyline | null) => void;
   selectedLeyline?: Leyline | null;
   isDrawingMode?: boolean;
+  onLeylineRemove?: (leylineId: string) => void;
 }
 
 export const LeylineSystem: React.FC<LeylineSystemProps> = ({
@@ -26,7 +27,8 @@ export const LeylineSystem: React.FC<LeylineSystemProps> = ({
   onLeylineCreate,
   onLeylineSelect,
   selectedLeyline,
-  isDrawingMode = false
+  isDrawingMode = false,
+  onLeylineRemove,
 }) => {
   const { app, viewport } = useGameContext();
   const containerRef = useRef<PIXI.Container | null>(null);
@@ -111,12 +113,22 @@ export const LeylineSystem: React.FC<LeylineSystemProps> = ({
       fromWorld.x + thickness, fromWorld.y + thickness
     ]);
     
-    graphics.on('pointerdown', () => {
+    graphics.on('pointerdown', (event: PIXI.FederatedPointerEvent) => {
+      if (event.button === 2) {
+        event.preventDefault();
+        onLeylineRemove?.(leyline.id);
+        return;
+      }
       onLeylineSelect?.(leyline);
     });
-    
+
+    graphics.on('rightdown', (event: PIXI.FederatedPointerEvent) => {
+      event.preventDefault();
+      onLeylineRemove?.(leyline.id);
+    });
+
     return graphics;
-  }, [gridToWorld, selectedLeyline, onLeylineSelect]);
+  }, [gridToWorld, selectedLeyline, onLeylineSelect, onLeylineRemove]);
 
   // Create capacity label
   const createCapacityLabel = useCallback((leyline: Leyline) => {

--- a/src/app/play/PlayPageInternal.tsx
+++ b/src/app/play/PlayPageInternal.tsx
@@ -63,6 +63,7 @@ type BuildTypeId = keyof typeof SIM_BUILDINGS;
 
 const ISO_TILE_WIDTH = 64;
 const ISO_TILE_HEIGHT = 32;
+const LEYLINE_STORAGE_KEY = 'ad_leylines';
 
 const arraysEqual = (a: string[], b: string[]) =>
   a.length === b.length && a.every((value, index) => value === b[index]);
@@ -319,6 +320,46 @@ export default function PlayPage({ initialState = null, initialProposals = [] }:
   const [districts, _setDistricts] = useState<District[]>([]);
   const [leylines, setLeylines] = useState<Leyline[]>([]);
 
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const stored = localStorage.getItem(LEYLINE_STORAGE_KEY);
+      if (!stored) return;
+      const parsed = JSON.parse(stored);
+      if (!Array.isArray(parsed)) return;
+
+      const sanitized: Leyline[] = parsed
+        .filter((value): value is Leyline => {
+          if (!value || typeof value !== 'object') return false;
+          const candidate = value as Record<string, unknown>;
+          return (
+            typeof candidate.id === 'string' &&
+            typeof candidate.fromX === 'number' &&
+            typeof candidate.fromY === 'number' &&
+            typeof candidate.toX === 'number' &&
+            typeof candidate.toY === 'number' &&
+            typeof candidate.capacity === 'number' &&
+            typeof candidate.currentFlow === 'number' &&
+            typeof candidate.isActive === 'boolean'
+          );
+        })
+        .map((value) => {
+          const capacity = Math.max(0, value.capacity);
+          return {
+            ...value,
+            capacity,
+            currentFlow: Math.max(0, Math.min(value.currentFlow, capacity)),
+          };
+        });
+
+      if (sanitized.length > 0) {
+        setLeylines(sanitized);
+      }
+    } catch (err) {
+      logger.warn('Failed to load stored leylines', err);
+    }
+  }, []);
+
   const [mapSizeModalOpen, setMapSizeModalOpen] = useState(true);
   const [pendingMapSize, setPendingMapSize] = useState<number>(32);
 
@@ -570,7 +611,7 @@ export default function PlayPage({ initialState = null, initialProposals = [] }:
   const [tooltipLocked, setTooltipLocked] = useState(false);
   const [clickEffectKey, setClickEffectKey] = useState<string | null>(null);
   const [selectedLeyline, setSelectedLeyline] = useState<Leyline | null>(null);
-  const [isDrawingMode, _setIsDrawingMode] = useState(false);
+  const [isLeylineDrawing, setIsLeylineDrawing] = useState(false);
   const hasAutoOpenedCouncilRef = useRef(false);
   const [routeHoverToId, setRouteHoverToId] = useState<string | null>(null);
   const [assignLines, setAssignLines] = useState<AssignLine[]>([]);
@@ -628,6 +669,83 @@ export default function PlayPage({ initialState = null, initialProposals = [] }:
     }
     setMapSizeModalOpen(false);
   }, [pendingMapSize, state, saveState]);
+
+  const updateLeylines = useCallback((updater: (prev: Leyline[]) => Leyline[]) => {
+    setLeylines(prev => {
+      const next = updater(prev);
+      if (typeof window !== 'undefined') {
+        try {
+          localStorage.setItem(LEYLINE_STORAGE_KEY, JSON.stringify(next));
+        } catch (err) {
+          logger.warn('Failed to persist leylines', err);
+        }
+      }
+      return next;
+    });
+  }, []);
+
+  const handleLeylineCreate = useCallback((fromX: number, fromY: number, toX: number, toY: number) => {
+    const newLeyline: Leyline = {
+      id: generateId(),
+      fromX: Math.round(fromX),
+      fromY: Math.round(fromY),
+      toX: Math.round(toX),
+      toY: Math.round(toY),
+      capacity: 100,
+      currentFlow: 0,
+      isActive: true,
+    };
+    updateLeylines(prev => [...prev, newLeyline]);
+    setSelectedLeyline(newLeyline);
+  }, [generateId, updateLeylines]);
+
+  const handleLeylineDelete = useCallback((id: string) => {
+    updateLeylines(prev => prev.filter(leyline => leyline.id !== id));
+    setSelectedLeyline(prev => (prev && prev.id === id ? null : prev));
+  }, [updateLeylines]);
+
+  const handleLeylineUpdate = useCallback((id: string, updates: Partial<Leyline>) => {
+    let updated: Leyline | null = null;
+    updateLeylines(prev => prev.map(leyline => {
+      if (leyline.id !== id) return leyline;
+      const nextCapacity = updates.capacity !== undefined ? Math.max(0, Math.round(updates.capacity)) : leyline.capacity;
+      const rawFlow = updates.currentFlow !== undefined ? Math.max(0, Math.round(updates.currentFlow)) : leyline.currentFlow;
+      const nextFlow = Math.min(rawFlow, nextCapacity);
+      const next: Leyline = {
+        ...leyline,
+        ...updates,
+        id: leyline.id,
+        capacity: nextCapacity,
+        currentFlow: nextFlow,
+        isActive: updates.isActive !== undefined ? updates.isActive : leyline.isActive,
+      };
+      updated = next;
+      return next;
+    }));
+    if (updated) {
+      setSelectedLeyline(updated);
+    }
+  }, [updateLeylines]);
+
+  useEffect(() => {
+    if (!selectedLeyline) return;
+    const latest = leylines.find(l => l.id === selectedLeyline.id);
+    if (!latest) {
+      setSelectedLeyline(null);
+      return;
+    }
+    if (
+      latest.capacity !== selectedLeyline.capacity ||
+      latest.currentFlow !== selectedLeyline.currentFlow ||
+      latest.isActive !== selectedLeyline.isActive ||
+      latest.fromX !== selectedLeyline.fromX ||
+      latest.fromY !== selectedLeyline.fromY ||
+      latest.toX !== selectedLeyline.toX ||
+      latest.toY !== selectedLeyline.toY
+    ) {
+      setSelectedLeyline(latest);
+    }
+  }, [leylines, selectedLeyline]);
 
   const computeRoadPath = useCallback((sx:number, sy:number, tx:number, ty:number): Array<{x:number;y:number}> => {
     // Lightweight Dijkstra with road preference
@@ -1611,6 +1729,9 @@ export default function PlayPage({ initialState = null, initialProposals = [] }:
               leylines={leylines}
               selectedLeyline={selectedLeyline}
               setSelectedLeyline={setSelectedLeyline}
+              isLeylineDrawing={isLeylineDrawing}
+              onLeylineCreate={handleLeylineCreate}
+              onLeylineRemove={handleLeylineDelete}
               resources={resources}
               cycle={state.cycle ?? 0}
               constructionEvents={constructionEvents}
@@ -1629,6 +1750,91 @@ export default function PlayPage({ initialState = null, initialProposals = [] }:
               <div className="px-3 py-1.5 rounded-full bg-blue-900/30 text-blue-300 border border-blue-700/60 text-xs shadow-sm">{msg}</div>
             );
           })()}
+        </div>
+      )}
+
+      {selectedLeyline && (
+        <div className="fixed right-6 top-24 z-[12000] w-72 max-w-full pointer-events-auto">
+          <div className="rounded-lg border border-blue-700/60 bg-slate-900/95 p-4 shadow-xl backdrop-blur">
+            <div className="flex items-start justify-between gap-2">
+              <div>
+                <h3 className="text-sm font-semibold text-blue-200">Leyline Inspector</h3>
+                <p className="mt-1 text-xs text-gray-400">
+                  {`(${selectedLeyline.fromX}, ${selectedLeyline.fromY}) → (${selectedLeyline.toX}, ${selectedLeyline.toY})`}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setSelectedLeyline(null)}
+                className="rounded-full p-1 text-gray-400 hover:text-gray-200 hover:bg-slate-800"
+                aria-label="Close leyline inspector"
+              >
+                <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" stroke="currentColor" fill="none">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+            <div className="mt-3 space-y-3 text-xs text-gray-200">
+              <div>
+                <label className="block text-[11px] uppercase tracking-wide text-gray-400">Capacity</label>
+                <input
+                  type="number"
+                  min={0}
+                  step={10}
+                  value={selectedLeyline.capacity}
+                  onChange={(event) => {
+                    const parsed = Number(event.target.value);
+                    const sanitized = Number.isFinite(parsed) ? Math.max(0, Math.round(parsed)) : 0;
+                    const adjustedFlow = Math.min(selectedLeyline.currentFlow, sanitized);
+                    handleLeylineUpdate(selectedLeyline.id, { capacity: sanitized, currentFlow: adjustedFlow });
+                  }}
+                  className="mt-1 w-full rounded border border-slate-700 bg-slate-800 px-2 py-1 text-sm text-gray-100 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-400"
+                />
+              </div>
+              <div>
+                <label className="block text-[11px] uppercase tracking-wide text-gray-400">Current Flow</label>
+                <input
+                  type="number"
+                  min={0}
+                  step={5}
+                  value={selectedLeyline.currentFlow}
+                  onChange={(event) => {
+                    const parsed = Number(event.target.value);
+                    const sanitized = Number.isFinite(parsed) ? Math.max(0, Math.round(parsed)) : 0;
+                    handleLeylineUpdate(selectedLeyline.id, { currentFlow: Math.min(sanitized, selectedLeyline.capacity) });
+                  }}
+                  className="mt-1 w-full rounded border border-slate-700 bg-slate-800 px-2 py-1 text-sm text-gray-100 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-400"
+                />
+                <p className="mt-1 text-[11px] text-gray-400">
+                  {selectedLeyline.capacity === 0
+                    ? 'No capacity assigned yet.'
+                    : `${Math.round((selectedLeyline.currentFlow / Math.max(1, selectedLeyline.capacity)) * 100)}% utilized`}
+                </p>
+              </div>
+              <div className="flex items-center gap-2 text-[11px]">
+                <span className="text-gray-400">Status:</span>
+                <span className={`font-medium ${selectedLeyline.isActive ? 'text-emerald-300' : 'text-gray-400'}`}>
+                  {selectedLeyline.isActive ? 'Active' : 'Dormant'}
+                </span>
+              </div>
+              <div className="flex gap-2 pt-1">
+                <button
+                  type="button"
+                  onClick={() => handleLeylineUpdate(selectedLeyline.id, { isActive: !selectedLeyline.isActive })}
+                  className={`flex-1 rounded px-2 py-1 text-sm font-medium transition-colors ${selectedLeyline.isActive ? 'bg-blue-600 text-white hover:bg-blue-500' : 'bg-slate-700 text-gray-100 hover:bg-slate-600'}`}
+                >
+                  {selectedLeyline.isActive ? 'Pause Flow' : 'Resume Flow'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleLeylineDelete(selectedLeyline.id)}
+                  className="rounded px-2 py-1 text-sm font-medium text-white bg-red-600 hover:bg-red-500"
+                >
+                  Delete
+                </button>
+              </div>
+            </div>
+          </div>
         </div>
       )}
 
@@ -1793,6 +1999,7 @@ export default function PlayPage({ initialState = null, initialProposals = [] }:
               time: { ...gameTime, isPaused, intervalMs: Number((state as any)?.tick_interval_ms ?? 60000) }
             }}
             map={miniMapDescriptor}
+            isLeylineDrawing={isLeylineDrawing}
             cityManagement={{
               stats: {
                 population: placedBuildings.reduce((sum, b) => sum + (b.workers || 0), 0),
@@ -1860,6 +2067,9 @@ export default function PlayPage({ initialState = null, initialProposals = [] }:
                   headers: { 'Content-Type': 'application/json' },
                   body: JSON.stringify({ id: state.id, tick_interval_ms: sanitizedMs })
                 });
+              }
+              if (action === 'toggle-leylines') {
+                setIsLeylineDrawing(prev => !prev);
               }
               if (action === 'open-council') setIsCouncilOpen(true);
               if (action === 'open-edicts') setIsEdictsOpen(true);

--- a/src/components/game/GameLayers.tsx
+++ b/src/components/game/GameLayers.tsx
@@ -64,6 +64,9 @@ export interface GameLayersProps {
   leylines: Leyline[];
   selectedLeyline: Leyline | null;
   setSelectedLeyline: (l: Leyline | null) => void;
+  isLeylineDrawing?: boolean;
+  onLeylineCreate?: (fromX: number, fromY: number, toX: number, toY: number) => void;
+  onLeylineRemove?: (leylineId: string) => void;
   resources: GameResources;
   cycle: number;
   constructionEvents: Array<{
@@ -101,6 +104,9 @@ const GameLayers: React.FC<GameLayersProps> = ({
   leylines,
   selectedLeyline,
   setSelectedLeyline,
+  isLeylineDrawing = false,
+  onLeylineCreate,
+  onLeylineRemove,
   resources,
   cycle,
   constructionEvents,
@@ -146,7 +152,14 @@ const GameLayers: React.FC<GameLayersProps> = ({
         affordable={previewTypeId ? ((tutorialFree[previewTypeId] || 0) > 0 || (simResources ? canAfford(SIM_BUILDINGS[previewTypeId].cost, simResources) : false)) : false}
       />
       <DistrictSprites districts={districts} tileTypes={tileTypes} onDistrictHover={() => {}} />
-      <LeylineSystem leylines={leylines} onLeylineCreate={() => {}} onLeylineSelect={setSelectedLeyline} selectedLeyline={selectedLeyline} isDrawingMode={false} />
+      <LeylineSystem
+        leylines={leylines}
+        onLeylineCreate={onLeylineCreate}
+        onLeylineSelect={setSelectedLeyline}
+        selectedLeyline={selectedLeyline}
+        isDrawingMode={isLeylineDrawing}
+        onLeylineRemove={onLeylineRemove}
+      />
       <HeatLayer gridSize={Math.max(tileTypes.length, tileTypes[0]?.length ?? 0)} tileWidth={64} tileHeight={32} unrest={resources.unrest} threat={resources.threat} />
       {(() => {
         const connected = new Set<string>();

--- a/src/components/game/hud/PanelComposer.tsx
+++ b/src/components/game/hud/PanelComposer.tsx
@@ -66,6 +66,7 @@ export interface PanelComposerProps {
   onGameAction: (action: string, data?: unknown) => void;
   className?: string;
   map?: MiniMapDescriptor;
+  isLeylineDrawing?: boolean;
 }
 
 export function PanelComposer({
@@ -75,6 +76,7 @@ export function PanelComposer({
   cityManagement,
   map,
   className = '',
+  isLeylineDrawing = false,
 }: PanelComposerProps) {
   const { currentPreset } = useHUDLayoutPresets();
 
@@ -153,11 +155,13 @@ export function PanelComposer({
           onOpenEdicts={() => onGameAction('open-edicts')}
           onOpenOmens={() => onGameAction('open-omens')}
           onOpenSettings={() => onGameAction('open-settings')}
+          onToggleLeylineDrawing={() => onGameAction('toggle-leylines')}
           intervalMs={gameData.time.intervalMs}
           onChangeIntervalMs={(ms) =>
             onGameAction('set-speed', { intervalMs: ms, ms })
           }
           variant={currentPreset.panelVariants['action-panel'] || 'default'}
+          isLeylineDrawing={isLeylineDrawing}
         />
         <div className="mt-2" />
         <ModularSkillTreePanel

--- a/src/components/game/hud/panels/ModularActionPanel.tsx
+++ b/src/components/game/hud/panels/ModularActionPanel.tsx
@@ -7,10 +7,12 @@ interface ModularActionPanelProps {
   onOpenEdicts?: () => void;
   onOpenOmens?: () => void;
   onOpenSettings?: () => void;
+  onToggleLeylineDrawing?: () => void;
   intervalMs?: number;
   onChangeIntervalMs?: (ms: number) => void;
   variant?: 'default' | 'compact' | 'minimal';
   collapsible?: boolean;
+  isLeylineDrawing?: boolean;
 }
 
 interface ActionItemProps {
@@ -20,11 +22,13 @@ interface ActionItemProps {
   variant?: 'default' | 'compact' | 'minimal';
   disabled?: boolean;
   badge?: string | number;
+  active?: boolean;
 }
 
-function ActionItem({ label, onClick, icon, variant = 'default', disabled = false, badge }: ActionItemProps) {
+function ActionItem({ label, onClick, icon, variant = 'default', disabled = false, badge, active = false }: ActionItemProps) {
   const getButtonVariant = () => {
     if (disabled) return 'secondary';
+    if (active) return 'success';
     return 'primary';
   };
 
@@ -102,18 +106,26 @@ const actionIcons = {
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
     </svg>
+  ),
+  leylines: (
+    <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 19c4-6 12-6 16 0M4 5c4 6 12 6 16 0" />
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 5v14" />
+    </svg>
   )
 };
 
-export function ModularActionPanel({ 
-  onOpenCouncil, 
-  onOpenEdicts, 
-  onOpenOmens, 
-  onOpenSettings, 
+export function ModularActionPanel({
+  onOpenCouncil,
+  onOpenEdicts,
+  onOpenOmens,
+  onOpenSettings,
+  onToggleLeylineDrawing,
   intervalMs,
   onChangeIntervalMs,
   variant = 'default',
-  collapsible = true 
+  collapsible = true,
+  isLeylineDrawing = false
 }: ModularActionPanelProps) {
   const [isCollapsed, setIsCollapsed] = useState(false);
   
@@ -164,6 +176,7 @@ export function ModularActionPanel({
   const actions = [
     { label: 'Council', onClick: onOpenCouncil, icon: actionIcons.council, key: 'council' },
     { label: 'Edicts', onClick: onOpenEdicts, icon: actionIcons.edicts, key: 'edicts' },
+    { label: 'Leylines', onClick: onToggleLeylineDrawing, icon: actionIcons.leylines, key: 'leylines', active: isLeylineDrawing },
     { label: 'Omens', onClick: onOpenOmens, icon: actionIcons.omens, key: 'omens' },
     { label: 'Settings', onClick: onOpenSettings, icon: actionIcons.settings, key: 'settings' }
   ];
@@ -221,7 +234,9 @@ export function ModularActionPanel({
             onClick={action.onClick}
             icon={action.icon}
             variant={variant}
+            disabled={!action.onClick}
             badge={getActionBadge(action.key)}
+            active={Boolean(action.active)}
           />
         ))}
       </ResponsiveStack>


### PR DESCRIPTION
## Summary
- persist player-created leylines, expose creation/update/delete handlers, and surface an in-game inspector for adjusting capacity or flow
- pass the leyline drawing state and handlers into the Pixi layers so the leyline system responds to real create/remove callbacks
- add a Leylines toggle to the HUD action panel so players can flip drawing mode from the right rail

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9beeeeb608325866352e78d8a2bf6