### PR TITLE
Refactor worker simulation into modular services

### DIFF
--- a/packages/engine/src/simulation/workers/__tests__/workerProgressionService.test.ts
+++ b/packages/engine/src/simulation/workers/__tests__/workerProgressionService.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import { WorkerProgressionService } from '../workerProgressionService';
+import { createDefaultJobCatalog } from '../jobCatalog';
+import { LaborMarketService } from '../laborMarketService';
+import type { WorkerProfile, Workplace } from '../types';
+import type { Citizen } from '@engine/simulation/citizenBehavior';
+import { createGameTime } from '@engine/types/gameTime';
+
+function createWorkerProfile(roleId: string): { worker: WorkerProfile; coworker: WorkerProfile } {
+  const catalog = createDefaultJobCatalog();
+  const role = catalog.get(roleId);
+  if (!role) {
+    throw new Error(`Missing role ${roleId}`);
+  }
+
+  const baseProfile: WorkerProfile = {
+    citizenId: 'citizen-1',
+    currentRole: role,
+    experienceLevel: 0,
+    careerLevel: 1,
+    specializations: [],
+    certifications: [],
+    efficiency: 50,
+    reliability: 60,
+    teamwork: 70,
+    innovation: 30,
+    jobSatisfaction: 70,
+    workplaceRelationships: [],
+    promotionReadiness: 0,
+    trainingProgress: {},
+    careerGoals: {
+      targetLevel: 2,
+      timeframe: 50,
+    },
+    shiftType: 'day',
+    hoursPerWeek: 40,
+    overtimeHours: 0,
+    vacationDays: 10,
+    sickDays: 5,
+    currentWage: role.baseWage,
+    bonuses: 0,
+    benefits: {
+      healthcare: false,
+      retirement: false,
+      training: false,
+      flexibleHours: false,
+    },
+    performanceReviews: [],
+    burnoutRisk: 20,
+    workLifeBalance: 70,
+    stressLevel: 30,
+  };
+
+  const coworker: WorkerProfile = {
+    ...baseProfile,
+    citizenId: 'citizen-2',
+    teamwork: 80,
+  };
+
+  return { worker: { ...baseProfile }, coworker };
+}
+
+describe('WorkerProgressionService', () => {
+  it('updates worker progression metrics and workplace relationships', () => {
+    const { worker, coworker } = createWorkerProfile('farmer');
+
+    const workers = new Map<string, WorkerProfile>([
+      [worker.citizenId, worker],
+      [coworker.citizenId, coworker],
+    ]);
+
+    const workplace: Workplace = {
+      buildingId: 'building-1',
+      department: 'field operations',
+      workers: [worker.citizenId, coworker.citizenId],
+      teamCohesion: 50,
+      productivity: 60,
+      morale: 70,
+      workingConditions: {
+        safety: 70,
+        comfort: 60,
+        equipment: 50,
+        resources: 60,
+      },
+      cultureType: 'collaborative',
+      teamEvents: [],
+    };
+
+    const workplaces = new Map<string, Workplace>([[workplace.buildingId, workplace]]);
+
+    const laborMarketService = new LaborMarketService();
+    const laborMarket = laborMarketService.getLaborMarket();
+
+    const citizen = {
+      id: worker.citizenId,
+      personality: {
+        ambition: 0.5,
+        sociability: 0.6,
+        industriousness: 0.7,
+        contentment: 0.8,
+        curiosity: 0.5,
+      },
+      skills: {
+        agriculture: 40,
+        physical_strength: 40,
+      },
+    } as unknown as Citizen;
+
+    const progression = new WorkerProgressionService();
+    const randomValues = [0.05, 0.05];
+    const randomMock = () => (randomValues.length > 0 ? randomValues.shift()! : 0.5);
+
+    progression.updateWorkerProgression(worker, {
+      gameTime: createGameTime(0),
+      jobRoles: createDefaultJobCatalog(),
+      laborMarket,
+      citizen,
+      workers,
+      workplaces,
+      random: randomMock,
+    });
+
+    expect(worker.experienceLevel).toBeGreaterThan(0);
+    expect(worker.trainingProgress.agriculture).toBeGreaterThan(0);
+    expect(worker.efficiency).toBeLessThan(50);
+    expect(worker.reliability).toBeGreaterThan(60);
+    expect(worker.workLifeBalance).toBeLessThan(70);
+    expect(worker.stressLevel).toBeGreaterThan(30);
+
+    expect(worker.workplaceRelationships).toHaveLength(1);
+    expect(worker.workplaceRelationships[0]).toMatchObject({ coworkerId: 'citizen-2' });
+    expect(worker.workplaceRelationships[0].quality).toBeGreaterThan(50);
+
+    expect(workplace.morale).toBeGreaterThan(70);
+    expect(workplace.teamCohesion).toBeGreaterThan(50);
+  });
+});

--- a/packages/engine/src/simulation/workers/__tests__/workerSimulationSystem.test.ts
+++ b/packages/engine/src/simulation/workers/__tests__/workerSimulationSystem.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { WorkerSimulationSystem } from '@engine/simulation/workerSimulation';
+import { createDefaultJobCatalog } from '../jobCatalog';
+import {
+  LaborMarketService,
+  type LaborMarketUpdateContext,
+} from '../laborMarketService';
+import {
+  WorkerProgressionService,
+  type WorkerProgressionContext,
+} from '../workerProgressionService';
+import type { WorkerProfile } from '../types';
+import type { SimResources } from '@engine/index';
+import { createGameTime } from '@engine/types/gameTime';
+import { CitizenBehaviorSystem } from '@engine/simulation/citizenBehavior';
+
+class MockLaborMarketService extends LaborMarketService {
+  public updateCalls = 0;
+  public contexts: LaborMarketUpdateContext[] = [];
+
+  updateLaborMarket(context: LaborMarketUpdateContext): void {
+    this.updateCalls += 1;
+    this.contexts.push(context);
+    super.updateLaborMarket(context);
+  }
+}
+
+class MockWorkerProgressionService extends WorkerProgressionService {
+  public updateCalls = 0;
+  public updatedWorkers: string[] = [];
+
+  updateWorkerProgression(worker: WorkerProfile, context: WorkerProgressionContext): void {
+    this.updateCalls += 1;
+    this.updatedWorkers.push(worker.citizenId);
+    super.updateWorkerProgression(worker, context);
+  }
+}
+
+describe('WorkerSimulationSystem integration', () => {
+  it('delegates worker updates to progression and labor market services', () => {
+    const jobCatalog = createDefaultJobCatalog();
+    const laborMarketService = new MockLaborMarketService();
+    const progressionService = new MockWorkerProgressionService();
+
+    const system = new WorkerSimulationSystem({
+      jobCatalog,
+      laborMarketService,
+      workerProgressionService: progressionService,
+    });
+
+    const citizenBehavior = new CitizenBehaviorSystem();
+    const citizen = citizenBehavior.generateCitizen('citizen-1', 'Test Citizen', 30, 1);
+    citizen.skills.agriculture = 40;
+    citizen.skills.physical_strength = 40;
+
+    const worker = system.createWorker(citizen, 'farmer');
+    expect(worker).not.toBeNull();
+
+    const resources: SimResources = {
+      grain: 100,
+      coin: 100,
+      mana: 10,
+      favor: 5,
+      workers: 1,
+      wood: 50,
+      planks: 20,
+    };
+
+    system.updateSystem(
+      {
+        buildings: [],
+        resources,
+        citizens: [citizen],
+      },
+      createGameTime(60)
+    );
+
+    expect(progressionService.updateCalls).toBe(1);
+    expect(progressionService.updatedWorkers).toContain(citizen.id);
+
+    expect(laborMarketService.updateCalls).toBe(1);
+    expect(laborMarketService.contexts[0].buildings).toEqual([]);
+    expect(laborMarketService.contexts[0].resources).toEqual(resources);
+
+    const updatedWorker = system.getWorker(citizen.id);
+    expect(updatedWorker).toBeDefined();
+    expect(updatedWorker?.experienceLevel).toBeGreaterThan(0);
+
+    const summary = system.getLaborMarketSummary();
+    expect(summary.unemployment).toBe(
+      laborMarketService.getLaborMarket().unemploymentRate
+    );
+  });
+});

--- a/packages/engine/src/simulation/workers/jobCatalog.ts
+++ b/packages/engine/src/simulation/workers/jobCatalog.ts
@@ -1,0 +1,98 @@
+import type { JobRole } from './types';
+
+const DEFAULT_JOB_ROLES: JobRole[] = [
+  {
+    id: 'farmer',
+    title: 'Farmer',
+    category: 'production',
+    requiredSkills: { agriculture: 20, physical_strength: 30 },
+    baseWage: 15,
+    maxLevel: 5,
+    responsibilities: ['Crop cultivation', 'Livestock care', 'Equipment maintenance'],
+    workload: 70,
+    prestige: 40
+  },
+  {
+    id: 'miner',
+    title: 'Miner',
+    category: 'production',
+    requiredSkills: { mining: 25, physical_strength: 40 },
+    baseWage: 20,
+    maxLevel: 4,
+    responsibilities: ['Resource extraction', 'Safety protocols', 'Equipment operation'],
+    workload: 80,
+    prestige: 35
+  },
+  {
+    id: 'craftsman',
+    title: 'Craftsman',
+    category: 'production',
+    requiredSkills: { crafting: 30, creativity: 25 },
+    baseWage: 18,
+    maxLevel: 6,
+    responsibilities: ['Item creation', 'Quality control', 'Design innovation'],
+    workload: 60,
+    prestige: 55
+  },
+  {
+    id: 'merchant',
+    title: 'Merchant',
+    category: 'service',
+    requiredSkills: { negotiation: 35, social_skills: 40 },
+    baseWage: 25,
+    maxLevel: 5,
+    responsibilities: ['Trade management', 'Customer relations', 'Market analysis'],
+    workload: 65,
+    prestige: 60
+  },
+  {
+    id: 'guard',
+    title: 'Guard',
+    category: 'service',
+    requiredSkills: { combat: 40, vigilance: 35 },
+    baseWage: 22,
+    maxLevel: 4,
+    responsibilities: ['Security patrol', 'Threat assessment', 'Emergency response'],
+    workload: 75,
+    prestige: 50
+  },
+  {
+    id: 'supervisor',
+    title: 'Supervisor',
+    category: 'management',
+    requiredSkills: { leadership: 50, organization: 45 },
+    baseWage: 35,
+    maxLevel: 4,
+    responsibilities: ['Team coordination', 'Performance management', 'Resource allocation'],
+    workload: 85,
+    prestige: 75
+  },
+  {
+    id: 'researcher',
+    title: 'Researcher',
+    category: 'research',
+    requiredSkills: { intelligence: 60, curiosity: 50 },
+    baseWage: 30,
+    maxLevel: 6,
+    responsibilities: ['Knowledge discovery', 'Innovation development', 'Documentation'],
+    workload: 70,
+    prestige: 80
+  },
+  {
+    id: 'engineer',
+    title: 'Engineer',
+    category: 'maintenance',
+    requiredSkills: { engineering: 45, problem_solving: 40 },
+    baseWage: 28,
+    maxLevel: 5,
+    responsibilities: ['System maintenance', 'Efficiency optimization', 'Technical support'],
+    workload: 75,
+    prestige: 70
+  }
+];
+
+export function createDefaultJobCatalog(): Map<string, JobRole> {
+  return new Map(DEFAULT_JOB_ROLES.map(role => [role.id, role]));
+}
+
+export { DEFAULT_JOB_ROLES };

--- a/packages/engine/src/simulation/workers/laborMarketService.ts
+++ b/packages/engine/src/simulation/workers/laborMarketService.ts
@@ -1,0 +1,185 @@
+import type { SimResources } from '../../index';
+import type { SimulatedBuilding } from '../buildingSimulation';
+
+export interface LaborMarketJobOpening {
+  roleId: string;
+  buildingId: string;
+  urgency: number;
+  wageOffer: number;
+  requirements: Record<string, number>;
+  benefits: string[];
+}
+
+export interface LaborMarketTrainingProgram {
+  id: string;
+  skill: string;
+  duration: number;
+  cost: number;
+  effectiveness: number;
+  availability: number;
+}
+
+export interface LaborMarket {
+  jobOpenings: LaborMarketJobOpening[];
+  unemploymentRate: number;
+  averageWages: Record<string, number>;
+  skillDemand: Record<string, number>;
+  economicConditions: {
+    growth: number;
+    inflation: number;
+    competitiveness: number;
+  };
+  trainingPrograms: LaborMarketTrainingProgram[];
+}
+
+export interface LaborMarketUpdateContext {
+  buildings: SimulatedBuilding[];
+  resources: SimResources;
+  economicGrowth: number;
+}
+
+export class LaborMarketService {
+  private market: LaborMarket;
+
+  constructor(initialMarket?: LaborMarket) {
+    this.market = initialMarket
+      ? LaborMarketService.cloneMarket(initialMarket)
+      : LaborMarketService.createDefaultMarket();
+  }
+
+  getLaborMarket(): LaborMarket {
+    return this.market;
+  }
+
+  getAverageWage(category: string): number | undefined {
+    return this.market.averageWages[category];
+  }
+
+  updateLaborMarket({ buildings, economicGrowth }: LaborMarketUpdateContext): void {
+    this.market.economicConditions.growth = economicGrowth;
+
+    const skillDemand: Record<string, number> = {};
+    for (const building of buildings) {
+      const isOperational = building.workers > 0 && building.condition !== 'critical';
+      if (!isOperational) continue;
+
+      skillDemand.work_efficiency = (skillDemand.work_efficiency || 0) + 1;
+
+      switch (building.typeId) {
+        case 'farm':
+          skillDemand.agriculture = (skillDemand.agriculture || 0) + 2;
+          break;
+        case 'mine':
+          skillDemand.mining = (skillDemand.mining || 0) + 2;
+          break;
+        case 'automation_workshop':
+        case 'sawmill':
+          skillDemand.crafting = (skillDemand.crafting || 0) + 2;
+          break;
+        default:
+          break;
+      }
+    }
+
+    if (Object.keys(skillDemand).length > 0) {
+      const maxDemand = Object.values(skillDemand).reduce((max, value) => Math.max(max, value), 0);
+      const divisor = maxDemand > 0 ? maxDemand : 1;
+      for (const skill of Object.keys(skillDemand)) {
+        const normalized = (skillDemand[skill] / divisor) * 100;
+        this.market.skillDemand[skill] = Math.min(100, normalized);
+      }
+    }
+
+    const wageMultiplier = 1 + this.market.economicConditions.growth / 100;
+    for (const category of Object.keys(this.market.averageWages)) {
+      this.market.averageWages[category] *= wageMultiplier;
+    }
+  }
+
+  getSummary(): {
+    unemployment: number;
+    averageWage: number;
+    topSkillDemands: Array<{ skill: string; demand: number }>;
+    economicHealth: number;
+  } {
+    const wages = Object.values(this.market.averageWages);
+    const averageWage = wages.length > 0
+      ? wages.reduce((sum, wage) => sum + wage, 0) / wages.length
+      : 0;
+
+    const topSkillDemands = Object.entries(this.market.skillDemand)
+      .map(([skill, demand]) => ({ skill, demand }))
+      .sort((a, b) => b.demand - a.demand)
+      .slice(0, 5);
+
+    const { growth, inflation, competitiveness } = this.market.economicConditions;
+    const economicHealth = (growth + 100 + (100 - inflation) + competitiveness) / 3;
+
+    return {
+      unemployment: this.market.unemploymentRate,
+      averageWage,
+      topSkillDemands,
+      economicHealth
+    };
+  }
+
+  private static createDefaultMarket(): LaborMarket {
+    return {
+      jobOpenings: [],
+      unemploymentRate: 5,
+      averageWages: {
+        production: 18,
+        service: 23,
+        management: 35,
+        research: 30,
+        maintenance: 28
+      },
+      skillDemand: {
+        agriculture: 60,
+        mining: 70,
+        crafting: 50,
+        social_skills: 45,
+        leadership: 30,
+        intelligence: 40
+      },
+      economicConditions: {
+        growth: 10,
+        inflation: 3,
+        competitiveness: 60
+      },
+      trainingPrograms: [
+        {
+          id: 'basic_skills',
+          skill: 'work_efficiency',
+          duration: 5,
+          cost: 10,
+          effectiveness: 70,
+          availability: 20
+        },
+        {
+          id: 'leadership_training',
+          skill: 'leadership',
+          duration: 10,
+          cost: 25,
+          effectiveness: 80,
+          availability: 5
+        }
+      ]
+    };
+  }
+
+  private static cloneMarket(market: LaborMarket): LaborMarket {
+    return {
+      jobOpenings: market.jobOpenings.map(opening => ({
+        ...opening,
+        requirements: { ...opening.requirements },
+        benefits: [...opening.benefits]
+      })),
+      unemploymentRate: market.unemploymentRate,
+      averageWages: { ...market.averageWages },
+      skillDemand: { ...market.skillDemand },
+      economicConditions: { ...market.economicConditions },
+      trainingPrograms: market.trainingPrograms.map(program => ({ ...program }))
+    };
+  }
+}

--- a/packages/engine/src/simulation/workers/types.ts
+++ b/packages/engine/src/simulation/workers/types.ts
@@ -75,6 +75,34 @@ export interface WorkerProfile {
   stressLevel: number; // 0-100
 }
 
+// Workplace and team dynamics
+export interface Workplace {
+  buildingId: string;
+  department: string;
+  manager?: string; // worker ID
+  workers: string[]; // worker IDs
+  teamCohesion: number; // 0-100
+  productivity: number; // 0-100
+  morale: number; // 0-100
+
+  // Work environment
+  workingConditions: {
+    safety: number; // 0-100
+    comfort: number; // 0-100
+    equipment: number; // 0-100
+    resources: number; // 0-100
+  };
+
+  // Team events and culture
+  cultureType: 'competitive' | 'collaborative' | 'innovative' | 'traditional';
+  teamEvents: Array<{
+    cycle: number;
+    type: string;
+    impact: number; // -100 to 100
+    participants: string[];
+  }>;
+}
+
 export interface WorkShift {
   startHour: number;
   endHour: number;

--- a/packages/engine/src/simulation/workers/workerProgressionService.ts
+++ b/packages/engine/src/simulation/workers/workerProgressionService.ts
@@ -1,0 +1,157 @@
+import type { GameTime } from '../../types/gameTime';
+import type { Citizen } from '../citizenBehavior';
+import type { JobRole, WorkerProfile, Workplace } from './types';
+import type { LaborMarket } from './laborMarketService';
+import { calculateWageAdjustment, checkCareerProgression } from './career';
+
+export interface WorkerProgressionContext {
+  gameTime: GameTime;
+  jobRoles: Map<string, JobRole>;
+  laborMarket: LaborMarket;
+  citizen?: Citizen;
+  workers: Map<string, WorkerProfile>;
+  workplaces: Map<string, Workplace>;
+  random?: () => number;
+}
+
+export class WorkerProgressionService {
+  constructor(private readonly randomFn: () => number = Math.random) {}
+
+  updateWorkerProgression(worker: WorkerProfile, context: WorkerProgressionContext): void {
+    this.updateExperience(worker);
+    this.updatePerformance(worker);
+    this.updateJobSatisfaction(worker, context.citizen, context.laborMarket);
+    checkCareerProgression(worker, context.gameTime, context.jobRoles);
+    this.updateWorkLifeBalance(worker);
+    this.handleWorkplaceInteractions(
+      worker,
+      context.workers,
+      context.workplaces,
+      context.random ?? this.randomFn
+    );
+  }
+
+  private updateExperience(worker: WorkerProfile): void {
+    const baseGain = 1;
+    const efficiencyBonus = worker.efficiency / 100;
+    const experienceGain = baseGain * (1 + efficiencyBonus);
+
+    worker.experienceLevel = Math.min(100, worker.experienceLevel + experienceGain);
+
+    for (const skill of Object.keys(worker.currentRole.requiredSkills)) {
+      const currentLevel = worker.trainingProgress[skill] || 0;
+      const improvement = experienceGain * 0.5;
+      worker.trainingProgress[skill] = Math.min(100, currentLevel + improvement);
+    }
+  }
+
+  private updatePerformance(worker: WorkerProfile): void {
+    const experienceBonus = worker.experienceLevel * 0.2;
+    const stressPenalty = worker.stressLevel * 0.3;
+    const targetEfficiency = Math.max(20, Math.min(100, 50 + experienceBonus - stressPenalty));
+    worker.efficiency = this.lerp(worker.efficiency, targetEfficiency, 0.1);
+
+    const satisfactionBonus = worker.jobSatisfaction * 0.3;
+    const targetReliability = Math.max(30, Math.min(100, 60 + satisfactionBonus));
+    worker.reliability = this.lerp(worker.reliability, targetReliability, 0.05);
+
+    if (worker.currentRole.category === 'research') {
+      worker.innovation = Math.min(100, worker.innovation + 0.5);
+    }
+  }
+
+  private updateJobSatisfaction(
+    worker: WorkerProfile,
+    citizen: Citizen | undefined,
+    laborMarket: LaborMarket
+  ): void {
+    if (!citizen) return;
+
+    let satisfaction = worker.jobSatisfaction;
+
+    const marketWage = laborMarket.averageWages[worker.currentRole.category] ?? worker.currentRole.baseWage;
+    satisfaction += calculateWageAdjustment(worker, marketWage);
+
+    if (worker.workLifeBalance < 40) {
+      satisfaction -= 3;
+    } else if (worker.workLifeBalance > 70) {
+      satisfaction += 1;
+    }
+
+    if (worker.promotionReadiness > 80 && worker.careerLevel < worker.currentRole.maxLevel) {
+      satisfaction -= 1;
+    }
+
+    const prestigeAlignment = worker.currentRole.prestige / 100;
+    const ambitionAlignment = citizen.personality.ambition;
+    if (Math.abs(prestigeAlignment - ambitionAlignment) > 0.3) {
+      satisfaction -= 1;
+    }
+
+    worker.jobSatisfaction = Math.max(0, Math.min(100, satisfaction));
+  }
+
+  private updateWorkLifeBalance(worker: WorkerProfile): void {
+    const totalHours = worker.hoursPerWeek + worker.overtimeHours;
+    const workloadStress = worker.currentRole.workload;
+    const workPressure = (totalHours - 40) * 2 + workloadStress;
+
+    const targetBalance = Math.max(20, 100 - workPressure);
+    worker.workLifeBalance = this.lerp(worker.workLifeBalance, targetBalance, 0.1);
+
+    worker.stressLevel = Math.min(100, workPressure * 0.8);
+    worker.burnoutRisk = Math.max(0, worker.stressLevel - worker.workLifeBalance);
+  }
+
+  private handleWorkplaceInteractions(
+    worker: WorkerProfile,
+    workers: Map<string, WorkerProfile>,
+    workplaces: Map<string, Workplace>,
+    random: () => number
+  ): void {
+    const workplace = Array.from(workplaces.values()).find(w => w.workers.includes(worker.citizenId));
+    if (!workplace) return;
+
+    if (random() < 0.1) {
+      const coworkers = workplace.workers.filter(id => id !== worker.citizenId);
+      if (coworkers.length > 0) {
+        const coworkerId = coworkers[Math.floor(random() * coworkers.length)];
+        this.processWorkplaceInteraction(worker, coworkerId, workplace, workers);
+      }
+    }
+  }
+
+  private processWorkplaceInteraction(
+    worker: WorkerProfile,
+    coworkerId: string,
+    workplace: Workplace,
+    workers: Map<string, WorkerProfile>
+  ): void {
+    const coworker = workers.get(coworkerId);
+    if (!coworker) return;
+
+    let relationship = worker.workplaceRelationships.find(r => r.coworkerId === coworkerId);
+    if (!relationship) {
+      relationship = {
+        coworkerId,
+        relationship: 'peer',
+        quality: 50
+      };
+      worker.workplaceRelationships.push(relationship);
+    }
+
+    const interactionSuccess = (worker.teamwork + coworker.teamwork) / 2;
+    const qualityChange = interactionSuccess > 60 ? 2 : interactionSuccess < 40 ? -1 : 0;
+
+    relationship.quality = Math.max(0, Math.min(100, relationship.quality + qualityChange));
+
+    if (qualityChange > 0) {
+      workplace.morale = Math.min(100, workplace.morale + 0.5);
+      workplace.teamCohesion = Math.min(100, workplace.teamCohesion + 0.3);
+    }
+  }
+
+  private lerp(current: number, target: number, factor: number): number {
+    return current + (target - current) * factor;
+  }
+}


### PR DESCRIPTION
## Summary
- extract the static worker job catalog into a reusable provider
- introduce dedicated labor market and worker progression services used by the worker simulation
- update the worker simulation system to orchestrate the new services and add unit tests around worker updates

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9c683b5548325a50ffa27953b87cf