### PR TITLE
Lift chunk streaming into engine package

### DIFF
--- a/packages/engine/src/chunks/index.ts
+++ b/packages/engine/src/chunks/index.ts
@@ -1,0 +1,3 @@
+export * from "./types";
+export * from "./telemetry";
+export * from "./streaming";

--- a/packages/engine/src/chunks/streaming.ts
+++ b/packages/engine/src/chunks/streaming.ts
@@ -1,0 +1,170 @@
+import { createNullChunkTelemetry, type ChunkTelemetry } from "./telemetry";
+import {
+  type ChunkCache,
+  type ChunkCacheEntry,
+  type ChunkPayload,
+  type EnsureChunkResult,
+  type ReleaseResult,
+  getChunkKey,
+} from "./types";
+
+export interface ChunkStreamingOptions {
+  chunkSize: number;
+  maxLoadedChunks: number;
+  loadChunkData: (chunkX: number, chunkY: number) => Promise<ChunkPayload>;
+  telemetry?: ChunkTelemetry;
+  onChunkEvicted?: (chunkKey: string, entry: ChunkCacheEntry) => void;
+  worldSeed?: number;
+}
+
+export class ChunkStreamingManager {
+  private readonly cache: ChunkCache;
+  private readonly loading: Map<string, Promise<ChunkPayload>>;
+  private cleanupDisposer: (() => void) | undefined;
+  private readonly telemetry: ChunkTelemetry;
+  private readonly ownsTelemetry: boolean;
+
+  constructor(private readonly options: ChunkStreamingOptions) {
+    this.cache = new Map();
+    this.loading = new Map();
+    this.telemetry = options.telemetry ?? createNullChunkTelemetry();
+    this.ownsTelemetry = options.telemetry === undefined;
+
+    this.cleanupDisposer = this.telemetry.scheduleCleanup(
+      () => this.cache.entries(),
+      (chunkKey) => {
+        const released = this.releaseChunkInternal(chunkKey, "stale");
+        if (released) {
+          this.options.onChunkEvicted?.(chunkKey, released.entry);
+        }
+      },
+    ) ?? undefined;
+  }
+
+  get chunkCache(): ChunkCache {
+    return this.cache;
+  }
+
+  async ensureChunkLoaded(chunkX: number, chunkY: number): Promise<EnsureChunkResult> {
+    const chunkKey = getChunkKey(chunkX, chunkY);
+    const existing = this.cache.get(chunkKey);
+    const now = Date.now();
+
+    if (existing) {
+      existing.lastAccessed = now;
+      return { key: chunkKey, data: existing.data, isNew: false };
+    }
+
+    const loader = this.getOrCreateLoader(chunkKey, chunkX, chunkY);
+
+    try {
+      const start = performance.now();
+      this.telemetry.logLoadStart(chunkKey);
+      const payload = await loader;
+
+      const result = this.persistChunk(chunkKey, payload, now);
+      const durationMs = performance.now() - start;
+
+      this.telemetry.logLoadSuccess(chunkKey, {
+        durationMs,
+        tileCount: result.entry.tileCount,
+        cacheSize: this.cache.size,
+      });
+
+      this.enforceCapacity();
+
+      return { key: chunkKey, data: result.entry.data, isNew: true, renderPayload: payload };
+    } catch (error) {
+      this.telemetry.logLoadError(chunkKey, error);
+      this.loading.delete(chunkKey);
+      throw error;
+    }
+  }
+
+  releaseChunk(chunkKey: string, reason = "manual"): ReleaseResult | null {
+    const released = this.releaseChunkInternal(chunkKey, reason);
+    if (!released) {
+      return null;
+    }
+
+    return released;
+  }
+
+  dispose() {
+    if (this.cleanupDisposer) {
+      this.cleanupDisposer();
+      this.cleanupDisposer = undefined;
+    }
+
+    if (this.ownsTelemetry) {
+      this.telemetry.dispose();
+    }
+  }
+
+  private getOrCreateLoader(chunkKey: string, chunkX: number, chunkY: number) {
+    if (!this.loading.has(chunkKey)) {
+      const promise = this.options
+        .loadChunkData(chunkX, chunkY)
+        .finally(() => {
+          this.loading.delete(chunkKey);
+        });
+
+      this.loading.set(chunkKey, promise);
+    }
+
+    return this.loading.get(chunkKey)!;
+  }
+
+  private persistChunk(chunkKey: string, payload: ChunkPayload, lastAccessed: number) {
+    const { fields: _unused, ...data } = payload;
+    void _unused;
+    const tileCount = payload.tiles.reduce((count, row) => count + row.length, 0);
+
+    const entry: ChunkCacheEntry = {
+      key: chunkKey,
+      data,
+      tileCount,
+      lastAccessed,
+    };
+
+    this.cache.set(chunkKey, entry);
+
+    return { key: chunkKey, entry };
+  }
+
+  private enforceCapacity() {
+    if (this.cache.size <= this.options.maxLoadedChunks) {
+      return;
+    }
+
+    const entries = Array.from(this.cache.entries()).sort(([, a], [, b]) => a.lastAccessed - b.lastAccessed);
+    const excess = this.cache.size - this.options.maxLoadedChunks;
+
+    for (let i = 0; i < excess; i++) {
+      const [chunkKey] = entries[i];
+      const released = this.releaseChunkInternal(chunkKey, "evicted");
+      if (released) {
+        this.options.onChunkEvicted?.(chunkKey, released.entry);
+      }
+    }
+  }
+
+  private releaseChunkInternal(chunkKey: string, reason: string): ReleaseResult | null {
+    const entry = this.cache.get(chunkKey);
+    if (!entry) {
+      return null;
+    }
+
+    const start = performance.now();
+    this.cache.delete(chunkKey);
+
+    this.telemetry.logRelease(chunkKey, {
+      durationMs: performance.now() - start,
+      tileCount: entry.tileCount,
+      cacheSize: this.cache.size,
+      reason,
+    });
+
+    return { key: chunkKey, entry };
+  }
+}

--- a/packages/engine/src/chunks/telemetry.ts
+++ b/packages/engine/src/chunks/telemetry.ts
@@ -1,0 +1,60 @@
+import type { ChunkCacheEntry } from "./types";
+
+export interface ChunkTelemetryStats {
+  loads: number;
+  releases: number;
+  tilesLoaded: number;
+  tilesReleased: number;
+  lastCacheSize: number;
+  renderCreates: number;
+  renderDisposes: number;
+}
+
+export interface ChunkTelemetry {
+  stats: ChunkTelemetryStats;
+  logLoadStart: (chunkKey: string) => void;
+  logLoadSuccess: (
+    chunkKey: string,
+    details: { durationMs: number; tileCount: number; cacheSize: number }
+  ) => void;
+  logLoadError: (chunkKey: string, error: unknown) => void;
+  logRelease: (
+    chunkKey: string,
+    details: { durationMs: number; tileCount: number; cacheSize: number; reason: string }
+  ) => void;
+  logRenderCreate: (chunkKey: string, details: { tileCount: number }) => void;
+  logRenderDispose: (chunkKey: string, details: { tileCount: number }) => void;
+  scheduleCleanup: (
+    snapshot: () => Iterable<[string, ChunkCacheEntry]>,
+    evict: (chunkKey: string) => void,
+  ) => (() => void) | undefined;
+  dispose: () => void;
+}
+
+const noop = () => {
+  // no-op
+};
+
+const noopCleanup = () => undefined;
+
+export function createNullChunkTelemetry(): ChunkTelemetry {
+  return {
+    stats: {
+      loads: 0,
+      releases: 0,
+      tilesLoaded: 0,
+      tilesReleased: 0,
+      lastCacheSize: 0,
+      renderCreates: 0,
+      renderDisposes: 0,
+    },
+    logLoadStart: noop,
+    logLoadSuccess: noop,
+    logLoadError: noop,
+    logRelease: noop,
+    logRenderCreate: noop,
+    logRenderDispose: noop,
+    scheduleCleanup: noopCleanup,
+    dispose: noop,
+  };
+}

--- a/packages/engine/src/chunks/types.ts
+++ b/packages/engine/src/chunks/types.ts
@@ -1,0 +1,63 @@
+export interface ChunkFieldMaps {
+  height: number[][];
+  temperature: number[][];
+  moisture: number[][];
+  climate: string[][];
+  isRiver: boolean[][];
+  isWater: boolean[][];
+}
+
+export interface ChunkMetadata {
+  dominantClimate: string | null;
+  dominantBiome: string | null;
+  riverCount: number;
+  coastlineTiles: number;
+  elevation: { min: number; max: number; mean: number };
+}
+
+export interface ChunkPayload {
+  chunkX: number;
+  chunkY: number;
+  chunkSize: number;
+  seed: number;
+  tiles: string[][];
+  biomes?: string[][];
+  fields?: ChunkFieldMaps;
+  features?: unknown;
+  metadata?: ChunkMetadata;
+}
+
+export interface ChunkData {
+  chunkX: number;
+  chunkY: number;
+  chunkSize: number;
+  tiles: string[][];
+  biomes?: string[][];
+  features?: unknown;
+  metadata?: ChunkMetadata;
+}
+
+export interface ChunkCacheEntry {
+  key: string;
+  data: ChunkData;
+  tileCount: number;
+  lastAccessed: number;
+}
+
+export interface EnsureChunkResult {
+  key: string;
+  data: ChunkData;
+  isNew: boolean;
+  renderPayload?: ChunkPayload;
+}
+
+export interface ReleaseResult {
+  key: string;
+  entry: ChunkCacheEntry;
+}
+
+export type ChunkCache = Map<string, ChunkCacheEntry>;
+
+export function getChunkKey(chunkX: number, chunkY: number) {
+  return `${chunkX},${chunkY}`;
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -249,3 +249,6 @@ export * from './simulation/events';
 
 // Export time system
 export * from './systems/time';
+
+// Export chunk streaming utilities
+export * from './chunks';

--- a/src/components/game/ChunkedIsometricGrid.tsx
+++ b/src/components/game/ChunkedIsometricGrid.tsx
@@ -1,59 +1,13 @@
 "use client";
 
-import { useEffect, useRef, useState, useCallback } from "react";
-import * as PIXI from "pixi.js";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import type { Viewport } from "pixi-viewport";
 import { useGameContext } from "./GameContext";
-import logger from "@/lib/logger";
 import { worldToGrid } from "@/lib/isometric";
-import { createTileSprite, type GridTile } from "./grid/TileRenderer";
-import { TileOverlay } from "./grid/TileOverlay";
-import type { RegionFeatures } from "@/lib/world/generator";
-
-interface ChunkFieldMaps {
-  height: number[][];
-  temperature: number[][];
-  moisture: number[][];
-  climate: string[][];
-  isRiver: boolean[][];
-  isWater: boolean[][];
-}
-
-interface ChunkMetadata {
-  dominantClimate: string | null;
-  dominantBiome: string | null;
-  riverCount: number;
-  coastlineTiles: number;
-  elevation: { min: number; max: number; mean: number };
-}
-
-interface ChunkApiResponse {
-  chunkX: number;
-  chunkY: number;
-  chunkSize: number;
-  seed: number;
-  tiles: string[][];
-  biomes?: string[][];
-  fields?: ChunkFieldMaps;
-  features?: RegionFeatures;
-  metadata?: ChunkMetadata;
-}
-
-interface ChunkData {
-  chunkX: number;
-  chunkY: number;
-  chunkSize: number;
-  tiles: string[][];
-  biomes?: string[][];
-  features?: RegionFeatures;
-  metadata?: ChunkMetadata;
-}
-
-interface LoadedChunk {
-  data: ChunkData;
-  container: PIXI.Container;
-  tiles: Map<string, GridTile>;
-  lastAccessed: number;
-}
+import { createChunkRenderer, type ChunkRenderer } from "./chunks/ChunkRenderer";
+import { useChunkStreaming } from "./chunks/useChunkStreaming";
+import { createChunkTelemetry } from "./chunks/chunkTelemetry";
+import { getChunkKey } from "@engine/chunks";
 
 interface ChunkedIsometricGridProps {
   worldSeed?: number;
@@ -65,26 +19,55 @@ interface ChunkedIsometricGridProps {
   onTileClick?: (x: number, y: number, tileType?: string) => void;
 }
 
-export default function ChunkedIsometricGrid({
+function collectVisibleChunks(
+  viewport: Viewport,
+  chunkSize: number,
+  tileWidth: number,
+  tileHeight: number,
+) {
+  const bounds = viewport.getVisibleBounds();
+  const corners = [
+    { x: bounds.x, y: bounds.y },
+    { x: bounds.x + bounds.width, y: bounds.y },
+    { x: bounds.x, y: bounds.y + bounds.height },
+    { x: bounds.x + bounds.width, y: bounds.y + bounds.height },
+  ];
+
+  const gridCorners = corners.map((corner) => worldToGrid(corner.x, corner.y, tileWidth, tileHeight));
+  const minGridX = Math.min(...gridCorners.map((grid) => grid.gridX));
+  const maxGridX = Math.max(...gridCorners.map((grid) => grid.gridX));
+  const minGridY = Math.min(...gridCorners.map((grid) => grid.gridY));
+  const maxGridY = Math.max(...gridCorners.map((grid) => grid.gridY));
+
+  const minChunkX = Math.floor(minGridX / chunkSize) - 1;
+  const maxChunkX = Math.floor(maxGridX / chunkSize) + 1;
+  const minChunkY = Math.floor(minGridY / chunkSize) - 1;
+  const maxChunkY = Math.floor(maxGridY / chunkSize) + 1;
+
+  const visible = [] as Array<{ chunkX: number; chunkY: number; key: string }>;
+
+  for (let chunkX = minChunkX; chunkX <= maxChunkX; chunkX++) {
+    for (let chunkY = minChunkY; chunkY <= maxChunkY; chunkY++) {
+      const key = getChunkKey(chunkX, chunkY);
+      visible.push({ chunkX, chunkY, key });
+    }
+  }
+
+  return visible;
+}
+
+function ChunkedIsometricGrid({
   worldSeed = 12345,
   chunkSize = 32,
   tileWidth = 64,
   tileHeight = 32,
-  maxLoadedChunks = 6, // Reduced from 9 to 6 to prevent memory issues
+  maxLoadedChunks = 6,
   onTileHover,
   onTileClick,
 }: ChunkedIsometricGridProps) {
   const { viewport, app } = useGameContext();
-  const worldContainerRef = useRef<PIXI.Container | null>(null);
-  const loadedChunksRef = useRef<Map<string, LoadedChunk>>(new Map());
-  const overlayManagerRef = useRef<TileOverlay | null>(null);
-  const [isInitialized, setIsInitialized] = useState(false);
-  const loadingChunksRef = useRef<Set<string>>(new Set());
-  const lastViewportUpdateRef = useRef<{ x: number; y: number; scale: number }>({ x: 0, y: 0, scale: 1 });
-  const memoryCheckIntervalRef = useRef<NodeJS.Timeout | null>(null);
-  const lastMemoryCleanupRef = useRef<number>(0);
-  const memoryStatsRef = useRef({ totalSprites: 0, totalTextures: 0, totalContainers: 0 });
-  const renderStatsRef = useRef({ chunksLoaded: 0, chunksUnloaded: 0, spritesCreated: 0, spritesDestroyed: 0 });
+  const telemetry = useMemo(() => createChunkTelemetry({ cleanupIntervalMs: 30_000, chunkTimeoutMs: 60_000 }), []);
+  const rendererRef = useRef<ChunkRenderer | null>(null);
   const onTileHoverRef = useRef(onTileHover);
   const onTileClickRef = useRef(onTileClick);
 
@@ -96,6 +79,8 @@ export default function ChunkedIsometricGrid({
     onTileClickRef.current = onTileClick;
   }, [onTileClick]);
 
+  useEffect(() => () => telemetry.dispose(), [telemetry]);
+
   const handleTileHover = useCallback((x: number, y: number, tileType?: string) => {
     onTileHoverRef.current?.(x, y, tileType);
   }, []);
@@ -104,561 +89,127 @@ export default function ChunkedIsometricGrid({
     onTileClickRef.current?.(x, y, tileType);
   }, []);
 
-  // Convert world coordinates to chunk coordinates (via inverse isometric transform)
-  const worldToChunk = useCallback((worldX: number, worldY: number) => {
-    const gridCoords = worldToGrid(worldX, worldY, tileWidth, tileHeight);
-    const chunkX = Math.floor(gridCoords.gridX / chunkSize);
-    const chunkY = Math.floor(gridCoords.gridY / chunkSize);
-    return { chunkX, chunkY };
-  }, [chunkSize, tileWidth, tileHeight]);
-
-  // Load chunk data from API
-  const loadChunkData = useCallback(async (chunkX: number, chunkY: number): Promise<ChunkApiResponse | null> => {
-    try {
-      const response = await fetch(
-        `/api/map/chunk?chunkX=${chunkX}&chunkY=${chunkY}&chunkSize=${chunkSize}&seed=${worldSeed}`
-      );
-      if (!response.ok) {
-        throw new Error(`Failed to load chunk (${chunkX}, ${chunkY}): ${response.statusText}`);
-      }
-      const payload = (await response.json()) as ChunkApiResponse;
-      return payload;
-    } catch (error) {
-      logger.error(`Error loading chunk (${chunkX}, ${chunkY}):`, error);
-      return null;
-    }
-  }, [chunkSize, worldSeed]);
-
-  // Create visual representation of a chunk
-  const createChunkContainer = useCallback((chunkData: ChunkApiResponse): { container: PIXI.Container; tiles: Map<string, GridTile> } => {
-    const container = new PIXI.Container();
-    container.name = `chunk-${chunkData.chunkX}-${chunkData.chunkY}`;
-    container.sortableChildren = true;
-
-    const tiles = new Map<string, GridTile>();
-
-    if (!app?.renderer) {
-      logger.warn(`[GRAPHICS] Renderer unavailable while creating chunk ${chunkData.chunkX},${chunkData.chunkY}`);
-      return { container, tiles };
-    }
-
-    const heightMap = chunkData.fields?.height;
-    const temperatureMap = chunkData.fields?.temperature;
-    const moistureMap = chunkData.fields?.moisture;
-    const climateMap = chunkData.fields?.climate;
-
-    // Create tiles for this chunk
-    for (let localY = 0; localY < chunkData.chunkSize; localY++) {
-      for (let localX = 0; localX < chunkData.chunkSize; localX++) {
-        const globalX = chunkData.chunkX * chunkData.chunkSize + localX;
-        const globalY = chunkData.chunkY * chunkData.chunkSize + localY;
-        const tileType = chunkData.tiles[localY]?.[localX] || 'grass';
-        const biome = chunkData.biomes?.[localY]?.[localX];
-        const heightValue = heightMap?.[localY]?.[localX];
-        const temperatureValue = temperatureMap?.[localY]?.[localX];
-        const moistureValue = moistureMap?.[localY]?.[localX];
-        const climateValue = climateMap?.[localY]?.[localX];
-
-        // Create tile sprite with global coordinates
-        const tile = createTileSprite(
-          globalX,
-          globalY,
-          container,
-          tileWidth,
-          tileHeight,
-          chunkData.tiles,
-          app.renderer,
-          { tileTypeOverride: tileType },
-        );
-        tile.tileType = tileType;
-        tile.biome = biome;
-        tile.height = heightValue;
-        tile.temperature = temperatureValue;
-        tile.moisture = moistureValue;
-        tile.climate = climateValue;
-
-        if (typeof heightValue === 'number' && !['water', 'deep_water', 'river', 'coast'].includes(tileType)) {
-          const shade = Math.max(0.65, Math.min(1, 0.72 + heightValue * 0.28));
-          const shadeChannel = Math.round(shade * 255);
-          const tintHex = (shadeChannel << 16) | (shadeChannel << 8) | shadeChannel;
-          tile.sprite.tint = tintHex;
-        }
-
-        if (tileType === 'river') {
-          tile.sprite.alpha = 0.95;
-        }
-
-        const key = `${globalX},${globalY}`;
-        tiles.set(key, tile);
-        container.addChild(tile.sprite);
-      }
-    }
-    
-    return { container, tiles };
-  }, [app, tileWidth, tileHeight]);
-
-  // Load and render a chunk
-  const loadChunk = useCallback(async (chunkX: number, chunkY: number) => {
-    const chunkKey = `${chunkX},${chunkY}`;
-    const loadedChunks = loadedChunksRef.current;
-
-    if (!app?.renderer) {
-      logger.warn(`[MEMORY] Skipping load for chunk ${chunkKey} - renderer unavailable`);
-      return;
-    }
-
-    // Skip if already loaded or loading
-    if (loadedChunks.has(chunkKey) || loadingChunksRef.current.has(chunkKey)) {
-      logger.debug(`[MEMORY] Skipping chunk ${chunkKey} - already loaded/loading`);
-      return;
-    }
-    
-    const startTime = performance.now();
-    const memoryBefore = memoryStatsRef.current;
-    logger.info(`[MEMORY] Starting to load chunk ${chunkKey}. Current stats: sprites=${memoryBefore.totalSprites}, containers=${memoryBefore.totalContainers}`);
-    
-    loadingChunksRef.current.add(chunkKey);
-    
-    try {
-      const chunkData = await loadChunkData(chunkX, chunkY);
-      if (!chunkData || !worldContainerRef.current) {
-        logger.error(`[MEMORY] Failed to load chunk data for (${chunkX}, ${chunkY})`);
-        return;
-      }
-      
-      const { container, tiles } = createChunkContainer(chunkData);
-      const { fields: _fields, ...persistable } = chunkData;
-
-      // Update memory stats
-      memoryStatsRef.current.totalContainers++;
-      memoryStatsRef.current.totalSprites += tiles.size;
-      renderStatsRef.current.chunksLoaded++;
-      renderStatsRef.current.spritesCreated += tiles.size;
-      logger.debug(`🔍 [MEMORY TRACKING] Chunk ${chunkKey} loaded - Total sprites: ${memoryStatsRef.current.totalSprites}, Containers: ${memoryStatsRef.current.totalContainers}`);
-      logger.debug(`🎮 [RENDER TRACKING] Chunks loaded: ${renderStatsRef.current.chunksLoaded}, Sprites created: ${renderStatsRef.current.spritesCreated}`);
-      
-      worldContainerRef.current.addChild(container);
-      logger.debug(`[GRAPHICS] Added chunk container ${chunkKey} to world container. World children: ${worldContainerRef.current.children.length}`);
-      
-      const loadedChunk: LoadedChunk = {
-        data: {
-          chunkX: persistable.chunkX,
-          chunkY: persistable.chunkY,
-          chunkSize: persistable.chunkSize,
-          tiles: persistable.tiles,
-          biomes: persistable.biomes,
-          features: persistable.features,
-          metadata: persistable.metadata,
-        },
-        container,
-        tiles,
-        lastAccessed: Date.now(),
-      };
-      
-      loadedChunks.set(chunkKey, loadedChunk);
-      
-      const loadTime = performance.now() - startTime;
-      const memoryAfter = memoryStatsRef.current;
-      logger.info(`[MEMORY] Loaded chunk ${chunkKey} in ${loadTime.toFixed(2)}ms. Tiles: ${tiles.size}. New stats: sprites=${memoryAfter.totalSprites}, containers=${memoryAfter.totalContainers}`);
-      
-      // Log detailed tile information
-      logger.debug(`[GRAPHICS] Chunk ${chunkKey} tiles breakdown:`, Array.from(tiles.entries()).map(([key, tile]) => ({
-        position: key,
-        spriteExists: !!tile.sprite,
-        spriteParent: tile.sprite?.parent?.constructor.name,
-        spriteDestroyed: tile.sprite?.destroyed
-      })));
-      
-    } catch (error) {
-      logger.error(`[MEMORY] Failed to load chunk (${chunkX}, ${chunkY}):`, error);
-    } finally {
-      loadingChunksRef.current.delete(chunkKey);
-    }
-  }, [app, loadChunkData, createChunkContainer]);
-
-  // Unload a chunk to free memory
-  const unloadChunk = useCallback((chunkKey: string) => {
-    const loadedChunks = loadedChunksRef.current;
-    const chunk = loadedChunks.get(chunkKey);
-    
-    if (!chunk) {
-      logger.warn(`[MEMORY] Attempted to unload non-existent chunk ${chunkKey}`);
-      return;
-    }
-    
-    const startTime = performance.now();
-    const memoryBefore = memoryStatsRef.current;
-    const tileCount = chunk.tiles.size;
-    
-    logger.info(`[MEMORY] Starting to unload chunk ${chunkKey}. Tiles to dispose: ${tileCount}. Current stats: sprites=${memoryBefore.totalSprites}, containers=${memoryBefore.totalContainers}`);
-    
-    if (worldContainerRef.current) {
-      // Log each tile disposal
-      let disposedCount = 0;
-      chunk.tiles.forEach((tile, tileKey) => {
-        try {
-          logger.debug(`[GRAPHICS] Disposing tile ${tileKey} in chunk ${chunkKey}. Sprite destroyed: ${tile.sprite?.destroyed}`);
-          tile.dispose();
-          disposedCount++;
-          renderStatsRef.current.spritesDestroyed++;
-        } catch (error) {
-          logger.error(`[MEMORY] Error disposing tile ${tileKey}:`, error);
-        }
-      });
-      
-      // Remove and destroy container
-      try {
-        if (chunk.container.parent) {
-          worldContainerRef.current.removeChild(chunk.container);
-          logger.debug(`[GRAPHICS] Removed chunk container ${chunkKey} from world container. Remaining children: ${worldContainerRef.current.children.length}`);
-        }
-        
-        const containerChildren = chunk.container.children.length;
-        chunk.container.destroy({ children: true, texture: true });
-        logger.debug(`[GRAPHICS] Destroyed chunk container ${chunkKey} with ${containerChildren} children`);
-        
-      } catch (error) {
-        logger.error(`[MEMORY] Error destroying container for chunk ${chunkKey}:`, error);
-      }
-      
-      // Update memory stats
-      memoryStatsRef.current.totalSprites -= tileCount;
-      memoryStatsRef.current.totalContainers--;
-      renderStatsRef.current.chunksUnloaded++;
-      
-      chunk.tiles.clear();
-      loadedChunks.delete(chunkKey);
-      
-      const unloadTime = performance.now() - startTime;
-      const memoryAfter = memoryStatsRef.current;
-      logger.info(`[MEMORY] Unloaded chunk ${chunkKey} in ${unloadTime.toFixed(2)}ms. Disposed ${disposedCount}/${tileCount} tiles. New stats: sprites=${memoryAfter.totalSprites}, containers=${memoryAfter.totalContainers}`);
-      logger.debug(`🧹 [MEMORY CLEANUP] Chunk ${chunkKey} unloaded - Disposed ${disposedCount} sprites, Remaining: ${memoryAfter.totalSprites}`);
-      
-      // Log render stats summary
-      const renderStats = renderStatsRef.current;
-      logger.debug(`[RENDER_STATS] Total - Loaded: ${renderStats.chunksLoaded}, Unloaded: ${renderStats.chunksUnloaded}, Sprites Created: ${renderStats.spritesCreated}, Sprites Destroyed: ${renderStats.spritesDestroyed}`);
-      logger.debug(`🗑️ [RENDER CLEANUP] Chunks unloaded: ${renderStats.chunksUnloaded}, Sprites destroyed: ${renderStats.spritesDestroyed}`);
-    }
+  const onChunkEvicted = useCallback((chunkKey: string) => {
+    rendererRef.current?.destroyChunk(chunkKey);
   }, []);
 
+  const { ensureChunkLoaded, releaseChunk, chunkCache } = useChunkStreaming({
+    worldSeed,
+    chunkSize,
+    maxLoadedChunks,
+    telemetry,
+    onChunkEvicted,
+  });
 
+  const updateVisibleChunks = useCallback(async () => {
+    if (!viewport) return;
+    const renderer = rendererRef.current;
+    if (!renderer) return;
 
-  // Get chunks that should be visible based on viewport (compute in grid space)
-  const getVisibleChunks = useCallback(() => {
-    if (!viewport) return [];
-    
-    const bounds = viewport.getVisibleBounds();
+    const visible = collectVisibleChunks(viewport, chunkSize, tileWidth, tileHeight);
+    const visibleKeys = new Set(visible.map((chunk) => chunk.key));
 
-    // Project viewport world-space corners back to grid indices
-    const corners = [
-      { x: bounds.x, y: bounds.y },
-      { x: bounds.x + bounds.width, y: bounds.y },
-      { x: bounds.x, y: bounds.y + bounds.height },
-      { x: bounds.x + bounds.width, y: bounds.y + bounds.height },
-    ];
-    const gridCorners = corners.map((c) => worldToGrid(c.x, c.y, tileWidth, tileHeight));
+    await Promise.all(
+      visible.map(async ({ chunkX, chunkY, key }) => {
+        const result = await ensureChunkLoaded(chunkX, chunkY);
+        if (rendererRef.current !== renderer) return;
+        if (result.renderPayload && !renderer.hasChunk(key)) {
+          renderer.renderChunk(key, result.renderPayload);
+        }
+      }),
+    );
 
-    const minGridX = Math.min(...gridCorners.map((g) => g.gridX));
-    const maxGridX = Math.max(...gridCorners.map((g) => g.gridX));
-    const minGridY = Math.min(...gridCorners.map((g) => g.gridY));
-    const maxGridY = Math.max(...gridCorners.map((g) => g.gridY));
-
-    // Add a one-chunk padding in all directions
-    const minChunkX = Math.floor(minGridX / chunkSize) - 1;
-    const maxChunkX = Math.floor(maxGridX / chunkSize) + 1;
-    const minChunkY = Math.floor(minGridY / chunkSize) - 1;
-    const maxChunkY = Math.floor(maxGridY / chunkSize) + 1;
-    
-    const visibleChunks: { chunkX: number; chunkY: number }[] = [];
-    for (let chunkX = minChunkX; chunkX <= maxChunkX; chunkX++) {
-      for (let chunkY = minChunkY; chunkY <= maxChunkY; chunkY++) {
-        visibleChunks.push({ chunkX, chunkY });
-      }
-    }
-    
-    return visibleChunks;
-  }, [viewport, chunkSize, tileWidth, tileHeight]);
-
-  // Manage chunk loading/unloading based on viewport
-  const updateChunks = useCallback(async () => {
-    if (!viewport || !worldContainerRef.current) return;
-    
-    const visibleChunks = getVisibleChunks();
-    const loadedChunks = loadedChunksRef.current;
-    const currentTime = Date.now();
-    
-    // Load visible chunks
-    const loadPromises = visibleChunks.map(({ chunkX, chunkY }) => {
-      const chunkKey = `${chunkX},${chunkY}`;
-      if (loadedChunks.has(chunkKey)) {
-        // Update access time
-        loadedChunks.get(chunkKey)!.lastAccessed = currentTime;
-      } else {
-        // Load new chunk
-        return loadChunk(chunkX, chunkY);
+    renderer.getRenderedChunkKeys().forEach((key) => {
+      if (!visibleKeys.has(key)) {
+        renderer.destroyChunk(key);
+        releaseChunk(key);
       }
     });
-    
-    await Promise.all(loadPromises.filter(Boolean));
-    
-    // Unload chunks that are too far away or exceed max limit
-    const visibleChunkKeys = new Set(visibleChunks.map(({ chunkX, chunkY }) => `${chunkX},${chunkY}`));
-    const chunksToUnload: string[] = [];
-    
-    loadedChunks.forEach((chunk, chunkKey) => {
-      if (!visibleChunkKeys.has(chunkKey)) {
-        chunksToUnload.push(chunkKey);
-      }
-    });
-    
-    // If we have too many chunks, unload the least recently accessed ones
-    if (loadedChunks.size > maxLoadedChunks) {
-      const sortedChunks = Array.from(loadedChunks.entries())
-        .sort(([, a], [, b]) => a.lastAccessed - b.lastAccessed);
-      
-      const excessCount = loadedChunks.size - maxLoadedChunks;
-      for (let i = 0; i < excessCount; i++) {
-        chunksToUnload.push(sortedChunks[i][0]);
-      }
-    }
-    
-    // Unload chunks
-    chunksToUnload.forEach(chunkKey => unloadChunk(chunkKey));
-    
-  }, [viewport, getVisibleChunks, loadChunk, unloadChunk, maxLoadedChunks]);
 
-  // Initialize world container
+    renderer.updateVisibility(viewport, true);
+  }, [viewport, chunkSize, tileWidth, tileHeight, ensureChunkLoaded, releaseChunk]);
+
   useEffect(() => {
-    if (!viewport || worldContainerRef.current) return;
+    if (!viewport || !app?.renderer) {
+      return;
+    }
 
-    const worldContainer = new PIXI.Container();
-    worldContainer.name = 'chunked-world';
-    worldContainer.sortableChildren = true;
-    worldContainer.zIndex = 100;
-    (worldContainer as unknown as { eventMode: string }).eventMode = 'static';
-    
-    viewport.addChild(worldContainer);
-    worldContainerRef.current = worldContainer;
-    
-    // Initialize overlay manager
-    overlayManagerRef.current = new TileOverlay(worldContainer, {
+    const renderer = createChunkRenderer({
+      viewport,
+      renderer: app.renderer,
+      ticker: app.ticker ?? null,
+      chunkSize,
       tileWidth,
       tileHeight,
-      getTileType: (x, y) => {
-        // Find the chunk containing this tile
-        const chunkX = Math.floor(x / chunkSize);
-        const chunkY = Math.floor(y / chunkSize);
-        const chunkKey = `${chunkX},${chunkY}`;
-        const chunk = loadedChunksRef.current.get(chunkKey);
-        
-        if (chunk) {
-          const localX = x - chunkX * chunkSize;
-          const localY = y - chunkY * chunkSize;
-          return chunk.data.tiles[localY]?.[localX] || 'grass';
-        }
-        return 'grass';
-      },
+      chunkCache,
       onTileHover: handleTileHover,
       onTileClick: handleTileClick,
+      telemetry,
     });
-    
-    // Set initial viewport position and zoom
-    viewport.setZoom(1.5);
-    viewport.moveCenter(0, 0);
-    
-    setIsInitialized(true);
-    
-    // Start memory monitoring with inline cleanup
-    memoryCheckIntervalRef.current = setInterval(() => {
-      const now = Date.now();
-      if (now - lastMemoryCleanupRef.current < 30000) return;
-      
-      const loadedChunks = loadedChunksRef.current;
-      const CHUNK_TIMEOUT = 60000; // 1 minute
-      
-      const chunksToRemove: string[] = [];
-      loadedChunks.forEach((chunk, chunkKey) => {
-        if (now - chunk.lastAccessed > CHUNK_TIMEOUT) {
-          chunksToRemove.push(chunkKey);
-        }
-      });
-      
-      chunksToRemove.forEach(chunkKey => {
-        const chunk = loadedChunks.get(chunkKey);
-        if (chunk && worldContainerRef.current) {
-          chunk.tiles.forEach((tile) => {
-            tile.dispose();
-          });
-          worldContainerRef.current.removeChild(chunk.container);
-          chunk.container.destroy({ children: true, texture: true });
-          chunk.tiles.clear();
-          loadedChunks.delete(chunkKey);
-        }
-      });
-      
-      lastMemoryCleanupRef.current = now;
-      if (chunksToRemove.length > 0) {
-        logger.debug(`Memory cleanup completed. Removed ${chunksToRemove.length} old chunks.`);
-      }
-    }, 30000); // Every 30 seconds
-    
+
+    rendererRef.current = renderer;
+    void updateVisibleChunks();
+
     return () => {
-      // Clear memory monitoring interval
-      if (memoryCheckIntervalRef.current) {
-        clearInterval(memoryCheckIntervalRef.current);
-        memoryCheckIntervalRef.current = null;
-      }
-      overlayManagerRef.current?.destroy();
-      overlayManagerRef.current = null;
-      
-      if (worldContainer.parent) {
-        worldContainer.parent.removeChild(worldContainer);
-      }
-      worldContainer.destroy({ children: true });
-      worldContainerRef.current = null;
-      
-      // Properly dispose of all loaded chunks
-      loadedChunksRef.current.forEach((chunk, chunkKey) => {
-        chunk.tiles.forEach((tile) => {
-          tile.dispose(); // Use the proper dispose method from GridTile
-        });
-        chunk.container.destroy({ children: true, texture: true });
-        chunk.tiles.clear();
-      });
-      loadedChunksRef.current.clear();
-      loadingChunksRef.current.clear();
-
-      // NOTE: Do not set state in cleanup to avoid triggering re-renders during effect teardown
-      // setIsInitialized(false);
+      const keys = renderer.getRenderedChunkKeys();
+      keys.forEach((key) => releaseChunk(key));
+      renderer.destroy();
+      rendererRef.current = null;
     };
-  }, [viewport, tileWidth, tileHeight, chunkSize, handleTileHover, handleTileClick]);
+  }, [
+    app,
+    viewport,
+    chunkSize,
+    tileWidth,
+    tileHeight,
+    chunkCache,
+    handleTileHover,
+    handleTileClick,
+    telemetry,
+    updateVisibleChunks,
+    releaseChunk,
+  ]);
 
-  // Handle viewport changes with throttling
   useEffect(() => {
-    if (!viewport || !isInitialized) return;
-    
-    let updateTimeout: NodeJS.Timeout;
+    if (!viewport) return;
+
+    let updateTimeout: ReturnType<typeof setTimeout> | null = null;
     let isUpdating = false;
-    
-    const handleViewportChange = () => {
-      if (isUpdating) return; // Prevent concurrent updates
-      
-      const center = viewport.center;
-      const scale = viewport.scale?.x || 1;
-      const lastUpdate = lastViewportUpdateRef.current;
-      
-      // Only update if viewport moved significantly or scale changed (increased thresholds to reduce flickering)
-      const moved = Math.abs(center.x - lastUpdate.x) > tileWidth * 3 || 
-                   Math.abs(center.y - lastUpdate.y) > tileHeight * 3;
-      const scaleChanged = Math.abs(scale - lastUpdate.scale) > 0.3; // Less sensitive
-      
-      // Increased minimum update interval to reduce flickering
-      if (moved || scaleChanged) {
+
+    const scheduleUpdate = () => {
+      if (isUpdating) return;
+      if (updateTimeout) {
         clearTimeout(updateTimeout);
-        updateTimeout = setTimeout(async () => {
-          isUpdating = true;
-          try {
-            await updateChunks();
-            lastViewportUpdateRef.current = { x: center.x, y: center.y, scale };
-          } finally {
-            isUpdating = false;
-          }
-        }, 300); // Increased throttle time further
       }
-    };
-    
-    viewport.on('moved', handleViewportChange);
-    viewport.on('zoomed', handleViewportChange);
-    
-    // Initial chunk loading
-    updateChunks();
-    
-    return () => {
-      clearTimeout(updateTimeout);
-      viewport.off('moved', handleViewportChange);
-      viewport.off('zoomed', handleViewportChange);
-    };
-    // Only depend on primitives; updateChunks is stable via useCallback and viewport is stable from context
-  }, [viewport, isInitialized, tileWidth, tileHeight]);
 
-  // Performance optimization: Viewport culling and LOD
-  useEffect(() => {
-    if (!viewport || !worldContainerRef.current || !app?.ticker) return;
-    
-    let lastScale = viewport.scale?.x || 1;
-    let lastUpdateTime = 0;
-    let t = 0;
-    
-    const updateVisibilityAndLOD = (force = false) => {
-      const now = Date.now();
-      if (!force && now - lastUpdateTime < 200) return; // Throttle to 5fps to reduce flickering
-      
-      if (!viewport || !viewport.scale) return;
-      
-      const scale = viewport.scale.x;
-      const bounds = viewport.getVisibleBounds();
-      const padding = Math.max(tileWidth, tileHeight) * 4; // Increased padding for stability
-      
-      const visibleLeft = bounds.x - padding;
-      const visibleRight = bounds.x + bounds.width + padding;
-      const visibleTop = bounds.y - padding;
-      const visibleBottom = bounds.y + bounds.height + padding;
-      
-      const scaleChanged = Math.abs(scale - lastScale) > 0.3; // Less sensitive to prevent flickering
-      
-      // Update visibility for all loaded chunks (less frequently)
-      loadedChunksRef.current.forEach((chunk) => {
-        chunk.tiles.forEach((tile) => {
-          const isInViewport = tile.worldX >= visibleLeft && 
-                             tile.worldX <= visibleRight && 
-                             tile.worldY >= visibleTop && 
-                             tile.worldY <= visibleBottom;
-          
-          const shouldShowTile = scale > 0.1 && isInViewport; // Lower threshold for better visibility
-          
-          // Only update visibility if there's a significant change to prevent flickering
-          if (tile.sprite.visible !== shouldShowTile) {
-            tile.sprite.visible = shouldShowTile;
-          }
-        });
-      });
-      
-      if (scaleChanged) {
-        lastScale = scale;
-      }
-      lastUpdateTime = now;
+      updateTimeout = setTimeout(async () => {
+        isUpdating = true;
+        try {
+          await updateVisibleChunks();
+        } finally {
+          isUpdating = false;
+        }
+      }, 250);
     };
-    
-    const tick = () => {
-      t += app.ticker.deltaMS;
-      
-      // Update selection overlay animation only
-      const sel = overlayManagerRef.current?.selectOverlay;
-      if (sel && sel.visible) {
-        const base = 0.35;
-        const amp = 0.1;
-        const w = 0.002;
-        sel.alpha = base + amp * (0.5 + 0.5 * Math.sin(t * w));
-      }
-      
-      // Only update visibility occasionally, not every frame
-      if (t % 100 < app.ticker.deltaMS) {
-        updateVisibilityAndLOD();
-      }
-    };
-    
-    // Initial visibility update
-    updateVisibilityAndLOD(true);
-    
-    app.ticker.add(tick);
-    
-    return () => {
-      app.ticker.remove(tick);
-    };
-  }, [viewport, app, tileWidth, tileHeight]);
 
-  return null; // This component doesn't render React elements
+    viewport.on("moved", scheduleUpdate);
+    viewport.on("zoomed", scheduleUpdate);
+
+    void updateVisibleChunks();
+
+    return () => {
+      if (updateTimeout) {
+        clearTimeout(updateTimeout);
+      }
+      viewport.off("moved", scheduleUpdate);
+      viewport.off("zoomed", scheduleUpdate);
+    };
+  }, [viewport, updateVisibleChunks]);
+
+  return null;
 }
 
+export default ChunkedIsometricGrid;
 export type { ChunkedIsometricGridProps };
 export { ChunkedIsometricGrid };
+

--- a/src/components/game/chunks/ChunkRenderer.test.ts
+++ b/src/components/game/chunks/ChunkRenderer.test.ts
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../grid/TileRenderer", () => {
+  return {
+    createTileSprite: vi.fn((gridX: number, gridY: number) => {
+      const dispose = vi.fn();
+      const sprite = {
+        visible: true,
+        alpha: 1,
+        tint: 0xffffff,
+        parent: null as unknown,
+        position: { set: vi.fn() },
+        destroy: vi.fn(),
+      };
+
+      return {
+        x: gridX,
+        y: gridY,
+        worldX: gridX,
+        worldY: gridY,
+        tileType: "grass",
+        sprite,
+        dispose,
+      };
+    }),
+  };
+});
+
+const overlayDestroy = vi.fn();
+
+vi.mock("../grid/TileOverlay", () => ({
+  TileOverlay: vi.fn().mockImplementation(() => ({
+    hoverOverlay: { visible: false },
+    selectOverlay: { visible: false, alpha: 0 },
+    destroy: overlayDestroy,
+  })),
+}));
+
+vi.mock("pixi.js", () => {
+  class Container {
+    children: unknown[] = [];
+    name = "";
+    sortableChildren = false;
+    zIndex = 0;
+    parent: Container | null = null;
+
+    addChild(child: any) {
+      this.children.push(child);
+      child.parent = this;
+      return child;
+    }
+
+    removeChild(child: any) {
+      this.children = this.children.filter((entry) => entry !== child);
+      child.parent = null;
+      return child;
+    }
+
+    destroy() {
+      this.children = [];
+    }
+  }
+
+  class Renderer {
+    render() {}
+  }
+
+  class Graphics extends Container {
+    fill() {}
+    moveTo() {}
+    lineTo() {}
+    closePath() {}
+    clear() {}
+    setStrokeStyle() {}
+    stroke() {}
+  }
+
+  class Polygon {}
+
+  const RenderTexture = {
+    create: vi.fn(() => ({})),
+  };
+
+  class Sprite {
+    visible = true;
+    alpha = 1;
+    tint = 0xffffff;
+    destroyed = false;
+    parent: Container | null = null;
+    position = { set: vi.fn() };
+
+    destroy() {
+      this.destroyed = true;
+    }
+  }
+
+  return { Container, Renderer, Graphics, Polygon, RenderTexture, Sprite };
+});
+
+import * as PIXI from "pixi.js";
+import { createChunkRenderer } from "./ChunkRenderer";
+import { getChunkKey, type ChunkCacheEntry, type ChunkPayload } from "@engine/chunks";
+
+const telemetryStub = () => ({
+  stats: {
+    loads: 0,
+    releases: 0,
+    tilesLoaded: 0,
+    tilesReleased: 0,
+    lastCacheSize: 0,
+    renderCreates: 0,
+    renderDisposes: 0,
+  },
+  logLoadStart: vi.fn(),
+  logLoadSuccess: vi.fn(),
+  logLoadError: vi.fn(),
+  logRelease: vi.fn(),
+  logRenderCreate: vi.fn(),
+  logRenderDispose: vi.fn(),
+  scheduleCleanup: vi.fn(() => () => undefined),
+  dispose: vi.fn(),
+});
+
+const createPayload = (chunkX: number, chunkY: number): ChunkPayload => ({
+  chunkX,
+  chunkY,
+  chunkSize: 2,
+  seed: 1,
+  tiles: [
+    ["grass", "grass"],
+    ["grass", "grass"],
+  ],
+});
+
+const toCacheEntry = (payload: ChunkPayload): ChunkCacheEntry => ({
+  key: getChunkKey(payload.chunkX, payload.chunkY),
+  data: {
+    chunkX: payload.chunkX,
+    chunkY: payload.chunkY,
+    chunkSize: payload.chunkSize,
+    tiles: payload.tiles,
+  },
+  tileCount: payload.tiles.length * payload.tiles[0].length,
+  lastAccessed: Date.now(),
+});
+
+describe("ChunkRenderer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates and disposes rendered chunks", () => {
+    const payload = createPayload(0, 0);
+    const cache = new Map([[payload.chunkX + "," + payload.chunkY, toCacheEntry(payload)]]);
+    const viewport: any = {
+      addChild: vi.fn(),
+      removeChild: vi.fn(),
+      setZoom: vi.fn(),
+      moveCenter: vi.fn(),
+      getVisibleBounds: vi.fn(() => ({ x: 0, y: 0, width: 256, height: 256 })),
+      scale: { x: 1, y: 1 },
+    };
+    const ticker = { add: vi.fn(), remove: vi.fn() };
+    const telemetry = telemetryStub();
+
+    const renderer = createChunkRenderer({
+      viewport,
+      renderer: new PIXI.Renderer(),
+      ticker,
+      chunkSize: payload.chunkSize,
+      tileWidth: 64,
+      tileHeight: 32,
+      chunkCache: cache,
+      telemetry,
+    });
+
+    const chunkKey = getChunkKey(payload.chunkX, payload.chunkY);
+    const rendered = renderer.renderChunk(chunkKey, payload);
+    expect(rendered).not.toBeNull();
+    expect(rendered?.tiles.size).toBe(4);
+    expect(telemetry.logRenderCreate).toHaveBeenCalledWith(chunkKey, expect.objectContaining({ tileCount: 4 }));
+
+    const tiles = rendered ? Array.from(rendered.tiles.values()) : [];
+    renderer.destroyChunk(chunkKey);
+    tiles.forEach((tile) => expect(tile.dispose).toHaveBeenCalled());
+    expect(telemetry.logRenderDispose).toHaveBeenCalledWith(chunkKey, expect.objectContaining({ tileCount: 4 }));
+
+    renderer.destroy();
+    expect(ticker.remove).toHaveBeenCalled();
+    expect(overlayDestroy).toHaveBeenCalled();
+  });
+});
+

--- a/src/components/game/chunks/ChunkRenderer.ts
+++ b/src/components/game/chunks/ChunkRenderer.ts
@@ -1,0 +1,288 @@
+"use client";
+
+import * as PIXI from "pixi.js";
+import type { Viewport } from "pixi-viewport";
+import logger from "@/lib/logger";
+import { createTileSprite, type GridTile } from "../grid/TileRenderer";
+import { TileOverlay } from "../grid/TileOverlay";
+import { getChunkKey, type ChunkCacheEntry, type ChunkPayload } from "@engine/chunks";
+import type { ChunkTelemetry } from "./chunkTelemetry";
+
+interface TickerLike {
+  add: (fn: (...args: unknown[]) => unknown) => unknown;
+  remove: (fn: (...args: unknown[]) => unknown) => unknown;
+}
+
+export interface ChunkRendererOptions {
+  viewport: Viewport;
+  renderer: PIXI.Renderer | null;
+  ticker?: TickerLike | null;
+  chunkSize: number;
+  tileWidth: number;
+  tileHeight: number;
+  chunkCache: ReadonlyMap<string, ChunkCacheEntry>;
+  onTileHover?: (x: number, y: number, tileType?: string) => void;
+  onTileClick?: (x: number, y: number, tileType?: string) => void;
+  telemetry?: ChunkTelemetry;
+}
+
+interface RenderedChunk {
+  container: PIXI.Container;
+  tiles: Map<string, GridTile>;
+  tileCount: number;
+}
+
+function buildChunkContainer(
+  payload: ChunkPayload,
+  renderer: PIXI.Renderer,
+  tileWidth: number,
+  tileHeight: number,
+): RenderedChunk {
+  const container = new PIXI.Container();
+  container.name = `chunk-${payload.chunkX}-${payload.chunkY}`;
+  container.sortableChildren = true;
+  (container as unknown as { eventMode?: string }).eventMode = "static";
+
+  const tiles = new Map<string, GridTile>();
+
+  const heightMap = payload.fields?.height;
+  const temperatureMap = payload.fields?.temperature;
+  const moistureMap = payload.fields?.moisture;
+  const climateMap = payload.fields?.climate;
+
+  for (let localY = 0; localY < payload.chunkSize; localY++) {
+    for (let localX = 0; localX < payload.chunkSize; localX++) {
+      const globalX = payload.chunkX * payload.chunkSize + localX;
+      const globalY = payload.chunkY * payload.chunkSize + localY;
+      const tileType = payload.tiles[localY]?.[localX] ?? "grass";
+      const biome = payload.biomes?.[localY]?.[localX];
+      const heightValue = heightMap?.[localY]?.[localX];
+      const temperatureValue = temperatureMap?.[localY]?.[localX];
+      const moistureValue = moistureMap?.[localY]?.[localX];
+      const climateValue = climateMap?.[localY]?.[localX];
+
+      const tile = createTileSprite(
+        globalX,
+        globalY,
+        container,
+        tileWidth,
+        tileHeight,
+        payload.tiles,
+        renderer,
+        { tileTypeOverride: tileType },
+      );
+
+      tile.tileType = tileType;
+      tile.biome = biome;
+      tile.height = heightValue;
+      tile.temperature = temperatureValue;
+      tile.moisture = moistureValue;
+      tile.climate = climateValue;
+
+      if (
+        typeof heightValue === "number" &&
+        !["water", "deep_water", "river", "coast"].includes(tileType)
+      ) {
+        const shade = Math.max(0.65, Math.min(1, 0.72 + heightValue * 0.28));
+        const shadeChannel = Math.round(shade * 255);
+        const tintHex = (shadeChannel << 16) | (shadeChannel << 8) | shadeChannel;
+        tile.sprite.tint = tintHex;
+      }
+
+      if (tileType === "river") {
+        tile.sprite.alpha = 0.95;
+      }
+
+      const key = `${globalX},${globalY}`;
+      tiles.set(key, tile);
+      container.addChild(tile.sprite);
+    }
+  }
+
+  return { container, tiles, tileCount: tiles.size };
+}
+
+export class ChunkRenderer {
+  private readonly viewport: Viewport;
+  private readonly renderer: PIXI.Renderer | null;
+  private readonly ticker: TickerLike | null;
+  private readonly chunkSize: number;
+  private readonly tileWidth: number;
+  private readonly tileHeight: number;
+  private readonly chunkCache: ReadonlyMap<string, ChunkCacheEntry>;
+  private readonly telemetry?: ChunkTelemetry;
+  private readonly renderedChunks = new Map<string, RenderedChunk>();
+  private worldContainer: PIXI.Container;
+  private overlay: TileOverlay | null = null;
+  private lastVisibilityUpdate = 0;
+
+  constructor(options: ChunkRendererOptions) {
+    this.viewport = options.viewport;
+    this.renderer = options.renderer;
+    this.ticker = options.ticker ?? null;
+    this.chunkSize = options.chunkSize;
+    this.tileWidth = options.tileWidth;
+    this.tileHeight = options.tileHeight;
+    this.chunkCache = options.chunkCache;
+    this.telemetry = options.telemetry;
+
+    this.worldContainer = new PIXI.Container();
+    this.worldContainer.name = "chunked-world";
+    this.worldContainer.sortableChildren = true;
+    this.worldContainer.zIndex = 100;
+    (this.worldContainer as unknown as { eventMode?: string }).eventMode = "static";
+
+    this.viewport.addChild(this.worldContainer);
+    this.viewport.setZoom?.(1.5);
+    this.viewport.moveCenter?.(0, 0);
+
+    this.overlay = new TileOverlay(this.worldContainer, {
+      tileWidth: this.tileWidth,
+      tileHeight: this.tileHeight,
+      getTileType: this.getTileType,
+      onTileHover: options.onTileHover,
+      onTileClick: options.onTileClick,
+    });
+
+    if (this.ticker) {
+      this.ticker.add(this.handleTick);
+    }
+  }
+
+  hasChunk(chunkKey: string) {
+    return this.renderedChunks.has(chunkKey);
+  }
+
+  getRenderedChunkKeys() {
+    return Array.from(this.renderedChunks.keys());
+  }
+
+  renderChunk(chunkKey: string, payload: ChunkPayload) {
+    if (!this.renderer) {
+      logger.warn(`[CHUNK_RENDER] Renderer unavailable for chunk ${chunkKey}`);
+      return null;
+    }
+
+    if (this.renderedChunks.has(chunkKey)) {
+      return this.renderedChunks.get(chunkKey)!;
+    }
+
+    const rendered = buildChunkContainer(payload, this.renderer, this.tileWidth, this.tileHeight);
+    this.worldContainer.addChild(rendered.container);
+    this.renderedChunks.set(chunkKey, rendered);
+    this.telemetry?.logRenderCreate(chunkKey, { tileCount: rendered.tileCount });
+    this.updateVisibility(this.viewport, true);
+
+    return rendered;
+  }
+
+  destroyChunk(chunkKey: string) {
+    const rendered = this.renderedChunks.get(chunkKey);
+    if (!rendered) {
+      return;
+    }
+
+    rendered.tiles.forEach((tile) => {
+      try {
+        tile.dispose();
+      } catch (error) {
+        logger.error(`[CHUNK_RENDER] Failed disposing tile ${tile.x},${tile.y}`, error);
+      }
+    });
+
+    if (rendered.container.parent) {
+      rendered.container.parent.removeChild(rendered.container);
+    }
+    rendered.container.destroy({ children: true, texture: true });
+    this.renderedChunks.delete(chunkKey);
+    this.telemetry?.logRenderDispose(chunkKey, { tileCount: rendered.tileCount });
+  }
+
+  updateVisibility(viewport: Viewport, force = false) {
+    const now = performance.now();
+    if (!force && now - this.lastVisibilityUpdate < 200) {
+      return;
+    }
+
+    const scale = viewport.scale?.x ?? 1;
+    const bounds = viewport.getVisibleBounds();
+    const padding = Math.max(this.tileWidth, this.tileHeight) * 4;
+
+    const visibleLeft = bounds.x - padding;
+    const visibleRight = bounds.x + bounds.width + padding;
+    const visibleTop = bounds.y - padding;
+    const visibleBottom = bounds.y + bounds.height + padding;
+
+    this.renderedChunks.forEach((chunk) => {
+      chunk.tiles.forEach((tile) => {
+        const isInViewport =
+          tile.worldX >= visibleLeft &&
+          tile.worldX <= visibleRight &&
+          tile.worldY >= visibleTop &&
+          tile.worldY <= visibleBottom;
+
+        const shouldShowTile = scale > 0.1 && isInViewport;
+        if (tile.sprite.visible !== shouldShowTile) {
+          tile.sprite.visible = shouldShowTile;
+        }
+      });
+    });
+
+    this.lastVisibilityUpdate = now;
+  }
+
+  destroy() {
+    if (this.ticker) {
+      this.ticker.remove(this.handleTick);
+    }
+
+    this.getRenderedChunkKeys().forEach((key) => this.destroyChunk(key));
+
+    this.overlay?.destroy();
+    this.overlay = null;
+
+    if (this.worldContainer.parent) {
+      this.worldContainer.parent.removeChild(this.worldContainer);
+    }
+    this.worldContainer.destroy({ children: true });
+  }
+
+  private readonly getTileType = (gridX: number, gridY: number) => {
+    const chunkX = Math.floor(gridX / this.chunkSize);
+    const chunkY = Math.floor(gridY / this.chunkSize);
+    const chunkKey = getChunkKey(chunkX, chunkY);
+    const chunk = this.chunkCache.get(chunkKey);
+
+    if (!chunk) {
+      return undefined;
+    }
+
+    const localX = gridX - chunk.data.chunkX * chunk.data.chunkSize;
+    const localY = gridY - chunk.data.chunkY * chunk.data.chunkSize;
+    return chunk.data.tiles[localY]?.[localX];
+  };
+
+  private readonly handleTick = () => {
+    const now = performance.now();
+    const delta = now - this.lastVisibilityUpdate;
+
+    if (this.overlay?.selectOverlay.visible) {
+      const base = 0.35;
+      const amp = 0.1;
+      const w = 0.002;
+      const t = now;
+      this.overlay.selectOverlay.alpha = base + amp * (0.5 + 0.5 * Math.sin(t * w));
+    }
+
+    if (delta > 200) {
+      this.updateVisibility(this.viewport);
+    }
+  };
+}
+
+export function createChunkRenderer(options: ChunkRendererOptions) {
+  return new ChunkRenderer(options);
+}
+
+export type { RenderedChunk };
+

--- a/src/components/game/chunks/chunkTelemetry.ts
+++ b/src/components/game/chunks/chunkTelemetry.ts
@@ -1,0 +1,109 @@
+import logger from "@/lib/logger";
+import type {
+  ChunkCacheEntry,
+  ChunkTelemetry,
+  ChunkTelemetryStats,
+} from "@engine/chunks";
+
+export interface ChunkTelemetryOptions {
+  cleanupIntervalMs?: number;
+  chunkTimeoutMs?: number;
+}
+
+export function createChunkTelemetry({
+  cleanupIntervalMs = 30_000,
+  chunkTimeoutMs = 60_000,
+}: ChunkTelemetryOptions = {}): ChunkTelemetry {
+  const stats: ChunkTelemetryStats = {
+    loads: 0,
+    releases: 0,
+    tilesLoaded: 0,
+    tilesReleased: 0,
+    lastCacheSize: 0,
+    renderCreates: 0,
+    renderDisposes: 0,
+  };
+
+  let cleanupHandle: ReturnType<typeof setInterval> | null = null;
+
+  const scheduleCleanup = (
+    snapshot: () => Iterable<[string, ChunkCacheEntry]>,
+    evict: (chunkKey: string) => void,
+  ) => {
+    if (cleanupHandle) {
+      clearInterval(cleanupHandle);
+    }
+
+    cleanupHandle = setInterval(() => {
+      const now = Date.now();
+      const staleKeys: string[] = [];
+
+      for (const [chunkKey, entry] of snapshot()) {
+        if (now - entry.lastAccessed > chunkTimeoutMs) {
+          staleKeys.push(chunkKey);
+        }
+      }
+
+      if (staleKeys.length > 0) {
+        logger.debug(
+          `[CHUNK_TELEMETRY] Cleaning up ${staleKeys.length} stale chunk(s): ${staleKeys.join(",")}`
+        );
+      }
+
+      staleKeys.forEach(evict);
+    }, cleanupIntervalMs);
+
+    return () => {
+      if (cleanupHandle) {
+        clearInterval(cleanupHandle);
+        cleanupHandle = null;
+      }
+    };
+  };
+
+  const telemetry: ChunkTelemetry = {
+    stats,
+    logLoadStart(chunkKey) {
+      logger.info(`[CHUNK_LOAD] Begin loading ${chunkKey}`);
+    },
+    logLoadSuccess(chunkKey, { durationMs, tileCount, cacheSize }) {
+      stats.loads += 1;
+      stats.tilesLoaded += tileCount;
+      stats.lastCacheSize = cacheSize;
+      logger.info(
+        `[CHUNK_LOAD] Loaded ${chunkKey} in ${durationMs.toFixed(2)}ms (tiles=${tileCount}, cache=${cacheSize})`
+      );
+    },
+    logLoadError(chunkKey, error) {
+      logger.error(`[CHUNK_LOAD] Failed loading ${chunkKey}`, error);
+    },
+    logRelease(chunkKey, { durationMs, tileCount, cacheSize, reason }) {
+      stats.releases += 1;
+      stats.tilesReleased += tileCount;
+      stats.lastCacheSize = cacheSize;
+      logger.info(
+        `[CHUNK_RELEASE] Released ${chunkKey} in ${durationMs.toFixed(2)}ms (tiles=${tileCount}, cache=${cacheSize}, reason=${reason})`
+      );
+    },
+    logRenderCreate(chunkKey, { tileCount }) {
+      stats.renderCreates += 1;
+      logger.debug(`[CHUNK_RENDER] Created container for ${chunkKey} (tiles=${tileCount})`);
+    },
+    logRenderDispose(chunkKey, { tileCount }) {
+      stats.renderDisposes += 1;
+      logger.debug(`[CHUNK_RENDER] Disposed container for ${chunkKey} (tiles=${tileCount})`);
+    },
+    scheduleCleanup,
+    dispose() {
+      if (cleanupHandle) {
+        clearInterval(cleanupHandle);
+        cleanupHandle = null;
+      }
+    },
+  };
+
+  return telemetry;
+}
+
+export type { ChunkTelemetry, ChunkTelemetryStats } from "@engine/chunks";
+

--- a/src/components/game/chunks/useChunkStreaming.test.ts
+++ b/src/components/game/chunks/useChunkStreaming.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import { ChunkStreamingManager, type ChunkPayload } from "@engine/chunks";
+
+const createPayload = (chunkX: number, chunkY: number): ChunkPayload => ({
+  chunkX,
+  chunkY,
+  chunkSize: 2,
+  seed: 1,
+  tiles: [
+    ["grass", "grass"],
+    ["grass", "grass"],
+  ],
+});
+
+const telemetryStub = () => ({
+  stats: {
+    loads: 0,
+    releases: 0,
+    tilesLoaded: 0,
+    tilesReleased: 0,
+    lastCacheSize: 0,
+    renderCreates: 0,
+    renderDisposes: 0,
+  },
+  logLoadStart: vi.fn(),
+  logLoadSuccess: vi.fn(),
+  logLoadError: vi.fn(),
+  logRelease: vi.fn(),
+  logRenderCreate: vi.fn(),
+  logRenderDispose: vi.fn(),
+  scheduleCleanup: vi.fn(() => () => undefined),
+  dispose: vi.fn(),
+});
+
+describe("ChunkStreamingManager", () => {
+  it("evicts least recently used chunks when capacity is exceeded", async () => {
+    const evicted: string[] = [];
+    const loadChunkData = vi.fn(async (chunkX: number, chunkY: number) => createPayload(chunkX, chunkY));
+    const manager = new ChunkStreamingManager({
+      worldSeed: 7,
+      chunkSize: 2,
+      maxLoadedChunks: 2,
+      telemetry: telemetryStub(),
+      onChunkEvicted: (chunkKey) => evicted.push(chunkKey),
+      loadChunkData,
+    });
+
+    await manager.ensureChunkLoaded(0, 0);
+    await manager.ensureChunkLoaded(1, 0);
+    expect(manager.chunkCache.size).toBe(2);
+
+    await manager.ensureChunkLoaded(2, 0);
+
+    expect(manager.chunkCache.size).toBe(2);
+    expect(evicted).toContain("0,0");
+    expect(loadChunkData).toHaveBeenCalledTimes(3);
+
+    manager.dispose();
+  });
+
+  it("does not refetch chunks already cached", async () => {
+    const loadChunkData = vi.fn(async (chunkX: number, chunkY: number) => createPayload(chunkX, chunkY));
+    const manager = new ChunkStreamingManager({
+      worldSeed: 11,
+      chunkSize: 2,
+      maxLoadedChunks: 3,
+      telemetry: telemetryStub(),
+      loadChunkData,
+    });
+
+    const first = await manager.ensureChunkLoaded(0, 0);
+    expect(first.isNew).toBe(true);
+
+    const second = await manager.ensureChunkLoaded(0, 0);
+    expect(second.isNew).toBe(false);
+    expect(loadChunkData).toHaveBeenCalledTimes(1);
+
+    manager.dispose();
+  });
+});
+

--- a/src/components/game/chunks/useChunkStreaming.ts
+++ b/src/components/game/chunks/useChunkStreaming.ts
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, useMemo } from "react";
+import {
+  ChunkStreamingManager,
+  type ChunkCacheEntry,
+  type ChunkPayload,
+} from "@engine/chunks";
+import { createChunkTelemetry, type ChunkTelemetry } from "./chunkTelemetry";
+
+export interface ChunkStreamingOptions {
+  worldSeed: number;
+  chunkSize: number;
+  maxLoadedChunks: number;
+  telemetry?: ChunkTelemetry;
+  onChunkEvicted?: (chunkKey: string, entry: ChunkCacheEntry) => void;
+  loadChunkData?: (chunkX: number, chunkY: number) => Promise<ChunkPayload>;
+}
+
+async function fetchChunkPayload(
+  chunkX: number,
+  chunkY: number,
+  chunkSize: number,
+  worldSeed: number,
+): Promise<ChunkPayload> {
+  const response = await fetch(
+    `/api/map/chunk?chunkX=${chunkX}&chunkY=${chunkY}&chunkSize=${chunkSize}&seed=${worldSeed}`,
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to load chunk (${chunkX}, ${chunkY}): ${response.statusText}`);
+  }
+
+  return (await response.json()) as ChunkPayload;
+}
+
+export function useChunkStreaming(options: ChunkStreamingOptions) {
+  const { worldSeed, chunkSize, maxLoadedChunks, telemetry, onChunkEvicted, loadChunkData } = options;
+
+  const manager = useMemo(() => {
+    const chunkTelemetry = telemetry ?? createChunkTelemetry();
+    const loader = loadChunkData ?? ((chunkX: number, chunkY: number) =>
+      fetchChunkPayload(chunkX, chunkY, chunkSize, worldSeed));
+
+    return new ChunkStreamingManager({
+      chunkSize,
+      maxLoadedChunks,
+      telemetry: chunkTelemetry,
+      onChunkEvicted,
+      loadChunkData: loader,
+    });
+  }, [chunkSize, loadChunkData, maxLoadedChunks, onChunkEvicted, telemetry, worldSeed]);
+
+  useEffect(() => () => manager.dispose(), [manager]);
+
+  return useMemo(
+    () => ({
+      ensureChunkLoaded: manager.ensureChunkLoaded.bind(manager),
+      releaseChunk: manager.releaseChunk.bind(manager),
+      chunkCache: manager.chunkCache,
+    }),
+    [manager],
+  );
+}
+
+export { ChunkStreamingManager } from "@engine/chunks";
+export type { ChunkTelemetry, ChunkCacheEntry } from "@engine/chunks";
+export type { EnsureChunkResult, ReleaseResult } from "@engine/chunks";


### PR DESCRIPTION
## Summary
- move chunk payload types, telemetry contracts, and the streaming manager into `packages/engine` and re-export them for shared use
- update the React chunk streaming hook and telemetry helper to wrap the engine manager, provide the default fetch loader, and remove the duplicated front-end types
- point the grid, renderer, and tests at the engine exports so chunk bookkeeping is handled by the shared manager

## Testing
- npm run lint
- npm run test
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9c782abe48325bfb627042355dba5