### PR TITLE
Refactor chunk streaming into hook and add tests

### DIFF
--- a/src/components/game/ChunkedIsometricGrid.tsx
+++ b/src/components/game/ChunkedIsometricGrid.tsx
@@ -1,59 +1,9 @@
 "use client";
 
-import { useEffect, useRef, useState, useCallback } from "react";
-import * as PIXI from "pixi.js";
+import { useCallback, useEffect, useRef } from "react";
 import { useGameContext } from "./GameContext";
-import logger from "@/lib/logger";
-import { worldToGrid } from "@/lib/isometric";
-import { createTileSprite, type GridTile } from "./grid/TileRenderer";
 import { TileOverlay } from "./grid/TileOverlay";
-import type { RegionFeatures } from "@engine";
-
-interface ChunkFieldMaps {
-  height: number[][];
-  temperature: number[][];
-  moisture: number[][];
-  climate: string[][];
-  isRiver: boolean[][];
-  isWater: boolean[][];
-}
-
-interface ChunkMetadata {
-  dominantClimate: string | null;
-  dominantBiome: string | null;
-  riverCount: number;
-  coastlineTiles: number;
-  elevation: { min: number; max: number; mean: number };
-}
-
-interface ChunkApiResponse {
-  chunkX: number;
-  chunkY: number;
-  chunkSize: number;
-  seed: number;
-  tiles: string[][];
-  biomes?: string[][];
-  fields?: ChunkFieldMaps;
-  features?: RegionFeatures;
-  metadata?: ChunkMetadata;
-}
-
-interface ChunkData {
-  chunkX: number;
-  chunkY: number;
-  chunkSize: number;
-  tiles: string[][];
-  biomes?: string[][];
-  features?: RegionFeatures;
-  metadata?: ChunkMetadata;
-}
-
-interface LoadedChunk {
-  data: ChunkData;
-  container: PIXI.Container;
-  tiles: Map<string, GridTile>;
-  lastAccessed: number;
-}
+import { useChunkStreaming } from "./grid/useChunkStreaming";
 
 interface ChunkedIsometricGridProps {
   worldSeed?: number;
@@ -70,21 +20,12 @@ export default function ChunkedIsometricGrid({
   chunkSize = 32,
   tileWidth = 64,
   tileHeight = 32,
-  maxLoadedChunks = 6, // Reduced from 9 to 6 to prevent memory issues
+  maxLoadedChunks = 6,
   onTileHover,
   onTileClick,
 }: ChunkedIsometricGridProps) {
   const { viewport, app } = useGameContext();
-  const worldContainerRef = useRef<PIXI.Container | null>(null);
-  const loadedChunksRef = useRef<Map<string, LoadedChunk>>(new Map());
   const overlayManagerRef = useRef<TileOverlay | null>(null);
-  const [isInitialized, setIsInitialized] = useState(false);
-  const loadingChunksRef = useRef<Set<string>>(new Set());
-  const lastViewportUpdateRef = useRef<{ x: number; y: number; scale: number }>({ x: 0, y: 0, scale: 1 });
-  const memoryCheckIntervalRef = useRef<NodeJS.Timeout | null>(null);
-  const lastMemoryCleanupRef = useRef<number>(0);
-  const memoryStatsRef = useRef({ totalSprites: 0, totalTextures: 0, totalContainers: 0 });
-  const renderStatsRef = useRef({ chunksLoaded: 0, chunksUnloaded: 0, spritesCreated: 0, spritesDestroyed: 0 });
   const onTileHoverRef = useRef(onTileHover);
   const onTileClickRef = useRef(onTileClick);
 
@@ -104,535 +45,83 @@ export default function ChunkedIsometricGrid({
     onTileClickRef.current?.(x, y, tileType);
   }, []);
 
-  // Convert world coordinates to chunk coordinates (via inverse isometric transform)
-  const worldToChunk = useCallback((worldX: number, worldY: number) => {
-    const gridCoords = worldToGrid(worldX, worldY, tileWidth, tileHeight);
-    const chunkX = Math.floor(gridCoords.gridX / chunkSize);
-    const chunkY = Math.floor(gridCoords.gridY / chunkSize);
-    return { chunkX, chunkY };
-  }, [chunkSize, tileWidth, tileHeight]);
+  const { worldContainer, loadedChunks, getTileType } = useChunkStreaming({
+    app,
+    viewport,
+    worldSeed,
+    chunkSize,
+    tileWidth,
+    tileHeight,
+    maxLoadedChunks,
+  });
 
-  // Load chunk data from API
-  const loadChunkData = useCallback(async (chunkX: number, chunkY: number): Promise<ChunkApiResponse | null> => {
-    try {
-      const response = await fetch(
-        `/api/map/chunk?chunkX=${chunkX}&chunkY=${chunkY}&chunkSize=${chunkSize}&seed=${worldSeed}`
-      );
-      if (!response.ok) {
-        throw new Error(`Failed to load chunk (${chunkX}, ${chunkY}): ${response.statusText}`);
-      }
-      const payload = (await response.json()) as ChunkApiResponse;
-      return payload;
-    } catch (error) {
-      logger.error(`Error loading chunk (${chunkX}, ${chunkY}):`, error);
-      return null;
-    }
-  }, [chunkSize, worldSeed]);
-
-  // Create visual representation of a chunk
-  const createChunkContainer = useCallback((chunkData: ChunkApiResponse): { container: PIXI.Container; tiles: Map<string, GridTile> } => {
-    const container = new PIXI.Container();
-    container.name = `chunk-${chunkData.chunkX}-${chunkData.chunkY}`;
-    container.sortableChildren = true;
-
-    const tiles = new Map<string, GridTile>();
-
-    if (!app?.renderer) {
-      logger.warn(`[GRAPHICS] Renderer unavailable while creating chunk ${chunkData.chunkX},${chunkData.chunkY}`);
-      return { container, tiles };
-    }
-
-    const heightMap = chunkData.fields?.height;
-    const temperatureMap = chunkData.fields?.temperature;
-    const moistureMap = chunkData.fields?.moisture;
-    const climateMap = chunkData.fields?.climate;
-
-    // Create tiles for this chunk
-    for (let localY = 0; localY < chunkData.chunkSize; localY++) {
-      for (let localX = 0; localX < chunkData.chunkSize; localX++) {
-        const globalX = chunkData.chunkX * chunkData.chunkSize + localX;
-        const globalY = chunkData.chunkY * chunkData.chunkSize + localY;
-        const tileType = chunkData.tiles[localY]?.[localX] || 'grass';
-        const biome = chunkData.biomes?.[localY]?.[localX];
-        const heightValue = heightMap?.[localY]?.[localX];
-        const temperatureValue = temperatureMap?.[localY]?.[localX];
-        const moistureValue = moistureMap?.[localY]?.[localX];
-        const climateValue = climateMap?.[localY]?.[localX];
-
-        // Create tile sprite with global coordinates
-        const tile = createTileSprite(
-          globalX,
-          globalY,
-          container,
-          tileWidth,
-          tileHeight,
-          chunkData.tiles,
-          app.renderer,
-          { tileTypeOverride: tileType },
-        );
-        tile.tileType = tileType;
-        tile.biome = biome;
-        tile.height = heightValue;
-        tile.temperature = temperatureValue;
-        tile.moisture = moistureValue;
-        tile.climate = climateValue;
-
-        if (typeof heightValue === 'number' && !['water', 'deep_water', 'river', 'coast'].includes(tileType)) {
-          const shade = Math.max(0.65, Math.min(1, 0.72 + heightValue * 0.28));
-          const shadeChannel = Math.round(shade * 255);
-          const tintHex = (shadeChannel << 16) | (shadeChannel << 8) | shadeChannel;
-          tile.sprite.tint = tintHex;
-        }
-
-        if (tileType === 'river') {
-          tile.sprite.alpha = 0.95;
-        }
-
-        const key = `${globalX},${globalY}`;
-        tiles.set(key, tile);
-        container.addChild(tile.sprite);
-      }
-    }
-    
-    return { container, tiles };
-  }, [app, tileWidth, tileHeight]);
-
-  // Load and render a chunk
-  const loadChunk = useCallback(async (chunkX: number, chunkY: number) => {
-    const chunkKey = `${chunkX},${chunkY}`;
-    const loadedChunks = loadedChunksRef.current;
-
-    if (!app?.renderer) {
-      logger.warn(`[MEMORY] Skipping load for chunk ${chunkKey} - renderer unavailable`);
-      return;
-    }
-
-    // Skip if already loaded or loading
-    if (loadedChunks.has(chunkKey) || loadingChunksRef.current.has(chunkKey)) {
-      logger.debug(`[MEMORY] Skipping chunk ${chunkKey} - already loaded/loading`);
-      return;
-    }
-    
-    const startTime = performance.now();
-    const memoryBefore = memoryStatsRef.current;
-    logger.info(`[MEMORY] Starting to load chunk ${chunkKey}. Current stats: sprites=${memoryBefore.totalSprites}, containers=${memoryBefore.totalContainers}`);
-    
-    loadingChunksRef.current.add(chunkKey);
-    
-    try {
-      const chunkData = await loadChunkData(chunkX, chunkY);
-      if (!chunkData || !worldContainerRef.current) {
-        logger.error(`[MEMORY] Failed to load chunk data for (${chunkX}, ${chunkY})`);
-        return;
-      }
-      
-      const { container, tiles } = createChunkContainer(chunkData);
-      const { fields: _fields, ...persistable } = chunkData;
-
-      // Update memory stats
-      memoryStatsRef.current.totalContainers++;
-      memoryStatsRef.current.totalSprites += tiles.size;
-      renderStatsRef.current.chunksLoaded++;
-      renderStatsRef.current.spritesCreated += tiles.size;
-      logger.debug(`🔍 [MEMORY TRACKING] Chunk ${chunkKey} loaded - Total sprites: ${memoryStatsRef.current.totalSprites}, Containers: ${memoryStatsRef.current.totalContainers}`);
-      logger.debug(`🎮 [RENDER TRACKING] Chunks loaded: ${renderStatsRef.current.chunksLoaded}, Sprites created: ${renderStatsRef.current.spritesCreated}`);
-      
-      worldContainerRef.current.addChild(container);
-      logger.debug(`[GRAPHICS] Added chunk container ${chunkKey} to world container. World children: ${worldContainerRef.current.children.length}`);
-      
-      const loadedChunk: LoadedChunk = {
-        data: {
-          chunkX: persistable.chunkX,
-          chunkY: persistable.chunkY,
-          chunkSize: persistable.chunkSize,
-          tiles: persistable.tiles,
-          biomes: persistable.biomes,
-          features: persistable.features,
-          metadata: persistable.metadata,
-        },
-        container,
-        tiles,
-        lastAccessed: Date.now(),
-      };
-      
-      loadedChunks.set(chunkKey, loadedChunk);
-      
-      const loadTime = performance.now() - startTime;
-      const memoryAfter = memoryStatsRef.current;
-      logger.info(`[MEMORY] Loaded chunk ${chunkKey} in ${loadTime.toFixed(2)}ms. Tiles: ${tiles.size}. New stats: sprites=${memoryAfter.totalSprites}, containers=${memoryAfter.totalContainers}`);
-      
-      // Log detailed tile information
-      logger.debug(`[GRAPHICS] Chunk ${chunkKey} tiles breakdown:`, Array.from(tiles.entries()).map(([key, tile]) => ({
-        position: key,
-        spriteExists: !!tile.sprite,
-        spriteParent: tile.sprite?.parent?.constructor.name,
-        spriteDestroyed: tile.sprite?.destroyed
-      })));
-      
-    } catch (error) {
-      logger.error(`[MEMORY] Failed to load chunk (${chunkX}, ${chunkY}):`, error);
-    } finally {
-      loadingChunksRef.current.delete(chunkKey);
-    }
-  }, [app, loadChunkData, createChunkContainer]);
-
-  // Unload a chunk to free memory
-  const unloadChunk = useCallback((chunkKey: string) => {
-    const loadedChunks = loadedChunksRef.current;
-    const chunk = loadedChunks.get(chunkKey);
-    
-    if (!chunk) {
-      logger.warn(`[MEMORY] Attempted to unload non-existent chunk ${chunkKey}`);
-      return;
-    }
-    
-    const startTime = performance.now();
-    const memoryBefore = memoryStatsRef.current;
-    const tileCount = chunk.tiles.size;
-    
-    logger.info(`[MEMORY] Starting to unload chunk ${chunkKey}. Tiles to dispose: ${tileCount}. Current stats: sprites=${memoryBefore.totalSprites}, containers=${memoryBefore.totalContainers}`);
-    
-    if (worldContainerRef.current) {
-      // Log each tile disposal
-      let disposedCount = 0;
-      chunk.tiles.forEach((tile, tileKey) => {
-        try {
-          logger.debug(`[GRAPHICS] Disposing tile ${tileKey} in chunk ${chunkKey}. Sprite destroyed: ${tile.sprite?.destroyed}`);
-          tile.dispose();
-          disposedCount++;
-          renderStatsRef.current.spritesDestroyed++;
-        } catch (error) {
-          logger.error(`[MEMORY] Error disposing tile ${tileKey}:`, error);
-        }
-      });
-      
-      // Remove and destroy container
-      try {
-        if (chunk.container.parent) {
-          worldContainerRef.current.removeChild(chunk.container);
-          logger.debug(`[GRAPHICS] Removed chunk container ${chunkKey} from world container. Remaining children: ${worldContainerRef.current.children.length}`);
-        }
-        
-        const containerChildren = chunk.container.children.length;
-        chunk.container.destroy({ children: true, texture: true });
-        logger.debug(`[GRAPHICS] Destroyed chunk container ${chunkKey} with ${containerChildren} children`);
-        
-      } catch (error) {
-        logger.error(`[MEMORY] Error destroying container for chunk ${chunkKey}:`, error);
-      }
-      
-      // Update memory stats
-      memoryStatsRef.current.totalSprites -= tileCount;
-      memoryStatsRef.current.totalContainers--;
-      renderStatsRef.current.chunksUnloaded++;
-      
-      chunk.tiles.clear();
-      loadedChunks.delete(chunkKey);
-      
-      const unloadTime = performance.now() - startTime;
-      const memoryAfter = memoryStatsRef.current;
-      logger.info(`[MEMORY] Unloaded chunk ${chunkKey} in ${unloadTime.toFixed(2)}ms. Disposed ${disposedCount}/${tileCount} tiles. New stats: sprites=${memoryAfter.totalSprites}, containers=${memoryAfter.totalContainers}`);
-      logger.debug(`🧹 [MEMORY CLEANUP] Chunk ${chunkKey} unloaded - Disposed ${disposedCount} sprites, Remaining: ${memoryAfter.totalSprites}`);
-      
-      // Log render stats summary
-      const renderStats = renderStatsRef.current;
-      logger.debug(`[RENDER_STATS] Total - Loaded: ${renderStats.chunksLoaded}, Unloaded: ${renderStats.chunksUnloaded}, Sprites Created: ${renderStats.spritesCreated}, Sprites Destroyed: ${renderStats.spritesDestroyed}`);
-      logger.debug(`🗑️ [RENDER CLEANUP] Chunks unloaded: ${renderStats.chunksUnloaded}, Sprites destroyed: ${renderStats.spritesDestroyed}`);
-    }
-  }, []);
-
-
-
-  // Get chunks that should be visible based on viewport (compute in grid space)
-  const getVisibleChunks = useCallback(() => {
-    if (!viewport) return [];
-    
-    const bounds = viewport.getVisibleBounds();
-
-    // Project viewport world-space corners back to grid indices
-    const corners = [
-      { x: bounds.x, y: bounds.y },
-      { x: bounds.x + bounds.width, y: bounds.y },
-      { x: bounds.x, y: bounds.y + bounds.height },
-      { x: bounds.x + bounds.width, y: bounds.y + bounds.height },
-    ];
-    const gridCorners = corners.map((c) => worldToGrid(c.x, c.y, tileWidth, tileHeight));
-
-    const minGridX = Math.min(...gridCorners.map((g) => g.gridX));
-    const maxGridX = Math.max(...gridCorners.map((g) => g.gridX));
-    const minGridY = Math.min(...gridCorners.map((g) => g.gridY));
-    const maxGridY = Math.max(...gridCorners.map((g) => g.gridY));
-
-    // Add a one-chunk padding in all directions
-    const minChunkX = Math.floor(minGridX / chunkSize) - 1;
-    const maxChunkX = Math.floor(maxGridX / chunkSize) + 1;
-    const minChunkY = Math.floor(minGridY / chunkSize) - 1;
-    const maxChunkY = Math.floor(maxGridY / chunkSize) + 1;
-    
-    const visibleChunks: { chunkX: number; chunkY: number }[] = [];
-    for (let chunkX = minChunkX; chunkX <= maxChunkX; chunkX++) {
-      for (let chunkY = minChunkY; chunkY <= maxChunkY; chunkY++) {
-        visibleChunks.push({ chunkX, chunkY });
-      }
-    }
-    
-    return visibleChunks;
-  }, [viewport, chunkSize, tileWidth, tileHeight]);
-
-  // Manage chunk loading/unloading based on viewport
-  const updateChunks = useCallback(async () => {
-    if (!viewport || !worldContainerRef.current) return;
-    
-    const visibleChunks = getVisibleChunks();
-    const loadedChunks = loadedChunksRef.current;
-    const currentTime = Date.now();
-    
-    // Load visible chunks
-    const loadPromises = visibleChunks.map(({ chunkX, chunkY }) => {
-      const chunkKey = `${chunkX},${chunkY}`;
-      if (loadedChunks.has(chunkKey)) {
-        // Update access time
-        loadedChunks.get(chunkKey)!.lastAccessed = currentTime;
-      } else {
-        // Load new chunk
-        return loadChunk(chunkX, chunkY);
-      }
-    });
-    
-    await Promise.all(loadPromises.filter(Boolean));
-    
-    // Unload chunks that are too far away or exceed max limit
-    const visibleChunkKeys = new Set(visibleChunks.map(({ chunkX, chunkY }) => `${chunkX},${chunkY}`));
-    const chunksToUnload: string[] = [];
-    
-    loadedChunks.forEach((chunk, chunkKey) => {
-      if (!visibleChunkKeys.has(chunkKey)) {
-        chunksToUnload.push(chunkKey);
-      }
-    });
-    
-    // If we have too many chunks, unload the least recently accessed ones
-    if (loadedChunks.size > maxLoadedChunks) {
-      const sortedChunks = Array.from(loadedChunks.entries())
-        .sort(([, a], [, b]) => a.lastAccessed - b.lastAccessed);
-      
-      const excessCount = loadedChunks.size - maxLoadedChunks;
-      for (let i = 0; i < excessCount; i++) {
-        chunksToUnload.push(sortedChunks[i][0]);
-      }
-    }
-    
-    // Unload chunks
-    chunksToUnload.forEach(chunkKey => unloadChunk(chunkKey));
-    
-  }, [viewport, getVisibleChunks, loadChunk, unloadChunk, maxLoadedChunks]);
-
-  // Initialize world container
   useEffect(() => {
-    if (!viewport || worldContainerRef.current) return;
+    if (!worldContainer) return;
 
-    const worldContainer = new PIXI.Container();
-    worldContainer.name = 'chunked-world';
-    worldContainer.sortableChildren = true;
-    worldContainer.zIndex = 100;
-    (worldContainer as unknown as { eventMode: string }).eventMode = 'static';
-    
-    viewport.addChild(worldContainer);
-    worldContainerRef.current = worldContainer;
-    
-    // Initialize overlay manager
-    overlayManagerRef.current = new TileOverlay(worldContainer, {
+    const overlay = new TileOverlay(worldContainer, {
       tileWidth,
       tileHeight,
-      getTileType: (x, y) => {
-        // Find the chunk containing this tile
-        const chunkX = Math.floor(x / chunkSize);
-        const chunkY = Math.floor(y / chunkSize);
-        const chunkKey = `${chunkX},${chunkY}`;
-        const chunk = loadedChunksRef.current.get(chunkKey);
-        
-        if (chunk) {
-          const localX = x - chunkX * chunkSize;
-          const localY = y - chunkY * chunkSize;
-          return chunk.data.tiles[localY]?.[localX] || 'grass';
-        }
-        return 'grass';
-      },
+      getTileType,
       onTileHover: handleTileHover,
       onTileClick: handleTileClick,
     });
-    
-    // Set initial viewport position and zoom
-    viewport.setZoom(1.5);
-    viewport.moveCenter(0, 0);
-    
-    setIsInitialized(true);
-    
-    // Start memory monitoring with inline cleanup
-    memoryCheckIntervalRef.current = setInterval(() => {
-      const now = Date.now();
-      if (now - lastMemoryCleanupRef.current < 30000) return;
-      
-      const loadedChunks = loadedChunksRef.current;
-      const CHUNK_TIMEOUT = 60000; // 1 minute
-      
-      const chunksToRemove: string[] = [];
-      loadedChunks.forEach((chunk, chunkKey) => {
-        if (now - chunk.lastAccessed > CHUNK_TIMEOUT) {
-          chunksToRemove.push(chunkKey);
-        }
-      });
-      
-      chunksToRemove.forEach(chunkKey => {
-        const chunk = loadedChunks.get(chunkKey);
-        if (chunk && worldContainerRef.current) {
-          chunk.tiles.forEach((tile) => {
-            tile.dispose();
-          });
-          worldContainerRef.current.removeChild(chunk.container);
-          chunk.container.destroy({ children: true, texture: true });
-          chunk.tiles.clear();
-          loadedChunks.delete(chunkKey);
-        }
-      });
-      
-      lastMemoryCleanupRef.current = now;
-      if (chunksToRemove.length > 0) {
-        logger.debug(`Memory cleanup completed. Removed ${chunksToRemove.length} old chunks.`);
-      }
-    }, 30000); // Every 30 seconds
-    
+
+    overlayManagerRef.current = overlay;
+
     return () => {
-      // Clear memory monitoring interval
-      if (memoryCheckIntervalRef.current) {
-        clearInterval(memoryCheckIntervalRef.current);
-        memoryCheckIntervalRef.current = null;
-      }
       overlayManagerRef.current?.destroy();
       overlayManagerRef.current = null;
-      
-      if (worldContainer.parent) {
-        worldContainer.parent.removeChild(worldContainer);
-      }
-      worldContainer.destroy({ children: true });
-      worldContainerRef.current = null;
-      
-      // Properly dispose of all loaded chunks
-      loadedChunksRef.current.forEach((chunk, chunkKey) => {
-        chunk.tiles.forEach((tile) => {
-          tile.dispose(); // Use the proper dispose method from GridTile
-        });
-        chunk.container.destroy({ children: true, texture: true });
-        chunk.tiles.clear();
-      });
-      loadedChunksRef.current.clear();
-      loadingChunksRef.current.clear();
-
-      // NOTE: Do not set state in cleanup to avoid triggering re-renders during effect teardown
-      // setIsInitialized(false);
     };
-  }, [viewport, tileWidth, tileHeight, chunkSize, handleTileHover, handleTileClick]);
+  }, [worldContainer, tileWidth, tileHeight, getTileType, handleTileHover, handleTileClick]);
 
-  // Handle viewport changes with throttling
   useEffect(() => {
-    if (!viewport || !isInitialized) return;
-    
-    let updateTimeout: NodeJS.Timeout;
-    let isUpdating = false;
-    
-    const handleViewportChange = () => {
-      if (isUpdating) return; // Prevent concurrent updates
-      
-      const center = viewport.center;
-      const scale = viewport.scale?.x || 1;
-      const lastUpdate = lastViewportUpdateRef.current;
-      
-      // Only update if viewport moved significantly or scale changed (increased thresholds to reduce flickering)
-      const moved = Math.abs(center.x - lastUpdate.x) > tileWidth * 3 || 
-                   Math.abs(center.y - lastUpdate.y) > tileHeight * 3;
-      const scaleChanged = Math.abs(scale - lastUpdate.scale) > 0.3; // Less sensitive
-      
-      // Increased minimum update interval to reduce flickering
-      if (moved || scaleChanged) {
-        clearTimeout(updateTimeout);
-        updateTimeout = setTimeout(async () => {
-          isUpdating = true;
-          try {
-            await updateChunks();
-            lastViewportUpdateRef.current = { x: center.x, y: center.y, scale };
-          } finally {
-            isUpdating = false;
-          }
-        }, 300); // Increased throttle time further
-      }
-    };
-    
-    viewport.on('moved', handleViewportChange);
-    viewport.on('zoomed', handleViewportChange);
-    
-    // Initial chunk loading
-    updateChunks();
-    
-    return () => {
-      clearTimeout(updateTimeout);
-      viewport.off('moved', handleViewportChange);
-      viewport.off('zoomed', handleViewportChange);
-    };
-    // Only depend on primitives; updateChunks is stable via useCallback and viewport is stable from context
-  }, [viewport, isInitialized, tileWidth, tileHeight]);
+    if (!viewport || !worldContainer || !app?.ticker) return;
 
-  // Performance optimization: Viewport culling and LOD
-  useEffect(() => {
-    if (!viewport || !worldContainerRef.current || !app?.ticker) return;
-    
     let lastScale = viewport.scale?.x || 1;
     let lastUpdateTime = 0;
     let t = 0;
-    
+
     const updateVisibilityAndLOD = (force = false) => {
       const now = Date.now();
-      if (!force && now - lastUpdateTime < 200) return; // Throttle to 5fps to reduce flickering
-      
+      if (!force && now - lastUpdateTime < 200) return;
+
       if (!viewport || !viewport.scale) return;
-      
+
       const scale = viewport.scale.x;
       const bounds = viewport.getVisibleBounds();
-      const padding = Math.max(tileWidth, tileHeight) * 4; // Increased padding for stability
-      
+      const padding = Math.max(tileWidth, tileHeight) * 4;
+
       const visibleLeft = bounds.x - padding;
       const visibleRight = bounds.x + bounds.width + padding;
       const visibleTop = bounds.y - padding;
       const visibleBottom = bounds.y + bounds.height + padding;
-      
-      const scaleChanged = Math.abs(scale - lastScale) > 0.3; // Less sensitive to prevent flickering
-      
-      // Update visibility for all loaded chunks (less frequently)
-      loadedChunksRef.current.forEach((chunk) => {
+
+      const scaleChanged = Math.abs(scale - lastScale) > 0.3;
+
+      loadedChunks.forEach((chunk) => {
         chunk.tiles.forEach((tile) => {
-          const isInViewport = tile.worldX >= visibleLeft && 
-                             tile.worldX <= visibleRight && 
-                             tile.worldY >= visibleTop && 
+          const isInViewport = tile.worldX >= visibleLeft &&
+                             tile.worldX <= visibleRight &&
+                             tile.worldY >= visibleTop &&
                              tile.worldY <= visibleBottom;
-          
-          const shouldShowTile = scale > 0.1 && isInViewport; // Lower threshold for better visibility
-          
-          // Only update visibility if there's a significant change to prevent flickering
+
+          const shouldShowTile = scale > 0.1 && isInViewport;
+
           if (tile.sprite.visible !== shouldShowTile) {
             tile.sprite.visible = shouldShowTile;
           }
         });
       });
-      
+
       if (scaleChanged) {
         lastScale = scale;
       }
       lastUpdateTime = now;
     };
-    
+
     const tick = () => {
       t += app.ticker.deltaMS;
-      
-      // Update selection overlay animation only
+
       const sel = overlayManagerRef.current?.selectOverlay;
       if (sel && sel.visible) {
         const base = 0.35;
@@ -640,24 +129,22 @@ export default function ChunkedIsometricGrid({
         const w = 0.002;
         sel.alpha = base + amp * (0.5 + 0.5 * Math.sin(t * w));
       }
-      
-      // Only update visibility occasionally, not every frame
+
       if (t % 100 < app.ticker.deltaMS) {
         updateVisibilityAndLOD();
       }
     };
-    
-    // Initial visibility update
+
     updateVisibilityAndLOD(true);
-    
+
     app.ticker.add(tick);
-    
+
     return () => {
       app.ticker.remove(tick);
     };
-  }, [viewport, app, tileWidth, tileHeight]);
+  }, [viewport, app, tileWidth, tileHeight, worldContainer, loadedChunks]);
 
-  return null; // This component doesn't render React elements
+  return null;
 }
 
 export type { ChunkedIsometricGridProps };

--- a/src/components/game/grid/__tests__/chunkRenderer.test.ts
+++ b/src/components/game/grid/__tests__/chunkRenderer.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import * as PIXI from "pixi.js";
+import { createChunkContainer, disposeChunkTiles, type LoadedChunk } from "../chunkRenderer";
+import type { GridTile } from "../TileRenderer";
+
+const { createTileSpriteMock } = vi.hoisted(() => {
+  return {
+    createTileSpriteMock: vi.fn((gridX: number, gridY: number) => {
+      const sprite = new PIXI.Sprite();
+      const dispose = vi.fn(() => {
+        sprite.destroy();
+      });
+
+      return {
+        x: gridX,
+        y: gridY,
+        worldX: gridX,
+        worldY: gridY,
+        tileType: "placeholder",
+        sprite,
+        dispose,
+      } as unknown as GridTile;
+    }),
+  };
+});
+
+vi.mock("../TileRenderer", () => ({
+  createTileSprite: createTileSpriteMock,
+}));
+
+describe("chunkRenderer", () => {
+  beforeEach(() => {
+    createTileSpriteMock.mockClear();
+  });
+
+  it("creates PIXI containers and tiles for each chunk cell", () => {
+    const chunkData = {
+      chunkX: 0,
+      chunkY: 1,
+      chunkSize: 2,
+      seed: 42,
+      tiles: [
+        ["grass", "water"],
+        ["mountain", "forest"],
+      ],
+      fields: {
+        height: [
+          [0.1, 0],
+          [0.2, 0.3],
+        ],
+        temperature: [
+          [0.5, 0.5],
+          [0.5, 0.5],
+        ],
+        moisture: [
+          [0.2, 0.2],
+          [0.2, 0.2],
+        ],
+        climate: [
+          ["temperate", "temperate"],
+          ["temperate", "temperate"],
+        ],
+        isRiver: [
+          [false, false],
+          [false, false],
+        ],
+        isWater: [
+          [false, true],
+          [false, false],
+        ],
+      },
+    };
+
+    const { container, tiles } = createChunkContainer(chunkData, {
+      renderer: {} as PIXI.Renderer,
+      tileWidth: 64,
+      tileHeight: 32,
+    });
+
+    expect(container.name).toBe("chunk-0-1");
+    expect(tiles.size).toBe(4);
+    expect(createTileSpriteMock).toHaveBeenCalledTimes(4);
+
+    expect(tiles.get("0,2")?.tileType).toBe("grass");
+    expect(tiles.get("1,2")?.tileType).toBe("water");
+    expect(tiles.get("0,3")?.tileType).toBe("mountain");
+    expect(tiles.get("1,3")?.tileType).toBe("forest");
+  });
+
+  it("disposes all tile sprites when releasing a chunk", () => {
+    const tileA: GridTile = {
+      x: 0,
+      y: 0,
+      worldX: 0,
+      worldY: 0,
+      tileType: "grass",
+      sprite: new PIXI.Sprite(),
+      dispose: vi.fn(),
+    };
+    const tileB: GridTile = {
+      x: 1,
+      y: 0,
+      worldX: 1,
+      worldY: 0,
+      tileType: "water",
+      sprite: new PIXI.Sprite(),
+      dispose: vi.fn(),
+    };
+
+    const loadedChunk: LoadedChunk = {
+      data: {
+        chunkX: 0,
+        chunkY: 0,
+        chunkSize: 1,
+        tiles: [["grass"]],
+      },
+      container: new PIXI.Container(),
+      tiles: new Map<string, GridTile>([
+        ["0,0", tileA],
+        ["1,0", tileB],
+      ]),
+      lastAccessed: Date.now(),
+    };
+
+    const disposed = disposeChunkTiles(loadedChunk);
+
+    expect(disposed).toBe(2);
+    expect(tileA.dispose).toHaveBeenCalledTimes(1);
+    expect(tileB.dispose).toHaveBeenCalledTimes(1);
+    expect(loadedChunk.tiles.size).toBe(0);
+  });
+});

--- a/src/components/game/grid/__tests__/useChunkStreaming.test.tsx
+++ b/src/components/game/grid/__tests__/useChunkStreaming.test.tsx
@@ -1,0 +1,286 @@
+import React, { useEffect } from "react";
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { JSDOM } from "jsdom";
+import { act } from "react-dom/test-utils";
+import { createRoot, type Root } from "react-dom/client";
+import * as PIXI from "pixi.js";
+import { useChunkStreaming, type UseChunkStreamingOptions, type UseChunkStreamingResult } from "../useChunkStreaming";
+import type { GridTile } from "../TileRenderer";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>");
+globalThis.window = dom.window as unknown as Window & typeof globalThis;
+globalThis.document = dom.window.document;
+globalThis.navigator = dom.window.navigator;
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+const { createTileSpriteMock } = vi.hoisted(() => ({
+  createTileSpriteMock: vi.fn((gridX: number, gridY: number) => {
+    const sprite = new PIXI.Sprite();
+    const dispose = vi.fn(() => {
+      sprite.destroy();
+    });
+
+    return {
+      x: gridX,
+      y: gridY,
+      worldX: gridX,
+      worldY: gridY,
+      tileType: "placeholder",
+      sprite,
+      dispose,
+    } as unknown as GridTile;
+  }),
+}));
+
+vi.mock("../TileRenderer", () => ({
+  createTileSprite: createTileSpriteMock,
+}));
+
+vi.mock("@/lib/isometric", () => ({
+  worldToGrid: (x: number, y: number) => ({ gridX: x, gridY: y }),
+}));
+
+class ViewportMock {
+  center = { x: 0, y: 0 };
+  scale = { x: 1, y: 1 };
+  private handlers = new Map<string, Set<() => void>>();
+  children: PIXI.Container[] = [];
+
+  addChild(child: PIXI.Container) {
+    this.children.push(child);
+    (child as unknown as { parent: ViewportMock | null }).parent = this;
+  }
+
+  removeChild(child: PIXI.Container) {
+    this.children = this.children.filter((c) => c !== child);
+    (child as unknown as { parent: ViewportMock | null }).parent = null;
+  }
+
+  setZoom(value: number) {
+    this.scale = { x: value, y: value };
+  }
+
+  moveCenter(x: number, y: number) {
+    this.center = { x, y };
+  }
+
+  getVisibleBounds() {
+    return { x: this.center.x, y: this.center.y, width: 1, height: 1 };
+  }
+
+  on(event: string, handler: () => void) {
+    if (!this.handlers.has(event)) {
+      this.handlers.set(event, new Set());
+    }
+    this.handlers.get(event)?.add(handler);
+  }
+
+  off(event: string, handler: () => void) {
+    this.handlers.get(event)?.delete(handler);
+  }
+
+  emit(event: string) {
+    this.handlers.get(event)?.forEach((handler) => handler());
+  }
+}
+
+interface HookHarnessProps {
+  options: UseChunkStreamingOptions;
+  onUpdate: (value: UseChunkStreamingResult) => void;
+}
+
+function HookHarness({ options, onUpdate }: HookHarnessProps) {
+  const result = useChunkStreaming(options);
+
+  useEffect(() => {
+    onUpdate(result);
+  }, [result, onUpdate]);
+
+  return null;
+}
+
+const originalFetch = global.fetch;
+let fetchMock: ReturnType<typeof vi.fn>;
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+let lastResult: UseChunkStreamingResult | null = null;
+
+function createAppStub() {
+  const listeners = new Set<() => void>();
+  return {
+    renderer: {} as PIXI.Renderer,
+    ticker: {
+      deltaMS: 16,
+      add: (fn: () => void) => {
+        listeners.add(fn);
+      },
+      remove: (fn: () => void) => {
+        listeners.delete(fn);
+      },
+    },
+    __listeners: listeners,
+  } as const;
+}
+
+async function renderHarness(options: UseChunkStreamingOptions) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+
+  await act(async () => {
+    root!.render(
+      <HookHarness
+        options={options}
+        onUpdate={(value) => {
+          lastResult = value;
+        }}
+      />,
+    );
+  });
+}
+
+async function waitForExpect(assertion: () => void, timeout = 1000) {
+  const start = Date.now();
+  while (true) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      if (Date.now() - start >= timeout) {
+        throw error;
+      }
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      });
+    }
+  }
+}
+
+function setupFetchMock() {
+  fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const parsed = new URL(url, "http://localhost");
+    const chunkX = Number(parsed.searchParams.get("chunkX"));
+    const chunkY = Number(parsed.searchParams.get("chunkY"));
+    const chunkSize = Number(parsed.searchParams.get("chunkSize")) || 32;
+    const tiles = Array.from({ length: chunkSize }, () => Array(chunkSize).fill("grass"));
+
+    return {
+      ok: true,
+      json: async () => ({
+        chunkX,
+        chunkY,
+        chunkSize,
+        seed: 1,
+        tiles,
+      }),
+    };
+  });
+  global.fetch = fetchMock as unknown as typeof fetch;
+}
+
+function makeOptions(overrides: Partial<UseChunkStreamingOptions> = {}): UseChunkStreamingOptions {
+  const viewport = new ViewportMock();
+  return {
+    app: createAppStub() as unknown as PIXI.Application,
+    viewport: viewport as unknown as import("pixi-viewport").Viewport,
+    worldSeed: 1,
+    chunkSize: 32,
+    tileWidth: 64,
+    tileHeight: 32,
+    maxLoadedChunks: 3,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  setupFetchMock();
+  createTileSpriteMock.mockClear();
+  lastResult = null;
+});
+
+afterEach(async () => {
+  if (root) {
+    await act(async () => {
+      root?.unmount();
+    });
+  }
+  root = null;
+  if (container) {
+    container.remove();
+    container = null;
+  }
+  global.fetch = originalFetch;
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe("useChunkStreaming", () => {
+  it("limits the number of cached chunks", async () => {
+    const options = makeOptions({ maxLoadedChunks: 2 });
+    await renderHarness(options);
+
+    await waitForExpect(() => {
+      expect(lastResult?.loadedChunks.size).toBe(2);
+    });
+  });
+
+  it("cleans up stale chunks via the memory sweep timer", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(0));
+
+    const options = makeOptions({ maxLoadedChunks: 2 });
+    await renderHarness(options);
+
+    await waitForExpect(() => {
+      expect(lastResult?.loadedChunks.size).toBe(2);
+    });
+
+    const firstChunk = lastResult?.loadedChunks.values().next().value;
+    const sampleTile = firstChunk ? firstChunk.tiles.values().next().value : null;
+
+    vi.setSystemTime(new Date(70_000));
+
+    await act(async () => {
+      vi.advanceTimersByTime(30_000);
+    });
+
+    await waitForExpect(() => {
+      expect(lastResult?.loadedChunks.size).toBe(0);
+    });
+
+    if (sampleTile) {
+      expect(sampleTile.dispose).toHaveBeenCalled();
+    }
+  });
+
+  it("throttles viewport-driven chunk refreshes", async () => {
+    vi.useFakeTimers();
+    const viewport = new ViewportMock();
+    const options = makeOptions({ viewport: viewport as unknown as import("pixi-viewport").Viewport });
+    await renderHarness(options);
+
+    await waitForExpect(() => {
+      expect(lastResult?.loadedChunks.size).toBeGreaterThan(0);
+    });
+
+    const initialCalls = fetchMock.mock.calls.length;
+
+    viewport.moveCenter(512, 0);
+    await act(async () => {
+      viewport.emit("moved");
+      vi.advanceTimersByTime(299);
+    });
+
+    expect(fetchMock.mock.calls.length).toBe(initialCalls);
+
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+    });
+
+    await waitForExpect(() => {
+      expect(fetchMock.mock.calls.length).toBeGreaterThan(initialCalls);
+    });
+  });
+});

--- a/src/components/game/grid/chunkRenderer.ts
+++ b/src/components/game/grid/chunkRenderer.ts
@@ -1,0 +1,135 @@
+import * as PIXI from "pixi.js";
+import type { Renderer } from "pixi.js";
+import logger from "@/lib/logger";
+import { createTileSprite, type GridTile } from "./TileRenderer";
+import type { RegionFeatures } from "@engine";
+
+export interface ChunkFieldMaps {
+  height: number[][];
+  temperature: number[][];
+  moisture: number[][];
+  climate: string[][];
+  isRiver: boolean[][];
+  isWater: boolean[][];
+}
+
+export interface ChunkMetadata {
+  dominantClimate: string | null;
+  dominantBiome: string | null;
+  riverCount: number;
+  coastlineTiles: number;
+  elevation: { min: number; max: number; mean: number };
+}
+
+export interface ChunkApiResponse {
+  chunkX: number;
+  chunkY: number;
+  chunkSize: number;
+  seed: number;
+  tiles: string[][];
+  biomes?: string[][];
+  fields?: ChunkFieldMaps;
+  features?: RegionFeatures;
+  metadata?: ChunkMetadata;
+}
+
+export interface ChunkData {
+  chunkX: number;
+  chunkY: number;
+  chunkSize: number;
+  tiles: string[][];
+  biomes?: string[][];
+  features?: RegionFeatures;
+  metadata?: ChunkMetadata;
+}
+
+export interface LoadedChunk {
+  data: ChunkData;
+  container: PIXI.Container;
+  tiles: Map<string, GridTile>;
+  lastAccessed: number;
+}
+
+interface CreateChunkContainerOptions {
+  renderer: Renderer;
+  tileWidth: number;
+  tileHeight: number;
+}
+
+export function createChunkContainer(
+  chunkData: ChunkApiResponse,
+  { renderer, tileWidth, tileHeight }: CreateChunkContainerOptions,
+): { container: PIXI.Container; tiles: Map<string, GridTile> } {
+  const container = new PIXI.Container();
+  container.name = `chunk-${chunkData.chunkX}-${chunkData.chunkY}`;
+  container.sortableChildren = true;
+
+  const tiles = new Map<string, GridTile>();
+
+  const heightMap = chunkData.fields?.height;
+  const temperatureMap = chunkData.fields?.temperature;
+  const moistureMap = chunkData.fields?.moisture;
+  const climateMap = chunkData.fields?.climate;
+
+  for (let localY = 0; localY < chunkData.chunkSize; localY++) {
+    for (let localX = 0; localX < chunkData.chunkSize; localX++) {
+      const globalX = chunkData.chunkX * chunkData.chunkSize + localX;
+      const globalY = chunkData.chunkY * chunkData.chunkSize + localY;
+      const tileType = chunkData.tiles[localY]?.[localX] ?? "grass";
+      const biome = chunkData.biomes?.[localY]?.[localX];
+      const heightValue = heightMap?.[localY]?.[localX];
+      const temperatureValue = temperatureMap?.[localY]?.[localX];
+      const moistureValue = moistureMap?.[localY]?.[localX];
+      const climateValue = climateMap?.[localY]?.[localX];
+
+      const tile = createTileSprite(
+        globalX,
+        globalY,
+        container,
+        tileWidth,
+        tileHeight,
+        chunkData.tiles,
+        renderer,
+        { tileTypeOverride: tileType },
+      );
+
+      tile.tileType = tileType;
+      tile.biome = biome;
+      tile.height = heightValue;
+      tile.temperature = temperatureValue;
+      tile.moisture = moistureValue;
+      tile.climate = climateValue;
+
+      if (typeof heightValue === "number" && !["water", "deep_water", "river", "coast"].includes(tileType)) {
+        const shade = Math.max(0.65, Math.min(1, 0.72 + heightValue * 0.28));
+        const shadeChannel = Math.round(shade * 255);
+        const tintHex = (shadeChannel << 16) | (shadeChannel << 8) | shadeChannel;
+        tile.sprite.tint = tintHex;
+      }
+
+      if (tileType === "river") {
+        tile.sprite.alpha = 0.95;
+      }
+
+      const key = `${globalX},${globalY}`;
+      tiles.set(key, tile);
+      container.addChild(tile.sprite);
+    }
+  }
+
+  return { container, tiles };
+}
+
+export function disposeChunkTiles(chunk: LoadedChunk): number {
+  let disposedCount = 0;
+  chunk.tiles.forEach((tile, tileKey) => {
+    try {
+      tile.dispose();
+      disposedCount++;
+    } catch (error) {
+      logger.error(`[MEMORY] Error disposing tile ${tileKey}:`, error);
+    }
+  });
+  chunk.tiles.clear();
+  return disposedCount;
+}

--- a/src/components/game/grid/useChunkStreaming.ts
+++ b/src/components/game/grid/useChunkStreaming.ts
@@ -1,0 +1,397 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import * as PIXI from "pixi.js";
+import type { Viewport } from "pixi-viewport";
+import logger from "@/lib/logger";
+import { worldToGrid } from "@/lib/isometric";
+import {
+  createChunkContainer,
+  disposeChunkTiles,
+  type ChunkApiResponse,
+  type LoadedChunk,
+} from "./chunkRenderer";
+
+interface MemoryStats {
+  totalSprites: number;
+  totalTextures: number;
+  totalContainers: number;
+}
+
+interface RenderStats {
+  chunksLoaded: number;
+  chunksUnloaded: number;
+  spritesCreated: number;
+  spritesDestroyed: number;
+}
+
+export interface UseChunkStreamingOptions {
+  app: PIXI.Application | null;
+  viewport: Viewport | null;
+  worldSeed: number;
+  chunkSize: number;
+  tileWidth: number;
+  tileHeight: number;
+  maxLoadedChunks: number;
+}
+
+export interface UseChunkStreamingResult {
+  worldContainer: PIXI.Container | null;
+  isInitialized: boolean;
+  loadedChunks: Map<string, LoadedChunk>;
+  memoryStats: MemoryStats;
+  renderStats: RenderStats;
+  getTileType: (x: number, y: number) => string;
+}
+
+export function useChunkStreaming({
+  app,
+  viewport,
+  worldSeed,
+  chunkSize,
+  tileWidth,
+  tileHeight,
+  maxLoadedChunks,
+}: UseChunkStreamingOptions): UseChunkStreamingResult {
+  const worldContainerRef = useRef<PIXI.Container | null>(null);
+  const loadedChunksRef = useRef<Map<string, LoadedChunk>>(new Map());
+  const loadingChunksRef = useRef<Set<string>>(new Set());
+  const lastViewportUpdateRef = useRef<{ x: number; y: number; scale: number }>({ x: 0, y: 0, scale: 1 });
+  const memoryCheckIntervalRef = useRef<NodeJS.Timeout | null>(null);
+  const lastMemoryCleanupRef = useRef<number>(0);
+  const memoryStatsRef = useRef<MemoryStats>({ totalSprites: 0, totalTextures: 0, totalContainers: 0 });
+  const renderStatsRef = useRef<RenderStats>({ chunksLoaded: 0, chunksUnloaded: 0, spritesCreated: 0, spritesDestroyed: 0 });
+  const [isInitialized, setIsInitialized] = useState(false);
+
+  const loadChunkData = useCallback(async (chunkX: number, chunkY: number): Promise<ChunkApiResponse | null> => {
+    try {
+      const response = await fetch(
+        `/api/map/chunk?chunkX=${chunkX}&chunkY=${chunkY}&chunkSize=${chunkSize}&seed=${worldSeed}`,
+      );
+      if (!response.ok) {
+        throw new Error(`Failed to load chunk (${chunkX}, ${chunkY}): ${response.statusText}`);
+      }
+      const payload = (await response.json()) as ChunkApiResponse;
+      return payload;
+    } catch (error) {
+      logger.error(`Error loading chunk (${chunkX}, ${chunkY}):`, error);
+      return null;
+    }
+  }, [chunkSize, worldSeed]);
+
+  const loadChunk = useCallback(async (chunkX: number, chunkY: number) => {
+    const chunkKey = `${chunkX},${chunkY}`;
+    const loadedChunks = loadedChunksRef.current;
+
+    if (!app?.renderer) {
+      logger.warn(`[MEMORY] Skipping load for chunk ${chunkKey} - renderer unavailable`);
+      return;
+    }
+
+    if (loadedChunks.has(chunkKey) || loadingChunksRef.current.has(chunkKey)) {
+      logger.debug(`[MEMORY] Skipping chunk ${chunkKey} - already loaded/loading`);
+      return;
+    }
+
+    const startTime = performance.now();
+    const memoryBefore = memoryStatsRef.current;
+    logger.info(`[MEMORY] Starting to load chunk ${chunkKey}. Current stats: sprites=${memoryBefore.totalSprites}, containers=${memoryBefore.totalContainers}`);
+
+    loadingChunksRef.current.add(chunkKey);
+
+    try {
+      const chunkData = await loadChunkData(chunkX, chunkY);
+      if (!chunkData || !worldContainerRef.current) {
+        logger.error(`[MEMORY] Failed to load chunk data for (${chunkX}, ${chunkY})`);
+        return;
+      }
+
+      const { container, tiles } = createChunkContainer(chunkData, {
+        renderer: app.renderer,
+        tileWidth,
+        tileHeight,
+      });
+      const { fields: _fields, ...persistable } = chunkData;
+      void _fields;
+
+      memoryStatsRef.current.totalContainers++;
+      memoryStatsRef.current.totalSprites += tiles.size;
+      renderStatsRef.current.chunksLoaded++;
+      renderStatsRef.current.spritesCreated += tiles.size;
+
+      worldContainerRef.current.addChild(container);
+
+      const loadedChunk: LoadedChunk = {
+        data: {
+          chunkX: persistable.chunkX,
+          chunkY: persistable.chunkY,
+          chunkSize: persistable.chunkSize,
+          tiles: persistable.tiles,
+          biomes: persistable.biomes,
+          features: persistable.features,
+          metadata: persistable.metadata,
+        },
+        container,
+        tiles,
+        lastAccessed: Date.now(),
+      };
+
+      loadedChunks.set(chunkKey, loadedChunk);
+
+      const loadTime = performance.now() - startTime;
+      const memoryAfter = memoryStatsRef.current;
+      logger.info(`[MEMORY] Loaded chunk ${chunkKey} in ${loadTime.toFixed(2)}ms. Tiles: ${tiles.size}. New stats: sprites=${memoryAfter.totalSprites}, containers=${memoryAfter.totalContainers}`);
+    } catch (error) {
+      logger.error(`[MEMORY] Failed to load chunk (${chunkX}, ${chunkY}):`, error);
+    } finally {
+      loadingChunksRef.current.delete(chunkKey);
+    }
+  }, [app, loadChunkData, tileHeight, tileWidth]);
+
+  const unloadChunk = useCallback((chunkKey: string) => {
+    const loadedChunks = loadedChunksRef.current;
+    const chunk = loadedChunks.get(chunkKey);
+
+    if (!chunk) {
+      logger.warn(`[MEMORY] Attempted to unload non-existent chunk ${chunkKey}`);
+      return;
+    }
+
+    const startTime = performance.now();
+    const memoryBefore = memoryStatsRef.current;
+    const tileCount = chunk.tiles.size;
+
+    logger.info(`[MEMORY] Starting to unload chunk ${chunkKey}. Tiles to dispose: ${tileCount}. Current stats: sprites=${memoryBefore.totalSprites}, containers=${memoryBefore.totalContainers}`);
+
+    if (worldContainerRef.current) {
+      let disposedCount = 0;
+      disposedCount += disposeChunkTiles(chunk);
+      renderStatsRef.current.spritesDestroyed += disposedCount;
+
+      try {
+        if (chunk.container.parent) {
+          worldContainerRef.current.removeChild(chunk.container);
+        }
+        const containerChildren = chunk.container.children.length;
+        chunk.container.destroy({ children: true, texture: true });
+        logger.debug(`[GRAPHICS] Destroyed chunk container ${chunkKey} with ${containerChildren} children`);
+      } catch (error) {
+        logger.error(`[MEMORY] Error destroying container for chunk ${chunkKey}:`, error);
+      }
+
+      memoryStatsRef.current.totalSprites -= tileCount;
+      memoryStatsRef.current.totalContainers--;
+      renderStatsRef.current.chunksUnloaded++;
+
+      loadedChunks.delete(chunkKey);
+
+      const unloadTime = performance.now() - startTime;
+      const memoryAfter = memoryStatsRef.current;
+      logger.info(`[MEMORY] Unloaded chunk ${chunkKey} in ${unloadTime.toFixed(2)}ms. Disposed ${disposedCount}/${tileCount} tiles. New stats: sprites=${memoryAfter.totalSprites}, containers=${memoryAfter.totalContainers}`);
+    }
+  }, []);
+
+  const getVisibleChunks = useCallback(() => {
+    if (!viewport) return [] as Array<{ chunkX: number; chunkY: number }>;
+
+    const bounds = viewport.getVisibleBounds();
+
+    const corners = [
+      { x: bounds.x, y: bounds.y },
+      { x: bounds.x + bounds.width, y: bounds.y },
+      { x: bounds.x, y: bounds.y + bounds.height },
+      { x: bounds.x + bounds.width, y: bounds.y + bounds.height },
+    ];
+    const gridCorners = corners.map((c) => worldToGrid(c.x, c.y, tileWidth, tileHeight));
+
+    const minGridX = Math.min(...gridCorners.map((g) => g.gridX));
+    const maxGridX = Math.max(...gridCorners.map((g) => g.gridX));
+    const minGridY = Math.min(...gridCorners.map((g) => g.gridY));
+    const maxGridY = Math.max(...gridCorners.map((g) => g.gridY));
+
+    const minChunkX = Math.floor(minGridX / chunkSize) - 1;
+    const maxChunkX = Math.floor(maxGridX / chunkSize) + 1;
+    const minChunkY = Math.floor(minGridY / chunkSize) - 1;
+    const maxChunkY = Math.floor(maxGridY / chunkSize) + 1;
+
+    const visibleChunks: Array<{ chunkX: number; chunkY: number }> = [];
+    for (let chunkX = minChunkX; chunkX <= maxChunkX; chunkX++) {
+      for (let chunkY = minChunkY; chunkY <= maxChunkY; chunkY++) {
+        visibleChunks.push({ chunkX, chunkY });
+      }
+    }
+
+    return visibleChunks;
+  }, [viewport, chunkSize, tileWidth, tileHeight]);
+
+  const updateChunks = useCallback(async () => {
+    if (!viewport || !worldContainerRef.current) return;
+
+    const visibleChunks = getVisibleChunks();
+    const loadedChunks = loadedChunksRef.current;
+    const currentTime = Date.now();
+
+    const loadPromises = visibleChunks.map(({ chunkX, chunkY }) => {
+      const chunkKey = `${chunkX},${chunkY}`;
+      if (loadedChunks.has(chunkKey)) {
+        loadedChunks.get(chunkKey)!.lastAccessed = currentTime;
+        return null;
+      }
+      return loadChunk(chunkX, chunkY);
+    });
+
+    await Promise.all(loadPromises.filter(Boolean));
+
+    const visibleChunkKeys = new Set(visibleChunks.map(({ chunkX, chunkY }) => `${chunkX},${chunkY}`));
+    const chunksToUnload: string[] = [];
+
+    loadedChunks.forEach((_, chunkKey) => {
+      if (!visibleChunkKeys.has(chunkKey)) {
+        chunksToUnload.push(chunkKey);
+      }
+    });
+
+    if (loadedChunks.size > maxLoadedChunks) {
+      const sortedChunks = Array.from(loadedChunks.entries()).sort(([, a], [, b]) => a.lastAccessed - b.lastAccessed);
+      const excessCount = loadedChunks.size - maxLoadedChunks;
+      for (let i = 0; i < excessCount; i++) {
+        chunksToUnload.push(sortedChunks[i][0]);
+      }
+    }
+
+    chunksToUnload.forEach((chunkKey) => unloadChunk(chunkKey));
+  }, [viewport, getVisibleChunks, loadChunk, unloadChunk, maxLoadedChunks]);
+
+  useEffect(() => {
+    if (!viewport || worldContainerRef.current) return;
+
+    const worldContainer = new PIXI.Container();
+    worldContainer.name = "chunked-world";
+    worldContainer.sortableChildren = true;
+    worldContainer.zIndex = 100;
+    (worldContainer as unknown as { eventMode: string }).eventMode = "static";
+
+    viewport.addChild(worldContainer);
+    worldContainerRef.current = worldContainer;
+
+    viewport.setZoom(1.5);
+    viewport.moveCenter(0, 0);
+
+    setIsInitialized(true);
+
+    const loadedChunks = loadedChunksRef.current;
+    const loadingChunks = loadingChunksRef.current;
+
+    memoryCheckIntervalRef.current = setInterval(() => {
+      const now = Date.now();
+      if (now - lastMemoryCleanupRef.current < 30000) return;
+
+      const CHUNK_TIMEOUT = 60000;
+      const chunksToRemove: string[] = [];
+
+      loadedChunks.forEach((chunk, chunkKey) => {
+        if (now - chunk.lastAccessed > CHUNK_TIMEOUT) {
+          chunksToRemove.push(chunkKey);
+        }
+      });
+
+      chunksToRemove.forEach((chunkKey) => unloadChunk(chunkKey));
+
+      lastMemoryCleanupRef.current = now;
+      if (chunksToRemove.length > 0) {
+        logger.debug(`Memory cleanup completed. Removed ${chunksToRemove.length} old chunks.`);
+      }
+    }, 30000);
+
+    return () => {
+      if (memoryCheckIntervalRef.current) {
+        clearInterval(memoryCheckIntervalRef.current);
+        memoryCheckIntervalRef.current = null;
+      }
+
+      if (worldContainer.parent) {
+        worldContainer.parent.removeChild(worldContainer);
+      }
+      worldContainer.destroy({ children: true });
+      worldContainerRef.current = null;
+
+      loadedChunks.forEach((chunk, chunkKey) => {
+        disposeChunkTiles(chunk);
+        try {
+          chunk.container.destroy({ children: true, texture: true });
+        } catch (error) {
+          logger.error(`[MEMORY] Error destroying container during cleanup for chunk ${chunkKey}:`, error);
+        }
+      });
+      loadedChunks.clear();
+      loadingChunks.clear();
+    };
+  }, [viewport, unloadChunk]);
+
+  useEffect(() => {
+    if (!viewport || !isInitialized) return;
+
+    let updateTimeout: NodeJS.Timeout | undefined;
+    let isUpdating = false;
+
+    const handleViewportChange = () => {
+      if (isUpdating) return;
+
+      const center = viewport.center;
+      const scale = viewport.scale?.x ?? 1;
+      const lastUpdate = lastViewportUpdateRef.current;
+
+      const moved = Math.abs(center.x - lastUpdate.x) > tileWidth * 3 ||
+        Math.abs(center.y - lastUpdate.y) > tileHeight * 3;
+      const scaleChanged = Math.abs(scale - lastUpdate.scale) > 0.3;
+
+      if (moved || scaleChanged) {
+        if (updateTimeout) {
+          clearTimeout(updateTimeout);
+        }
+        updateTimeout = setTimeout(async () => {
+          isUpdating = true;
+          try {
+            await updateChunks();
+            lastViewportUpdateRef.current = { x: center.x, y: center.y, scale };
+          } finally {
+            isUpdating = false;
+          }
+        }, 300);
+      }
+    };
+
+    viewport.on("moved", handleViewportChange);
+    viewport.on("zoomed", handleViewportChange);
+
+    updateChunks();
+
+    return () => {
+      if (updateTimeout) {
+        clearTimeout(updateTimeout);
+      }
+      viewport.off("moved", handleViewportChange);
+      viewport.off("zoomed", handleViewportChange);
+    };
+  }, [viewport, isInitialized, tileWidth, tileHeight, updateChunks]);
+
+  const getTileType = useCallback((x: number, y: number) => {
+    const chunkX = Math.floor(x / chunkSize);
+    const chunkY = Math.floor(y / chunkSize);
+    const chunkKey = `${chunkX},${chunkY}`;
+    const chunk = loadedChunksRef.current.get(chunkKey);
+    if (!chunk) {
+      return "grass";
+    }
+    const localX = x - chunkX * chunkSize;
+    const localY = y - chunkY * chunkSize;
+    return chunk.data.tiles[localY]?.[localX] ?? "grass";
+  }, [chunkSize]);
+
+  return useMemo(() => ({
+    worldContainer: worldContainerRef.current,
+    isInitialized,
+    loadedChunks: loadedChunksRef.current,
+    memoryStats: memoryStatsRef.current,
+    renderStats: renderStatsRef.current,
+    getTileType,
+  }), [isInitialized, getTileType]);
+}


### PR DESCRIPTION
## Summary
- extract chunk creation/disposal utilities into `chunkRenderer.ts` for reuse
- add a `useChunkStreaming` hook to manage chunk loading, memory cleanup, and viewport updates
- simplify `ChunkedIsometricGrid` to focus on overlays by consuming the new hook
- cover the hook and renderer with unit tests to assert chunk limits, cleanup, and throttling

## Testing
- npm run lint
- npm run test
- npm run build *(fails: existing type error in `packages/engine/src/simulation/workers/workerProgressionService.ts` referencing unexported `Citizen`)*

------
https://chatgpt.com/codex/tasks/task_e_68ca5703d7548325a3725352321f5bc9