### PR TITLE
Refactor game renderer controls into hooks

### DIFF
--- a/src/components/game/GameRenderer.tsx
+++ b/src/components/game/GameRenderer.tsx
@@ -1,15 +1,17 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import type { EdgeScrollState, GameRendererProps } from "./types";
+import { useState } from "react";
+import type { GameRendererProps } from "./types";
 import { useGameContext } from "./GameContext";
 import GameCanvas from "./GameCanvas";
-import { IsometricGrid } from "./IsometricGrid";
 import { GameProvider } from "./GameContext";
 import { Viewport } from "pixi-viewport";
 import * as PIXI from "pixi.js";
 import MiniMap from "./MiniMap";
 import logger from "@/lib/logger";
+import { useKeyboardNavigation } from "./renderer/useKeyboardNavigation";
+import { useEdgeScroll } from "./renderer/useEdgeScroll";
+import { useContainerDimensions } from "./renderer/useContainerDimensions";
 
 function GameRendererContent({
   width = 800,
@@ -22,187 +24,34 @@ function GameRendererContent({
   onReset,
 }: GameRendererProps) {
   logger.debug("GameRendererContent rendering with:", { width, height, gridSize });
+  void tileTypes;
   const [showHelp, setShowHelp] = useState(true);
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const [dims, setDims] = useState<{ w: number; h: number }>({ w: width, h: height });
   const { app, viewport } = useGameContext();
-  const edgeScrollRef = useRef<EdgeScrollState>({ vx: 0, vy: 0, raf: null });
-  // Keyboard pan/zoom helpers
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (!viewport) return;
-      const target = e.target;
-      if (
-        target instanceof HTMLElement &&
-        (target.tagName === 'INPUT' ||
-          target.tagName === 'TEXTAREA' ||
-          target.isContentEditable)
-      ) {
-        return;
-      }
-      const step = 64;
-      const zoomStep = 0.1;
-      if (e.key === 'ArrowLeft' || e.key.toLowerCase() === 'a') {
-        viewport.moveCenter(viewport.center.x - step, viewport.center.y);
-      } else if (e.key === 'ArrowRight' || e.key.toLowerCase() === 'd') {
-        viewport.moveCenter(viewport.center.x + step, viewport.center.y);
-      } else if (e.key === 'ArrowUp' || e.key.toLowerCase() === 'w') {
-        viewport.moveCenter(viewport.center.x, viewport.center.y - step);
-      } else if (e.key === 'ArrowDown' || e.key.toLowerCase() === 's') {
-        viewport.moveCenter(viewport.center.x, viewport.center.y + step);
-      } else if (e.key === '+' || e.key === '=' || e.key.toLowerCase() === 'e') {
-        viewport.setZoom(viewport.scale.x * (1 + zoomStep));
-      } else if (e.key === '-' || e.key.toLowerCase() === 'q') {
-        viewport.setZoom(viewport.scale.x * (1 - zoomStep));
-      } else if (e.key === '0') {
-        // quick recenter
-        const midY = (gridSize - 1) * (32 / 2);
-        viewport.moveCenter(0, midY);
-        viewport.setZoom(1.2);
-      }
-    };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [viewport, gridSize]);
+  const { ref: containerRef, width: canvasWidth, height: canvasHeight } = useContainerDimensions({
+    initialWidth: width,
+    initialHeight: height,
+  });
 
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-    let rAF: number | null = null;
-    let pending = false;
-
-    const updateNow = () => {
-      pending = false;
-      const rect = el.getBoundingClientRect();
-      const w = Math.max(320, Math.floor(rect.width));
-      const h = Math.max(320, Math.floor(rect.height));
-      setDims(prev => (prev.w === w && prev.h === h ? prev : { w, h }));
-      rAF = null;
-    };
-
-    const scheduleUpdate = () => {
-      if (pending) return;
-      pending = true;
-      if (rAF !== null) {
-        cancelAnimationFrame(rAF);
-      }
-      rAF = requestAnimationFrame(updateNow);
-    };
-
-    scheduleUpdate();
-    const ro = new ResizeObserver(scheduleUpdate);
-    ro.observe(el);
-    return () => {
-      ro.disconnect();
-      if (rAF !== null) cancelAnimationFrame(rAF);
-    };
-  }, []);
-
-  // Edge scroll: pan when cursor is near container edges using PIXI ticker
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el || !viewport || !enableEdgeScroll) return;
-    const ticker = app?.ticker;
-    if (!ticker) return;
-    const margin = 24; // px from edge
-    const maxSpeed = 12; // pixels per frame pan speed
-    const state = edgeScrollRef.current;
-
-    const animate = () => {
-      const { vx, vy } = state;
-      if (Math.abs(vx) < 0.01 && Math.abs(vy) < 0.01) {
-        stopAnimation();
-        return;
-      }
-      viewport.moveCenter(viewport.center.x + vx, viewport.center.y + vy);
-    };
-
-    const stopAnimation = () => {
-      if (state.raf !== null) {
-        state.raf = null;
-        ticker.remove(animate);
-      }
-    };
-
-    const startAnimation = () => {
-      if (state.raf === null) {
-        state.raf = 1;
-        ticker.add(animate);
-      }
-    };
-
-    const onMouseMove = (e: MouseEvent) => {
-      const rect = el.getBoundingClientRect();
-      const x = e.clientX - rect.left;
-      const y = e.clientY - rect.top;
-      let vx = 0, vy = 0;
-      if (x < margin) vx = -((margin - x) / margin) * maxSpeed;
-      else if (x > rect.width - margin) vx = ((x - (rect.width - margin)) / margin) * maxSpeed;
-      if (y < margin) vy = -((margin - y) / margin) * maxSpeed;
-      else if (y > rect.height - margin) vy = ((y - (rect.height - margin)) / margin) * maxSpeed;
-      state.vx = vx;
-      state.vy = vy;
-      if (vx !== 0 || vy !== 0) {
-        startAnimation();
-      } else {
-        stopAnimation();
-      }
-    };
-    const onMouseLeave = () => {
-      state.vx = 0;
-      state.vy = 0;
-      stopAnimation();
-    };
-
-    el.addEventListener('mousemove', onMouseMove);
-    el.addEventListener('mouseleave', onMouseLeave);
-    return () => {
-      el.removeEventListener('mousemove', onMouseMove);
-      el.removeEventListener('mouseleave', onMouseLeave);
-      stopAnimation();
-      state.vx = 0;
-      state.vy = 0;
-    };
-  }, [app, viewport, enableEdgeScroll]);
+  useKeyboardNavigation({ viewport, gridSize });
+  useEdgeScroll({
+    containerRef,
+    viewport,
+    app,
+    enabled: enableEdgeScroll,
+  });
 
   return (
     <div ref={containerRef} className="relative w-full h-full bg-gray-900">
       <GameCanvas
-        width={dims.w}
-        height={dims.h}
+        width={canvasWidth}
+        height={canvasHeight}
         onTileHover={onTileHover}
         onTileClick={onTileClick}
       />
 
-      {gridSize > 0 && (
-        <div className="absolute bottom-4 right-4 hidden sm:block pointer-events-auto">
-          <div className="bg-gray-900/80 border border-gray-700 rounded-lg shadow-lg p-2">
-            <MiniMap gridSize={gridSize} />
-          </div>
-        </div>
-      )}
+      {gridSize > 0 && <MiniMapOverlay gridSize={gridSize} />}
 
-      {showHelp && (
-        <div className="absolute top-2 left-2 pointer-events-none">
-          <div className="bg-gray-800/90 backdrop-blur-sm border border-gray-700 rounded-lg shadow-md px-3 py-2 text-[11px] sm:text-xs text-gray-200 max-w-xs pointer-events-none">
-            <div className="font-semibold text-gray-100 mb-1">How to interact</div>
-            <ul className="list-disc pl-4 space-y-0.5 text-gray-300">
-              <li>Click tiles to select</li>
-              <li>Drag to pan, scroll to zoom</li>
-              <li>Open Council to take actions</li>
-            </ul>
-            <div className="mt-2 flex items-center justify-between">
-              <span className="text-gray-400">Grid: {gridSize}×{gridSize}</span>
-              <button
-                onClick={() => setShowHelp(false)}
-                className="ml-2 px-2 py-0.5 text-[11px] rounded-md bg-gray-700 hover:bg-gray-600 text-gray-100 pointer-events-auto"
-              >
-                Got it
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      {showHelp && <HelpOverlay gridSize={gridSize} onDismiss={() => setShowHelp(false)} />}
 
       {/* Control buttons */}
       <div className="absolute top-2 left-2 pointer-events-auto flex gap-2">
@@ -226,6 +75,46 @@ function GameRendererContent({
             Reset
           </button>
         )}
+      </div>
+    </div>
+  );
+}
+
+function MiniMapOverlay({ gridSize }: { gridSize: number }) {
+  return (
+    <div className="absolute bottom-4 right-4 hidden sm:block pointer-events-auto">
+      <div className="bg-gray-900/80 border border-gray-700 rounded-lg shadow-lg p-2">
+        <MiniMap gridSize={gridSize} />
+      </div>
+    </div>
+  );
+}
+
+function HelpOverlay({
+  gridSize,
+  onDismiss,
+}: {
+  gridSize: number;
+  onDismiss: () => void;
+}) {
+  return (
+    <div className="absolute top-2 left-2 pointer-events-none">
+      <div className="bg-gray-800/90 backdrop-blur-sm border border-gray-700 rounded-lg shadow-md px-3 py-2 text-[11px] sm:text-xs text-gray-200 max-w-xs pointer-events-none">
+        <div className="font-semibold text-gray-100 mb-1">How to interact</div>
+        <ul className="list-disc pl-4 space-y-0.5 text-gray-300">
+          <li>Click tiles to select</li>
+          <li>Drag to pan, scroll to zoom</li>
+          <li>Open Council to take actions</li>
+        </ul>
+        <div className="mt-2 flex items-center justify-between">
+          <span className="text-gray-400">Grid: {gridSize}×{gridSize}</span>
+          <button
+            onClick={onDismiss}
+            className="ml-2 px-2 py-0.5 text-[11px] rounded-md bg-gray-700 hover:bg-gray-600 text-gray-100 pointer-events-auto"
+          >
+            Got it
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/components/game/renderer/useContainerDimensions.ts
+++ b/src/components/game/renderer/useContainerDimensions.ts
@@ -1,0 +1,99 @@
+import { useEffect, useRef, useState } from "react";
+import type { MutableRefObject } from "react";
+
+interface UseContainerDimensionsOptions {
+  initialWidth?: number;
+  initialHeight?: number;
+  minWidth?: number;
+  minHeight?: number;
+}
+
+interface ContainerDimensionsResult {
+  ref: MutableRefObject<HTMLDivElement | null>;
+  width: number;
+  height: number;
+}
+
+const DEFAULT_MIN_SIZE = 320;
+
+function clampSize(value: number | undefined, minimum: number) {
+  return Math.max(minimum, Math.floor(value ?? minimum));
+}
+
+export function useContainerDimensions({
+  initialWidth,
+  initialHeight,
+  minWidth = DEFAULT_MIN_SIZE,
+  minHeight = DEFAULT_MIN_SIZE,
+}: UseContainerDimensionsOptions = {}): ContainerDimensionsResult {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [dimensions, setDimensions] = useState(() => ({
+    width: clampSize(initialWidth, minWidth),
+    height: clampSize(initialHeight, minHeight),
+  }));
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return undefined;
+    }
+
+    const element = containerRef.current;
+    if (!element) {
+      return undefined;
+    }
+
+    let frameId: number | null = null;
+    let pending = false;
+
+    const measure = () => {
+      pending = false;
+      const rect = element.getBoundingClientRect();
+      const nextWidth = clampSize(rect.width, minWidth);
+      const nextHeight = clampSize(rect.height, minHeight);
+
+      setDimensions(prev =>
+        prev.width === nextWidth && prev.height === nextHeight
+          ? prev
+          : { width: nextWidth, height: nextHeight },
+      );
+      frameId = null;
+    };
+
+    const scheduleMeasure = () => {
+      if (pending) return;
+      pending = true;
+      if (frameId !== null) {
+        cancelAnimationFrame(frameId);
+      }
+      frameId = window.requestAnimationFrame(measure);
+    };
+
+    scheduleMeasure();
+
+    if (typeof ResizeObserver !== "undefined") {
+      const observer = new ResizeObserver(scheduleMeasure);
+      observer.observe(element);
+
+      return () => {
+        observer.disconnect();
+        if (frameId !== null) {
+          cancelAnimationFrame(frameId);
+        }
+        pending = false;
+      };
+    }
+
+    const handleResize = () => scheduleMeasure();
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      if (frameId !== null) {
+        cancelAnimationFrame(frameId);
+      }
+      pending = false;
+    };
+  }, [minHeight, minWidth]);
+
+  return { ref: containerRef, width: dimensions.width, height: dimensions.height };
+}

--- a/src/components/game/renderer/useEdgeScroll.ts
+++ b/src/components/game/renderer/useEdgeScroll.ts
@@ -1,0 +1,114 @@
+import { useEffect, useRef } from "react";
+import type { MutableRefObject } from "react";
+import type { Viewport } from "pixi-viewport";
+import type * as PIXI from "pixi.js";
+
+interface EdgeScrollState {
+  vx: number;
+  vy: number;
+  raf: number | null;
+}
+
+interface UseEdgeScrollOptions {
+  containerRef: MutableRefObject<HTMLElement | null>;
+  viewport: Viewport | null;
+  app: PIXI.Application | null;
+  enabled?: boolean;
+  margin?: number;
+  maxSpeed?: number;
+}
+
+const DEFAULT_MARGIN = 24;
+const DEFAULT_MAX_SPEED = 12;
+
+export function useEdgeScroll({
+  containerRef,
+  viewport,
+  app,
+  enabled = true,
+  margin = DEFAULT_MARGIN,
+  maxSpeed = DEFAULT_MAX_SPEED,
+}: UseEdgeScrollOptions) {
+  const stateRef = useRef<EdgeScrollState>({ vx: 0, vy: 0, raf: null });
+
+  useEffect(() => {
+    const element = containerRef.current;
+    const ticker = app?.ticker;
+
+    if (!enabled || !element || !viewport || !ticker) {
+      return undefined;
+    }
+
+    const state = stateRef.current;
+
+    const stopAnimation = () => {
+      if (state.raf !== null) {
+        state.raf = null;
+        ticker.remove(animate);
+      }
+    };
+
+    const animate = () => {
+      const { vx, vy } = state;
+      if (Math.abs(vx) < 0.01 && Math.abs(vy) < 0.01) {
+        stopAnimation();
+        return;
+      }
+      viewport.moveCenter(viewport.center.x + vx, viewport.center.y + vy);
+    };
+
+    const startAnimation = () => {
+      if (state.raf === null) {
+        state.raf = 1;
+        ticker.add(animate);
+      }
+    };
+
+    const handleMouseMove = (event: MouseEvent) => {
+      const rect = element.getBoundingClientRect();
+      const relativeX = event.clientX - rect.left;
+      const relativeY = event.clientY - rect.top;
+
+      let vx = 0;
+      let vy = 0;
+
+      if (relativeX < margin) {
+        vx = -((margin - relativeX) / margin) * maxSpeed;
+      } else if (relativeX > rect.width - margin) {
+        vx = ((relativeX - (rect.width - margin)) / margin) * maxSpeed;
+      }
+
+      if (relativeY < margin) {
+        vy = -((margin - relativeY) / margin) * maxSpeed;
+      } else if (relativeY > rect.height - margin) {
+        vy = ((relativeY - (rect.height - margin)) / margin) * maxSpeed;
+      }
+
+      state.vx = vx;
+      state.vy = vy;
+
+      if (vx !== 0 || vy !== 0) {
+        startAnimation();
+      } else {
+        stopAnimation();
+      }
+    };
+
+    const handleMouseLeave = () => {
+      state.vx = 0;
+      state.vy = 0;
+      stopAnimation();
+    };
+
+    element.addEventListener("mousemove", handleMouseMove);
+    element.addEventListener("mouseleave", handleMouseLeave);
+
+    return () => {
+      element.removeEventListener("mousemove", handleMouseMove);
+      element.removeEventListener("mouseleave", handleMouseLeave);
+      stopAnimation();
+      state.vx = 0;
+      state.vy = 0;
+    };
+  }, [app, containerRef, enabled, margin, maxSpeed, viewport]);
+}

--- a/src/components/game/renderer/useKeyboardNavigation.ts
+++ b/src/components/game/renderer/useKeyboardNavigation.ts
@@ -1,0 +1,61 @@
+import { useEffect } from "react";
+import type { Viewport } from "pixi-viewport";
+
+interface UseKeyboardNavigationOptions {
+  viewport: Viewport | null;
+  gridSize?: number;
+  step?: number;
+  zoomStep?: number;
+}
+
+const DEFAULT_STEP = 64;
+const DEFAULT_ZOOM_STEP = 0.1;
+
+export function useKeyboardNavigation({
+  viewport,
+  gridSize = 20,
+  step = DEFAULT_STEP,
+  zoomStep = DEFAULT_ZOOM_STEP,
+}: UseKeyboardNavigationOptions) {
+  useEffect(() => {
+    if (!viewport) return undefined;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target;
+      if (
+        target instanceof HTMLElement &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+
+      const key = event.key;
+      const lowerKey = key.toLowerCase();
+
+      if (key === "ArrowLeft" || lowerKey === "a") {
+        viewport.moveCenter(viewport.center.x - step, viewport.center.y);
+      } else if (key === "ArrowRight" || lowerKey === "d") {
+        viewport.moveCenter(viewport.center.x + step, viewport.center.y);
+      } else if (key === "ArrowUp" || lowerKey === "w") {
+        viewport.moveCenter(viewport.center.x, viewport.center.y - step);
+      } else if (key === "ArrowDown" || lowerKey === "s") {
+        viewport.moveCenter(viewport.center.x, viewport.center.y + step);
+      } else if (key === "+" || key === "=" || lowerKey === "e") {
+        viewport.setZoom(viewport.scale.x * (1 + zoomStep));
+      } else if (key === "-" || lowerKey === "q") {
+        viewport.setZoom(viewport.scale.x * (1 - zoomStep));
+      } else if (key === "0") {
+        const midY = (gridSize - 1) * (32 / 2);
+        viewport.moveCenter(0, midY);
+        viewport.setZoom(1.2);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [viewport, gridSize, step, zoomStep]);
+}

--- a/src/components/game/types.ts
+++ b/src/components/game/types.ts
@@ -21,9 +21,3 @@ export interface GameRendererProps {
   enableEdgeScroll?: boolean;
   onReset?: () => void;
 }
-
-export interface EdgeScrollState {
-  vx: number;
-  vy: number;
-  raf: number | null;
-}


### PR DESCRIPTION
## Summary
- extract keyboard navigation, edge scroll, and container resize logic from GameRenderer into dedicated hooks
- refactor GameRendererContent to compose the new hooks and render stateless overlay components
- simplify renderer types by localizing edge scroll state handling to the new hook

## Testing
- npm run lint
- npm run test
- npm run build *(fails: workerProgressionService imports a non-exported Citizen type)*

------
https://chatgpt.com/codex/tasks/task_e_68ca96c882c48325af8b58aab80a6311