### PR TITLE
Refactor game layers data flow

### DIFF
--- a/src/components/game/layers/ConnectedBuildingsLayer.tsx
+++ b/src/components/game/layers/ConnectedBuildingsLayer.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { BuildingsLayer } from '../../../../apps/web/features/buildings';
+import type { LayerBuilding, TileSelection } from './types';
+
+interface ConnectedBuildingsLayerProps {
+  buildings: LayerBuilding[];
+  storeConnectedIds: string[];
+  selectedTile: TileSelection | null;
+}
+
+const ConnectedBuildingsLayer: React.FC<ConnectedBuildingsLayerProps> = ({
+  buildings,
+  storeConnectedIds,
+  selectedTile,
+}) => (
+  <BuildingsLayer
+    buildings={buildings}
+    storeConnectedIds={storeConnectedIds}
+    selected={selectedTile ? { x: selectedTile.x, y: selectedTile.y } : null}
+  />
+);
+
+export default ConnectedBuildingsLayer;

--- a/src/components/game/layers/types.ts
+++ b/src/components/game/layers/types.ts
@@ -1,0 +1,74 @@
+import type { BuildTypeId } from '../panels/TileInfoPanel';
+import type { SimResources } from '../resourceUtils';
+import type { SimpleBuilding } from '../types';
+import type { RouteDef, RouteBuildingRef } from '../../../../apps/web/features/routes';
+
+export interface TileSelection {
+  x: number;
+  y: number;
+  tileType?: string;
+}
+
+export interface StoredBuilding {
+  id: string;
+  typeId: BuildTypeId;
+  x: number;
+  y: number;
+  level: number;
+  workers: number;
+}
+
+export interface TradeRoute {
+  id: string;
+  fromId: string;
+  toId: string;
+}
+
+export interface Marker {
+  id: string;
+  x: number;
+  y: number;
+  label?: string;
+}
+
+export type BuildPlacementHint =
+  | { valid: true }
+  | { valid: false; reason: string };
+
+export interface BuildPlacementHintsResult {
+  buildHint?: BuildPlacementHint;
+  highlightAllPlaceable: boolean;
+  hasCouncil: boolean;
+  isFreeBuild: boolean;
+  affordable: boolean;
+}
+
+export interface BuildPlacementInput {
+  previewTypeId: BuildTypeId | null;
+  hoverTile: TileSelection | null;
+  selectedTile: TileSelection | null;
+  placedBuildings: StoredBuilding[];
+  tutorialFree: Partial<Record<BuildTypeId, number>>;
+  simResources: SimResources | null;
+}
+
+export interface LayerBuilding extends SimpleBuilding {
+  workers: number;
+  level: number;
+}
+
+export interface WorkingCitizenVisualization {
+  id: string;
+  x: number;
+  y: number;
+  activity: 'working';
+  speed: number;
+}
+
+export interface LayerDatasets {
+  buildings: LayerBuilding[];
+  storeConnectedIds: string[];
+  routeDefs: RouteDef[];
+  routeBuildings: RouteBuildingRef[];
+  workingCitizens: WorkingCitizenVisualization[];
+}

--- a/src/components/game/layers/useBuildPlacementHints.ts
+++ b/src/components/game/layers/useBuildPlacementHints.ts
@@ -1,0 +1,86 @@
+import { useMemo } from 'react';
+import { BUILDABLE_TILES, SIM_BUILDINGS } from '../simCatalog';
+import { canAfford } from '../resourceUtils';
+import type { BuildPlacementHintsResult, BuildPlacementInput, BuildPlacementHint } from './types';
+
+function buildInsufficientReason(previewTypeId: keyof typeof SIM_BUILDINGS, simResources: BuildPlacementInput['simResources']) {
+  if (!simResources) return undefined;
+  const cost = SIM_BUILDINGS[previewTypeId]?.cost as Record<string, number> | undefined;
+  if (!cost) return undefined;
+
+  const lacking: string[] = [];
+  (Object.keys(cost) as Array<keyof typeof cost>).forEach(key => {
+    const required = cost[key] ?? 0;
+    const current = simResources[key as keyof typeof simResources] ?? 0;
+    if (required > current) {
+      const shortfall = required - current;
+      lacking.push(`${String(key)} ${shortfall}`);
+    }
+  });
+  if (lacking.length === 0) return undefined;
+  return `Insufficient: ${lacking.slice(0, 3).join(', ')}`;
+}
+
+export function useBuildPlacementHints({
+  previewTypeId,
+  hoverTile,
+  selectedTile,
+  placedBuildings,
+  tutorialFree,
+  simResources,
+}: BuildPlacementInput): BuildPlacementHintsResult {
+  return useMemo<BuildPlacementHintsResult>(() => {
+    const highlightAllPlaceable = Boolean(previewTypeId);
+    const hasCouncil = placedBuildings.some(b => b.typeId === 'council_hall');
+    const buildHint: BuildPlacementHint | undefined = (() => {
+      if (!previewTypeId) return undefined;
+      const tile = hoverTile || selectedTile;
+      if (!tile) return undefined;
+
+      const occupied = placedBuildings.some(b => b.x === tile.x && b.y === tile.y);
+      if (occupied) return { valid: false, reason: 'Occupied' };
+
+      const allowed = BUILDABLE_TILES[previewTypeId];
+      if (allowed && tile.tileType && !allowed.includes(tile.tileType)) {
+        return { valid: false, reason: 'Invalid terrain' };
+      }
+
+      const needsCouncil = previewTypeId === 'trade_post' || previewTypeId === 'automation_workshop';
+      if (needsCouncil && !hasCouncil) {
+        return { valid: false, reason: 'Requires Council Hall' };
+      }
+
+      const hasFree = (tutorialFree[previewTypeId] || 0) > 0;
+      if (!hasFree) {
+        const reason = buildInsufficientReason(previewTypeId, simResources);
+        if (reason) {
+          return { valid: false, reason };
+        }
+      }
+
+      return { valid: true };
+    })();
+
+    const isFreeBuild = previewTypeId ? (tutorialFree[previewTypeId] || 0) > 0 : false;
+    const affordable = previewTypeId
+      ? isFreeBuild || (simResources ? canAfford(SIM_BUILDINGS[previewTypeId].cost, simResources) : false)
+      : false;
+
+    return {
+      buildHint,
+      highlightAllPlaceable,
+      hasCouncil,
+      isFreeBuild,
+      affordable,
+    };
+  }, [
+    hoverTile,
+    placedBuildings,
+    previewTypeId,
+    selectedTile,
+    simResources,
+    tutorialFree,
+  ]);
+}
+
+export type { BuildPlacementHint } from './types';

--- a/src/components/game/layers/useLayerDatasets.ts
+++ b/src/components/game/layers/useLayerDatasets.ts
@@ -1,0 +1,80 @@
+import { useMemo } from 'react';
+import type { RouteBuildingRef, RouteDef } from '../../../../apps/web/features/routes';
+import type { LayerBuilding, LayerDatasets, StoredBuilding, TradeRoute, WorkingCitizenVisualization } from './types';
+
+const DEFAULT_SPEED = 1.0;
+
+function mapBuildings(placedBuildings: StoredBuilding[]): LayerBuilding[] {
+  return placedBuildings.map(building => ({
+    id: building.id,
+    typeId: building.typeId,
+    x: building.x,
+    y: building.y,
+    workers: building.workers,
+    level: building.level,
+  }));
+}
+
+function deriveStoreConnections(placedBuildings: StoredBuilding[], routes: TradeRoute[] | undefined): string[] {
+  if (!routes?.length) return [];
+  const connected = new Set<string>();
+
+  routes.forEach(route => {
+    const origin = placedBuildings.find(b => b.id === route.fromId);
+    const destination = placedBuildings.find(b => b.id === route.toId);
+    if (!origin || !destination) return;
+
+    if (origin.typeId === 'storehouse') {
+      connected.add(destination.id);
+    }
+    if (destination.typeId === 'storehouse') {
+      connected.add(origin.id);
+    }
+  });
+
+  return Array.from(connected);
+}
+
+function mapRoutes(routes: TradeRoute[] | undefined): RouteDef[] {
+  if (!routes?.length) return [];
+  return routes.map(route => ({ id: route.id, fromId: route.fromId, toId: route.toId }));
+}
+
+function mapRouteBuildings(placedBuildings: StoredBuilding[]): RouteBuildingRef[] {
+  return placedBuildings.map(building => ({ id: building.id, x: building.x, y: building.y }));
+}
+
+function mapWorkingCitizens(placedBuildings: StoredBuilding[]): WorkingCitizenVisualization[] {
+  return placedBuildings
+    .filter(building => building.workers > 0)
+    .map(building => ({
+      id: building.id,
+      x: building.x,
+      y: building.y,
+      activity: 'working' as const,
+      speed: DEFAULT_SPEED,
+    }));
+}
+
+interface UseLayerDatasetsParams {
+  placedBuildings: StoredBuilding[];
+  routes: TradeRoute[] | undefined;
+}
+
+export function useLayerDatasets({ placedBuildings, routes }: UseLayerDatasetsParams): LayerDatasets {
+  const buildings = useMemo(() => mapBuildings(placedBuildings), [placedBuildings]);
+  const storeConnectedIds = useMemo(() => deriveStoreConnections(placedBuildings, routes), [placedBuildings, routes]);
+  const routeDefs = useMemo(() => mapRoutes(routes), [routes]);
+  const routeBuildings = useMemo(() => mapRouteBuildings(placedBuildings), [placedBuildings]);
+  const workingCitizens = useMemo(() => mapWorkingCitizens(placedBuildings), [placedBuildings]);
+
+  return {
+    buildings,
+    storeConnectedIds,
+    routeDefs,
+    routeBuildings,
+    workingCitizens,
+  };
+}
+
+export type { LayerDatasets } from './types';


### PR DESCRIPTION
## Summary
- extract build placement validation into `useBuildPlacementHints` and expose helper flags for the preview layer
- prepare buildings, routes, and citizen overlays via `useLayerDatasets` so `GameLayers` focuses on rendering
- introduce a `ConnectedBuildingsLayer` wrapper and shared types to simplify props and future testing

## Testing
- npm run lint
- npm run test
- npm run build *(fails: existing type error in packages/engine/src/simulation/workers/workerProgressionService.ts complaining about missing Citizen export)*

------
https://chatgpt.com/codex/tasks/task_e_68ca96cae02c83259946c9d7cd427920