### PR TITLE
Refactor worker simulation dependencies

### DIFF
--- a/packages/engine/src/simulation/workers/__tests__/workerProgressionService.test.ts
+++ b/packages/engine/src/simulation/workers/__tests__/workerProgressionService.test.ts
@@ -1,14 +1,16 @@
 import { describe, it, expect } from 'vitest';
 import { WorkerProgressionService } from '../workerProgressionService';
-import { createDefaultJobCatalog } from '../jobCatalog';
+import { JobCatalogService } from '../jobCatalogService';
 import { LaborMarketService } from '../laborMarketService';
 import type { WorkerProfile, Workplace } from '../types';
 import type { Citizen } from '@engine/simulation/citizenBehavior';
 import { createGameTime } from '@engine/types/gameTime';
 
-function createWorkerProfile(roleId: string): { worker: WorkerProfile; coworker: WorkerProfile } {
-  const catalog = createDefaultJobCatalog();
-  const role = catalog.get(roleId);
+function createWorkerProfile(
+  roleId: string,
+  jobCatalog: JobCatalogService
+): { worker: WorkerProfile; coworker: WorkerProfile } {
+  const role = jobCatalog.getRole(roleId);
   if (!role) {
     throw new Error(`Missing role ${roleId}`);
   }
@@ -62,7 +64,8 @@ function createWorkerProfile(roleId: string): { worker: WorkerProfile; coworker:
 
 describe('WorkerProgressionService', () => {
   it('updates worker progression metrics and workplace relationships', () => {
-    const { worker, coworker } = createWorkerProfile('farmer');
+    const jobCatalog = new JobCatalogService();
+    const { worker, coworker } = createWorkerProfile('farmer', jobCatalog);
 
     const workers = new Map<string, WorkerProfile>([
       [worker.citizenId, worker],
@@ -112,7 +115,7 @@ describe('WorkerProgressionService', () => {
 
     progression.updateWorkerProgression(worker, {
       gameTime: createGameTime(0),
-      jobRoles: createDefaultJobCatalog(),
+      jobCatalog,
       laborMarket,
       citizen,
       workers,

--- a/packages/engine/src/simulation/workers/career.ts
+++ b/packages/engine/src/simulation/workers/career.ts
@@ -1,5 +1,6 @@
 import type { GameTime } from '../../types/gameTime';
-import type { JobRole, WorkerProfile } from './types';
+import type { WorkerProfile } from './types';
+import { JobCatalogService } from './jobCatalogService';
 
 // Adjust job satisfaction based on how a worker's wage compares to the market
 export function calculateWageAdjustment(worker: WorkerProfile, marketWage: number): number {
@@ -13,7 +14,7 @@ export function calculateWageAdjustment(worker: WorkerProfile, marketWage: numbe
 export function checkCareerProgression(
   worker: WorkerProfile,
   gameTime: GameTime,
-  jobRoles: Map<string, JobRole>
+  jobCatalog: JobCatalogService
 ): void {
   const currentCycle = Math.floor(gameTime.totalMinutes / 60);
 
@@ -30,7 +31,7 @@ export function checkCareerProgression(
   }
 
   if (worker.jobSatisfaction < 30 && Math.random() < 0.02) {
-    considerJobChange(worker, jobRoles);
+    considerJobChange(worker, jobCatalog);
   }
 }
 
@@ -64,10 +65,10 @@ export function promoteWorker(worker: WorkerProfile, currentCycle: number): void
 }
 
 // Consider switching jobs when better opportunities exist
-export function considerJobChange(worker: WorkerProfile, jobRoles: Map<string, JobRole>): void {
-  const availableRoles = Array.from(jobRoles.values()).filter(
-    (role) => role.id !== worker.currentRole.id
-  );
+export function considerJobChange(worker: WorkerProfile, jobCatalog: JobCatalogService): void {
+  const availableRoles = jobCatalog
+    .listRoles()
+    .filter((role) => role.id !== worker.currentRole.id);
 
   for (const role of availableRoles) {
     if (

--- a/packages/engine/src/simulation/workers/workerProgressionService.ts
+++ b/packages/engine/src/simulation/workers/workerProgressionService.ts
@@ -1,16 +1,17 @@
 import type { GameTime } from '../../types/gameTime';
-import type { Citizen } from '../citizenBehavior';
-import type { JobRole, WorkerProfile, Workplace } from './types';
+import type { Citizen } from '../citizens/citizen';
+import type { WorkerProfile, Workplace } from './types';
 import type { LaborMarket } from './laborMarketService';
 import { calculateWageAdjustment, checkCareerProgression } from './career';
+import { JobCatalogService } from './jobCatalogService';
 
 export interface WorkerProgressionContext {
   gameTime: GameTime;
-  jobRoles: Map<string, JobRole>;
+  jobCatalog: JobCatalogService;
   laborMarket: LaborMarket;
   citizen?: Citizen;
-  workers: Map<string, WorkerProfile>;
-  workplaces: Map<string, Workplace>;
+  workers: ReadonlyMap<string, WorkerProfile>;
+  workplaces: ReadonlyMap<string, Workplace>;
   random?: () => number;
 }
 
@@ -21,7 +22,7 @@ export class WorkerProgressionService {
     this.updateExperience(worker);
     this.updatePerformance(worker);
     this.updateJobSatisfaction(worker, context.citizen, context.laborMarket);
-    checkCareerProgression(worker, context.gameTime, context.jobRoles);
+    checkCareerProgression(worker, context.gameTime, context.jobCatalog);
     this.updateWorkLifeBalance(worker);
     this.handleWorkplaceInteractions(
       worker,
@@ -105,8 +106,8 @@ export class WorkerProgressionService {
 
   private handleWorkplaceInteractions(
     worker: WorkerProfile,
-    workers: Map<string, WorkerProfile>,
-    workplaces: Map<string, Workplace>,
+    workers: ReadonlyMap<string, WorkerProfile>,
+    workplaces: ReadonlyMap<string, Workplace>,
     random: () => number
   ): void {
     const workplace = Array.from(workplaces.values()).find(w => w.workers.includes(worker.citizenId));
@@ -125,7 +126,7 @@ export class WorkerProgressionService {
     worker: WorkerProfile,
     coworkerId: string,
     workplace: Workplace,
-    workers: Map<string, WorkerProfile>
+    workers: ReadonlyMap<string, WorkerProfile>
   ): void {
     const coworker = workers.get(coworkerId);
     if (!coworker) return;

--- a/packages/engine/src/simulation/workers/workerRepository.ts
+++ b/packages/engine/src/simulation/workers/workerRepository.ts
@@ -1,0 +1,55 @@
+import type { WorkerProfile, Workplace } from './types';
+
+/**
+ * Repository responsible for storing and retrieving worker and workplace data.
+ * This keeps the storage concern isolated from the higher level simulation
+ * system so the maps can be swapped for alternative implementations in tests.
+ */
+export class WorkerRepository {
+  private readonly workers: Map<string, WorkerProfile> = new Map();
+  private readonly workplaces: Map<string, Workplace> = new Map();
+
+  upsertWorker(worker: WorkerProfile): void {
+    this.workers.set(worker.citizenId, worker);
+  }
+
+  hasWorker(workerId: string): boolean {
+    return this.workers.has(workerId);
+  }
+
+  getWorker(workerId: string): WorkerProfile | undefined {
+    return this.workers.get(workerId);
+  }
+
+  removeWorker(workerId: string): boolean {
+    return this.workers.delete(workerId);
+  }
+
+  getAllWorkers(): WorkerProfile[] {
+    return Array.from(this.workers.values());
+  }
+
+  getWorkerMap(): ReadonlyMap<string, WorkerProfile> {
+    return this.workers;
+  }
+
+  upsertWorkplace(workplace: Workplace): void {
+    this.workplaces.set(workplace.buildingId, workplace);
+  }
+
+  getWorkplace(buildingId: string): Workplace | undefined {
+    return this.workplaces.get(buildingId);
+  }
+
+  removeWorkplace(buildingId: string): boolean {
+    return this.workplaces.delete(buildingId);
+  }
+
+  getAllWorkplaces(): Workplace[] {
+    return Array.from(this.workplaces.values());
+  }
+
+  getWorkplaceMap(): ReadonlyMap<string, Workplace> {
+    return this.workplaces;
+  }
+}


### PR DESCRIPTION
## Summary
- introduce a WorkerRepository and JobCatalogService to encapsulate storage and job role logic
- refactor WorkerSimulationSystem and supporting services to consume the new abstractions
- expand worker simulation integration tests to cover creation, assignment, and summaries

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca96e153d48325a9d554a515f52231