### PR TITLE
Refactor city services into modular collaborators

### DIFF
--- a/packages/engine/src/simulation/cityServices.ts
+++ b/packages/engine/src/simulation/cityServices.ts
@@ -1,248 +1,88 @@
-// Position and Building interfaces
-export interface Position {
-  x: number;
-  y: number;
-}
+import type { EmergencyDispatcherConfig } from './emergencyDispatcher';
+import { EmergencyDispatcher } from './emergencyDispatcher';
+import { ServiceCoverageMap } from './serviceCoverageMap';
+import { ServiceDemandModel, DEFAULT_DEMAND_CONFIG } from './serviceDemandModel';
+import {
+  Building,
+  EmergencyEvent,
+  Position,
+  ServiceBuilding,
+  ServiceDemand,
+  ServiceStats,
+  ServiceType
+} from './cityServices.types';
 
-export interface Building {
-  id: string;
-  typeId: string;
-  position: Position;
-  x: number;
-  y: number;
-}
-
-export interface ServiceBuilding extends Building {
-  serviceType: ServiceType;
-  capacity: number;
-  currentLoad: number;
-  efficiency: number;
-  coverage: number;
-  maintenanceCost: number;
-  staffing: number;
-  maxStaffing: number;
-}
-
-export enum ServiceType {
-  POLICE = 'police',
-  FIRE = 'fire',
-  HEALTHCARE = 'healthcare',
-  EDUCATION = 'education',
-  WATER = 'water',
-  POWER = 'power',
-  WASTE = 'waste',
-  PARKS = 'parks'
-}
-
-export interface ServiceCoverage {
-  position: Position;
-  radius: number;
-  effectiveness: number;
-  serviceType: ServiceType;
-}
-
-export interface ServiceDemand {
-  police: number;
-  fire: number;
-  healthcare: number;
-  education: number;
-  water: number;
-  power: number;
-  waste: number;
-  parks: number;
-}
-
-export interface ServiceStats {
-  coverage: number;
-  satisfaction: number;
-  efficiency: number;
-  cost: number;
-}
-
-export interface EmergencyEvent {
-  id: string;
-  type: 'fire' | 'crime' | 'medical' | 'accident';
-  position: Position;
-  severity: number;
-  startTime: number;
-  duration: number;
-  resolved: boolean;
-}
+export type {
+  Building,
+  EmergencyEvent,
+  Position,
+  ServiceBuilding,
+  ServiceDemand,
+  ServiceStats
+};
+export { ServiceType, ServiceCoverageMap, ServiceDemandModel, DEFAULT_DEMAND_CONFIG, EmergencyDispatcher };
+export type { EmergencyDispatcherConfig };
 
 export class CityServicesSystem {
-  private serviceBuildings: Map<string, ServiceBuilding> = new Map();
-  private serviceCoverage: ServiceCoverage[] = [];
-  private emergencyEvents: EmergencyEvent[] = [];
-  private serviceDemand: ServiceDemand = {
-    police: 0,
-    fire: 0,
-    healthcare: 0,
-    education: 0,
-    water: 0,
-    power: 0,
-    waste: 0,
-    parks: 0
-  };
-  private gridWidth: number;
-  private gridHeight: number;
-  private coverageGrid: Map<ServiceType, number[][]> = new Map();
+  private readonly serviceBuildings: Map<string, ServiceBuilding> = new Map();
+  private serviceDemand: ServiceDemand;
+  private readonly coverageMap: ServiceCoverageMap;
+  private readonly demandModel: ServiceDemandModel;
+  private readonly emergencyDispatcher: EmergencyDispatcher;
 
-  constructor(gridWidth: number, gridHeight: number) {
-    this.gridWidth = gridWidth;
-    this.gridHeight = gridHeight;
-    this.initializeCoverageGrids();
-  }
-
-  private initializeCoverageGrids(): void {
-    Object.values(ServiceType).forEach(serviceType => {
-      const grid = Array(this.gridHeight).fill(null).map(() => 
-        Array(this.gridWidth).fill(0)
+  constructor(
+    gridWidth: number,
+    gridHeight: number,
+    options?: {
+      demandModel?: ServiceDemandModel;
+      emergencyDispatcher?: EmergencyDispatcher;
+      coverageMap?: ServiceCoverageMap;
+      emergencyConfig?: Omit<EmergencyDispatcherConfig, 'gridWidth' | 'gridHeight'>;
+    }
+  ) {
+    this.coverageMap = options?.coverageMap ?? new ServiceCoverageMap(gridWidth, gridHeight);
+    this.demandModel = options?.demandModel ?? new ServiceDemandModel();
+    this.serviceDemand = this.demandModel.createEmptyDemand();
+    this.emergencyDispatcher =
+      options?.emergencyDispatcher ??
+      new EmergencyDispatcher(
+        (position, serviceType) => this.coverageMap.getCoverageAt(position, serviceType),
+        {
+          gridWidth,
+          gridHeight,
+          ...options?.emergencyConfig
+        }
       );
-      this.coverageGrid.set(serviceType, grid);
-    });
   }
 
   addServiceBuilding(building: ServiceBuilding): void {
     this.serviceBuildings.set(building.id, building);
-    this.updateServiceCoverage(building);
+    this.coverageMap.updateForBuilding(building);
   }
 
   removeServiceBuilding(buildingId: string): void {
-    const building = this.serviceBuildings.get(buildingId);
-    if (building) {
-      this.serviceBuildings.delete(buildingId);
-      this.recalculateAllCoverage();
+    if (this.serviceBuildings.delete(buildingId)) {
+      this.coverageMap.rebuild(this.serviceBuildings.values());
     }
-  }
-
-  private updateServiceCoverage(building: ServiceBuilding): void {
-    const coverage: ServiceCoverage = {
-      position: building.position,
-      radius: building.coverage,
-      effectiveness: building.efficiency * (building.staffing / building.maxStaffing),
-      serviceType: building.serviceType
-    };
-
-    this.serviceCoverage.push(coverage);
-    this.updateCoverageGrid(coverage);
-  }
-
-  private updateCoverageGrid(coverage: ServiceCoverage): void {
-    const grid = this.coverageGrid.get(coverage.serviceType);
-    if (!grid) return;
-
-    const centerX = Math.floor(coverage.position.x);
-    const centerY = Math.floor(coverage.position.y);
-    const radius = coverage.radius;
-
-    for (let y = Math.max(0, centerY - radius); y < Math.min(this.gridHeight, centerY + radius + 1); y++) {
-      for (let x = Math.max(0, centerX - radius); x < Math.min(this.gridWidth, centerX + radius + 1); x++) {
-        const distance = Math.sqrt((x - centerX) ** 2 + (y - centerY) ** 2);
-        if (distance <= radius) {
-          const effectiveness = coverage.effectiveness * (1 - distance / radius);
-          grid[y][x] = Math.max(grid[y][x], effectiveness);
-        }
-      }
-    }
-  }
-
-  private recalculateAllCoverage(): void {
-    // Reset all grids
-    this.initializeCoverageGrids();
-    this.serviceCoverage = [];
-
-    // Recalculate coverage for all buildings
-    this.serviceBuildings.forEach(building => {
-      this.updateServiceCoverage(building);
-    });
   }
 
   getCoverageAt(position: Position, serviceType: ServiceType): number {
-    const grid = this.coverageGrid.get(serviceType);
-    if (!grid) return 0;
-
-    const x = Math.floor(position.x);
-    const y = Math.floor(position.y);
-
-    if (x >= 0 && x < this.gridWidth && y >= 0 && y < this.gridHeight) {
-      return grid[y][x];
-    }
-    return 0;
+    return this.coverageMap.getCoverageAt(position, serviceType);
   }
 
   updateDemand(buildings: Building[], population: number): void {
-    // Calculate service demand based on population and buildings
-    this.serviceDemand = {
-      police: Math.floor(population * 0.002), // 2 per 1000 people
-      fire: Math.floor(population * 0.001), // 1 per 1000 people
-      healthcare: Math.floor(population * 0.003), // 3 per 1000 people
-      education: Math.floor(population * 0.005), // 5 per 1000 people
-      water: Math.floor(population * 1.2), // 120% of population
-      power: Math.floor(population * 1.5), // 150% of population
-      waste: Math.floor(population * 0.8), // 80% of population
-      parks: Math.floor(population * 0.001) // 1 per 1000 people
-    };
-
-    // Adjust demand based on building types
-    buildings.forEach(building => {
-      if (building.typeId === 'commercial') {
-        this.serviceDemand.police += 2;
-        this.serviceDemand.waste += 5;
-      } else if (building.typeId === 'industrial') {
-        this.serviceDemand.fire += 3;
-        this.serviceDemand.power += 10;
-        this.serviceDemand.waste += 8;
-      }
-    });
+    this.serviceDemand = this.demandModel.calculate(population, buildings);
   }
 
   spawnEmergencyEvent(type: EmergencyEvent['type'], position: Position, severity: number): void {
-    const event: EmergencyEvent = {
-      id: `emergency_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
-      type,
-      position,
-      severity,
-      startTime: Date.now(),
-      duration: severity * 30000, // 30 seconds per severity level
-      resolved: false
-    };
-
-    this.emergencyEvents.push(event);
-    this.respondToEmergency(event);
-  }
-
-  private respondToEmergency(event: EmergencyEvent): void {
-    const serviceType = this.getServiceTypeForEmergency(event.type);
-    const coverage = this.getCoverageAt(event.position, serviceType);
-    
-    // Response effectiveness based on coverage
-    const responseTime = Math.max(1000, 10000 - (coverage * 8000)); // 1-10 seconds
-    const effectiveness = Math.min(1, coverage * 1.2);
-
-    setTimeout(() => {
-      event.resolved = true;
-      event.duration = Math.floor(event.duration * (1 - effectiveness));
-    }, responseTime);
-  }
-
-  private getServiceTypeForEmergency(emergencyType: EmergencyEvent['type']): ServiceType {
-    switch (emergencyType) {
-      case 'fire': return ServiceType.FIRE;
-      case 'crime': return ServiceType.POLICE;
-      case 'medical': return ServiceType.HEALTHCARE;
-      case 'accident': return ServiceType.POLICE;
-      default: return ServiceType.POLICE;
-    }
+    this.emergencyDispatcher.spawnEmergencyEvent(type, position, severity);
   }
 
   update(deltaTime: number): void {
-    // Update service buildings
     this.serviceBuildings.forEach(building => {
-      // Simulate service usage
       const demandAtLocation = this.getDemandAtLocation(building.position, building.serviceType);
       building.currentLoad = Math.min(building.capacity, demandAtLocation);
-      
-      // Efficiency decreases with overload
+
       if (building.currentLoad > building.capacity * 0.8) {
         building.efficiency = Math.max(0.5, building.efficiency - 0.001);
       } else {
@@ -250,48 +90,26 @@ export class CityServicesSystem {
       }
     });
 
-    // Update emergency events
-    const currentTime = Date.now();
-    this.emergencyEvents = this.emergencyEvents.filter(event => {
-      if (event.resolved || currentTime - event.startTime > event.duration) {
-        return false;
-      }
-      return true;
-    });
-
-    // Randomly spawn emergency events
-    if (Math.random() < 0.001) { // 0.1% chance per update
-      const eventTypes: EmergencyEvent['type'][] = ['fire', 'crime', 'medical', 'accident'];
-      const randomType = eventTypes[Math.floor(Math.random() * eventTypes.length)];
-      const randomPosition: Position = {
-        x: Math.random() * this.gridWidth,
-        y: Math.random() * this.gridHeight
-      };
-      const randomSeverity = Math.floor(Math.random() * 5) + 1;
-      
-      this.spawnEmergencyEvent(randomType, randomPosition, randomSeverity);
-    }
+    this.emergencyDispatcher.update(deltaTime);
   }
 
   private getDemandAtLocation(position: Position, serviceType: ServiceType): number {
-    // Simple demand calculation based on service type
-    const baseDemand = this.serviceDemand[serviceType] || 0;
+    const baseDemand = this.serviceDemand[serviceType as keyof ServiceDemand] ?? 0;
     return Math.floor(baseDemand / Math.max(1, this.serviceBuildings.size));
   }
 
   getServiceStats(serviceType: ServiceType): ServiceStats {
-    const buildings = Array.from(this.serviceBuildings.values())
-      .filter(b => b.serviceType === serviceType);
-    
+    const buildings = Array.from(this.serviceBuildings.values()).filter(b => b.serviceType === serviceType);
+
     if (buildings.length === 0) {
       return { coverage: 0, satisfaction: 0, efficiency: 0, cost: 0 };
     }
 
     const totalCapacity = buildings.reduce((sum, b) => sum + b.capacity, 0);
-    const totalDemand = this.serviceDemand[serviceType] || 0;
+    const totalDemand = this.serviceDemand[serviceType as keyof ServiceDemand] ?? 0;
     const totalCost = buildings.reduce((sum, b) => sum + b.maintenanceCost, 0);
     const avgEfficiency = buildings.reduce((sum, b) => sum + b.efficiency, 0) / buildings.length;
-    
+
     const coverage = Math.min(1, totalCapacity / Math.max(1, totalDemand));
     const satisfaction = coverage * avgEfficiency;
 
@@ -305,16 +123,16 @@ export class CityServicesSystem {
 
   getAllServiceStats(): Record<ServiceType, ServiceStats> {
     const stats: Record<ServiceType, ServiceStats> = {} as Record<ServiceType, ServiceStats>;
-    
-    Object.values(ServiceType).forEach(serviceType => {
+
+    for (const serviceType of Object.values(ServiceType)) {
       stats[serviceType] = this.getServiceStats(serviceType);
-    });
+    }
 
     return stats;
   }
 
   getActiveEmergencies(): EmergencyEvent[] {
-    return this.emergencyEvents.filter(event => !event.resolved);
+    return this.emergencyDispatcher.getActiveEmergencies();
   }
 
   getServiceBuildings(serviceType?: ServiceType): ServiceBuilding[] {

--- a/packages/engine/src/simulation/cityServices.types.ts
+++ b/packages/engine/src/simulation/cityServices.types.ts
@@ -1,0 +1,69 @@
+export interface Position {
+  x: number;
+  y: number;
+}
+
+export interface Building {
+  id: string;
+  typeId: string;
+  position: Position;
+  x: number;
+  y: number;
+}
+
+export enum ServiceType {
+  POLICE = 'police',
+  FIRE = 'fire',
+  HEALTHCARE = 'healthcare',
+  EDUCATION = 'education',
+  WATER = 'water',
+  POWER = 'power',
+  WASTE = 'waste',
+  PARKS = 'parks'
+}
+
+export interface ServiceBuilding extends Building {
+  serviceType: ServiceType;
+  capacity: number;
+  currentLoad: number;
+  efficiency: number;
+  coverage: number;
+  maintenanceCost: number;
+  staffing: number;
+  maxStaffing: number;
+}
+
+export interface ServiceCoverage {
+  position: Position;
+  radius: number;
+  effectiveness: number;
+  serviceType: ServiceType;
+}
+
+export interface ServiceDemand {
+  police: number;
+  fire: number;
+  healthcare: number;
+  education: number;
+  water: number;
+  power: number;
+  waste: number;
+  parks: number;
+}
+
+export interface ServiceStats {
+  coverage: number;
+  satisfaction: number;
+  efficiency: number;
+  cost: number;
+}
+
+export interface EmergencyEvent {
+  id: string;
+  type: 'fire' | 'crime' | 'medical' | 'accident';
+  position: Position;
+  severity: number;
+  startTime: number;
+  duration: number;
+  resolved: boolean;
+}

--- a/packages/engine/src/simulation/emergencyDispatcher.ts
+++ b/packages/engine/src/simulation/emergencyDispatcher.ts
@@ -1,0 +1,109 @@
+import { ServiceType, type EmergencyEvent, type Position } from './cityServices.types';
+
+export type EmergencyDispatcherConfig = {
+  gridWidth: number;
+  gridHeight: number;
+  randomEventChance?: number;
+  severityDurationMultiplier?: number;
+  responseTimeBounds?: { min: number; max: number };
+  coverageEffectivenessMultiplier?: number;
+};
+
+const DEFAULT_EVENT_TYPES: EmergencyEvent['type'][] = ['fire', 'crime', 'medical', 'accident'];
+
+export class EmergencyDispatcher {
+  private events: EmergencyEvent[] = [];
+
+  constructor(
+    private readonly coverageLookup: (position: Position, serviceType: ServiceType) => number,
+    private readonly config: EmergencyDispatcherConfig,
+    private readonly random: () => number = Math.random
+  ) {}
+
+  spawnEmergencyEvent(type: EmergencyEvent['type'], position: Position, severity: number): EmergencyEvent {
+    const idFragment = this.random().toString(36).slice(2, 11) || Date.now().toString(36);
+    const event: EmergencyEvent = {
+      id: `emergency_${Date.now()}_${idFragment}`,
+      type,
+      position,
+      severity,
+      startTime: Date.now(),
+      duration: severity * (this.config.severityDurationMultiplier ?? 30000),
+      resolved: false
+    };
+
+    this.events.push(event);
+    this.respondToEmergency(event);
+    return event;
+  }
+
+  update(deltaTime?: number): void {
+    void deltaTime;
+    this.cleanupResolvedEvents();
+    this.maybeSpawnRandomEvent();
+  }
+
+  getActiveEmergencies(): EmergencyEvent[] {
+    return this.events.filter(event => !event.resolved);
+  }
+
+  private cleanupResolvedEvents(): void {
+    const now = Date.now();
+    this.events = this.events.filter(event => {
+      if (event.resolved) {
+        return false;
+      }
+      if (now - event.startTime > event.duration) {
+        return false;
+      }
+      return true;
+    });
+  }
+
+  private maybeSpawnRandomEvent(): void {
+    const chance = this.config.randomEventChance ?? 0.001;
+    if (this.random() >= chance) {
+      return;
+    }
+
+    const type = DEFAULT_EVENT_TYPES[Math.floor(this.random() * DEFAULT_EVENT_TYPES.length)];
+    const position: Position = {
+      x: this.random() * this.config.gridWidth,
+      y: this.random() * this.config.gridHeight
+    };
+    const severity = Math.floor(this.random() * 5) + 1;
+
+    this.spawnEmergencyEvent(type, position, severity);
+  }
+
+  private respondToEmergency(event: EmergencyEvent): void {
+    const serviceType = this.getServiceTypeForEmergency(event.type);
+    const coverage = this.coverageLookup(event.position, serviceType);
+
+    const bounds = this.config.responseTimeBounds ?? { min: 1000, max: 10000 };
+    const coverageEffect = this.config.coverageEffectivenessMultiplier ?? 1.2;
+
+    const responseRange = Math.max(bounds.max - bounds.min, 0);
+    const responseTime = Math.max(bounds.min, bounds.max - coverage * responseRange);
+    const effectiveness = Math.min(1, coverage * coverageEffect);
+
+    setTimeout(() => {
+      event.resolved = true;
+      event.duration = Math.floor(event.duration * (1 - effectiveness));
+    }, responseTime);
+  }
+
+  private getServiceTypeForEmergency(emergencyType: EmergencyEvent['type']): ServiceType {
+    switch (emergencyType) {
+      case 'fire':
+        return ServiceType.FIRE;
+      case 'crime':
+        return ServiceType.POLICE;
+      case 'medical':
+        return ServiceType.HEALTHCARE;
+      case 'accident':
+      default:
+        return ServiceType.POLICE;
+    }
+  }
+}

--- a/packages/engine/src/simulation/serviceCoverageMap.ts
+++ b/packages/engine/src/simulation/serviceCoverageMap.ts
@@ -1,0 +1,74 @@
+import { ServiceType, type Position, type ServiceBuilding } from './cityServices.types';
+
+export class ServiceCoverageMap {
+  private coverageGrid: Map<ServiceType, number[][]> = new Map();
+
+  constructor(private readonly gridWidth: number, private readonly gridHeight: number) {
+    this.reset();
+  }
+
+  reset(): void {
+    Object.values(ServiceType).forEach(serviceType => {
+      const grid = Array.from({ length: this.gridHeight }, () => Array(this.gridWidth).fill(0));
+      this.coverageGrid.set(serviceType, grid);
+    });
+  }
+
+  updateForBuilding(building: ServiceBuilding): void {
+    const effectiveness = building.efficiency * (building.maxStaffing > 0 ? building.staffing / building.maxStaffing : 0);
+    this.applyCoverage({
+      position: building.position,
+      radius: building.coverage,
+      effectiveness,
+      serviceType: building.serviceType
+    });
+  }
+
+  rebuild(buildings: Iterable<ServiceBuilding>): void {
+    this.reset();
+    for (const building of buildings) {
+      this.updateForBuilding(building);
+    }
+  }
+
+  getCoverageAt(position: Position, serviceType: ServiceType): number {
+    const grid = this.coverageGrid.get(serviceType);
+    if (!grid) {
+      return 0;
+    }
+
+    const x = Math.floor(position.x);
+    const y = Math.floor(position.y);
+
+    if (x >= 0 && x < this.gridWidth && y >= 0 && y < this.gridHeight) {
+      return grid[y][x];
+    }
+
+    return 0;
+  }
+
+  private applyCoverage({ position, radius, effectiveness, serviceType }: {
+    position: Position;
+    radius: number;
+    effectiveness: number;
+    serviceType: ServiceType;
+  }): void {
+    const grid = this.coverageGrid.get(serviceType);
+    if (!grid) {
+      return;
+    }
+
+    const centerX = Math.floor(position.x);
+    const centerY = Math.floor(position.y);
+
+    for (let y = Math.max(0, centerY - radius); y < Math.min(this.gridHeight, centerY + radius + 1); y++) {
+      for (let x = Math.max(0, centerX - radius); x < Math.min(this.gridWidth, centerX + radius + 1); x++) {
+        const distance = Math.sqrt((x - centerX) ** 2 + (y - centerY) ** 2);
+        if (distance <= radius) {
+          const cellEffectiveness = effectiveness * (radius > 0 ? 1 - distance / radius : 0);
+          grid[y][x] = Math.max(grid[y][x], cellEffectiveness);
+        }
+      }
+    }
+  }
+}

--- a/packages/engine/src/simulation/serviceDemandModel.ts
+++ b/packages/engine/src/simulation/serviceDemandModel.ts
@@ -1,0 +1,72 @@
+import { ServiceType, type Building, type ServiceDemand } from './cityServices.types';
+
+type DemandConfig = {
+  basePerCapita: Partial<Record<ServiceType, number>>;
+  buildingAdjustments: Record<string, Partial<Record<ServiceType, number>>>;
+};
+
+const DEFAULT_DEMAND_CONFIG: DemandConfig = {
+  basePerCapita: {
+    [ServiceType.POLICE]: 0.002,
+    [ServiceType.FIRE]: 0.001,
+    [ServiceType.HEALTHCARE]: 0.003,
+    [ServiceType.EDUCATION]: 0.005,
+    [ServiceType.WATER]: 1.2,
+    [ServiceType.POWER]: 1.5,
+    [ServiceType.WASTE]: 0.8,
+    [ServiceType.PARKS]: 0.001
+  },
+  buildingAdjustments: {
+    commercial: {
+      [ServiceType.POLICE]: 2,
+      [ServiceType.WASTE]: 5
+    },
+    industrial: {
+      [ServiceType.FIRE]: 3,
+      [ServiceType.POWER]: 10,
+      [ServiceType.WASTE]: 8
+    }
+  }
+};
+
+export class ServiceDemandModel {
+  constructor(private readonly config: DemandConfig = DEFAULT_DEMAND_CONFIG) {}
+
+  createEmptyDemand(): ServiceDemand {
+    const demand = {} as ServiceDemand;
+    for (const serviceType of Object.values(ServiceType)) {
+      demand[serviceType as keyof ServiceDemand] = 0;
+    }
+    return demand;
+  }
+
+  calculate(population: number, buildings: Building[]): ServiceDemand {
+    const demand = this.createEmptyDemand();
+
+    for (const serviceType of Object.values(ServiceType)) {
+      const ratio = this.config.basePerCapita[serviceType] ?? 0;
+      demand[serviceType as keyof ServiceDemand] = Math.floor(population * ratio);
+    }
+
+    for (const building of buildings) {
+      const adjustment = this.config.buildingAdjustments[building.typeId];
+      if (!adjustment) continue;
+
+      for (const [serviceType, delta] of Object.entries(adjustment)) {
+        const key = serviceType as keyof ServiceDemand;
+        demand[key] += delta ?? 0;
+      }
+    }
+
+    for (const serviceType of Object.values(ServiceType)) {
+      const key = serviceType as keyof ServiceDemand;
+      if (demand[key] < 0) {
+        demand[key] = 0;
+      }
+    }
+
+    return demand;
+  }
+}
+
+export { DEFAULT_DEMAND_CONFIG };


### PR DESCRIPTION
## Summary
- extract shared city service types and refactor `CityServicesSystem` to compose dedicated collaborators for coverage, demand, and emergencies
- add `ServiceCoverageMap` to own coverage matrices and `ServiceDemandModel` for configurable demand calculations
- create an `EmergencyDispatcher` that encapsulates spawning/resolving events and expose the utilities through `CityServicesSystem`

## Testing
- npm run lint
- npm run test
- npm run build *(fails: pre-existing type export error in packages/engine/src/simulation/workers/workerProgressionService.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68ca96e7d0f88325a4ba4b436b8e0897