### PR TITLE
Refactor viewport manager into composable hooks

### DIFF
--- a/packages/engine/src/simulation/workers/workerProgressionService.ts
+++ b/packages/engine/src/simulation/workers/workerProgressionService.ts
@@ -1,5 +1,5 @@
 import type { GameTime } from '../../types/gameTime';
-import type { Citizen } from '../citizenBehavior';
+import type { Citizen } from '../citizens/citizen';
 import type { JobRole, WorkerProfile, Workplace } from './types';
 import type { LaborMarket } from './laborMarketService';
 import { calculateWageAdjustment, checkCareerProgression } from './career';

--- a/src/components/game/viewport/viewportChangeWatcher.ts
+++ b/src/components/game/viewport/viewportChangeWatcher.ts
@@ -1,0 +1,113 @@
+import type { Viewport } from "pixi-viewport";
+
+export interface ViewportBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface ViewportChangeWatcherOptions {
+  viewport: Viewport;
+  onChange: (bounds: ViewportBounds, scale: number) => void;
+  debounceMs?: number;
+  positionThreshold?: number;
+  sizeThreshold?: number;
+  scaleThreshold?: number;
+  emitInitial?: boolean;
+}
+
+const DEFAULT_DEBOUNCE_MS = 150;
+const DEFAULT_POSITION_THRESHOLD = 50;
+const DEFAULT_SIZE_THRESHOLD = 100;
+const DEFAULT_SCALE_THRESHOLD = 0.05;
+
+function getViewportBounds(viewport: Viewport): ViewportBounds {
+  return {
+    x: viewport.left,
+    y: viewport.top,
+    width: viewport.worldScreenWidth,
+    height: viewport.worldScreenHeight,
+  };
+}
+
+function getViewportScale(viewport: Viewport): number {
+  const { scale } = viewport;
+  if (!scale) {
+    return 1;
+  }
+  if (typeof scale.x === "number") {
+    return scale.x;
+  }
+  if (typeof scale.y === "number") {
+    return scale.y;
+  }
+  return 1;
+}
+
+export function createViewportChangeWatcher({
+  viewport,
+  onChange,
+  debounceMs = DEFAULT_DEBOUNCE_MS,
+  positionThreshold = DEFAULT_POSITION_THRESHOLD,
+  sizeThreshold = DEFAULT_SIZE_THRESHOLD,
+  scaleThreshold = DEFAULT_SCALE_THRESHOLD,
+  emitInitial = true,
+}: ViewportChangeWatcherOptions): () => void {
+  const events = ["moved", "zoomed", "moved-end", "zoomed-end"] as const;
+
+  let lastBounds = getViewportBounds(viewport);
+  let lastScale = getViewportScale(viewport);
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+
+  const scheduleEmit = (bounds: ViewportBounds, scale: number) => {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+
+    timeout = setTimeout(() => {
+      onChange(bounds, scale);
+      lastBounds = bounds;
+      lastScale = scale;
+    }, debounceMs);
+  };
+
+  const handleViewportChange = () => {
+    const bounds = getViewportBounds(viewport);
+    const scale = getViewportScale(viewport);
+
+    const positionChanged =
+      Math.abs(bounds.x - lastBounds.x) > positionThreshold ||
+      Math.abs(bounds.y - lastBounds.y) > positionThreshold;
+    const sizeChanged =
+      Math.abs(bounds.width - lastBounds.width) > sizeThreshold ||
+      Math.abs(bounds.height - lastBounds.height) > sizeThreshold;
+    const scaleChanged = Math.abs(scale - lastScale) > scaleThreshold;
+
+    if (positionChanged || sizeChanged || scaleChanged) {
+      scheduleEmit(bounds, scale);
+    }
+  };
+
+  for (const event of events) {
+    viewport.on(event, handleViewportChange);
+  }
+
+  if (emitInitial) {
+    const initialBounds = getViewportBounds(viewport);
+    const initialScale = getViewportScale(viewport);
+    onChange(initialBounds, initialScale);
+    lastBounds = initialBounds;
+    lastScale = initialScale;
+  }
+
+  return () => {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+
+    for (const event of events) {
+      viewport.off(event, handleViewportChange);
+    }
+  };
+}

--- a/src/hooks/useViewportPerformanceMonitor.ts
+++ b/src/hooks/useViewportPerformanceMonitor.ts
@@ -1,0 +1,78 @@
+import { useEffect } from "react";
+import type { Ticker } from "pixi.js";
+
+export interface PerformanceMonitorLogger {
+  warn: (message: string) => void;
+}
+
+export interface UseViewportPerformanceMonitorOptions {
+  ticker: Ticker | null | undefined;
+  enabled?: boolean;
+  monitoringInterval?: number;
+  sampleSize?: number;
+  fpsWarningThreshold?: number;
+  logger?: PerformanceMonitorLogger;
+  onSample?: (fps: number, averageFps: number) => void;
+}
+
+const DEFAULT_MONITORING_INTERVAL = 60;
+const DEFAULT_SAMPLE_SIZE = 5;
+const DEFAULT_WARNING_THRESHOLD = 30;
+
+export function useViewportPerformanceMonitor({
+  ticker,
+  enabled = true,
+  monitoringInterval = DEFAULT_MONITORING_INTERVAL,
+  sampleSize = DEFAULT_SAMPLE_SIZE,
+  fpsWarningThreshold = DEFAULT_WARNING_THRESHOLD,
+  logger,
+  onSample,
+}: UseViewportPerformanceMonitorOptions): void {
+  useEffect(() => {
+    if (!enabled || !ticker) {
+      return undefined;
+    }
+
+    let frameCount = 0;
+    let lastTime = performance.now();
+    const fpsHistory: number[] = [];
+
+    const recordSample = (fps: number) => {
+      fpsHistory.push(fps);
+      if (fpsHistory.length > sampleSize) {
+        fpsHistory.shift();
+      }
+      const total = fpsHistory.reduce((sum, value) => sum + value, 0);
+      const average = fpsHistory.length > 0 ? total / fpsHistory.length : fps;
+      onSample?.(fps, average);
+      if (fps < fpsWarningThreshold) {
+        logger?.warn(`Low FPS detected: ${fps} (avg: ${average.toFixed(1)})`);
+      }
+    };
+
+    const monitorPerformance = () => {
+      frameCount += 1;
+      if (frameCount < monitoringInterval) {
+        return;
+      }
+
+      const now = performance.now();
+      const elapsed = now - lastTime;
+      if (elapsed <= 0) {
+        return;
+      }
+
+      const fps = Math.round((frameCount * 1000) / elapsed);
+      recordSample(fps);
+
+      frameCount = 0;
+      lastTime = now;
+    };
+
+    ticker.add(monitorPerformance);
+
+    return () => {
+      ticker.remove(monitorPerformance);
+    };
+  }, [ticker, enabled, monitoringInterval, sampleSize, fpsWarningThreshold, logger, onSample]);
+}

--- a/src/hooks/useViewportSetup.ts
+++ b/src/hooks/useViewportSetup.ts
@@ -1,0 +1,169 @@
+import { useEffect } from "react";
+import type { Viewport } from "pixi-viewport";
+
+export interface ViewportCenterOptions {
+  x: number;
+  y: number;
+}
+
+export interface ViewportZoomOptions {
+  value: number;
+  animate?: boolean;
+}
+
+type PluginOption<T> = T | boolean | undefined;
+
+type DragOptions = Parameters<Viewport["drag"]>[0];
+type PinchOptions = Parameters<Viewport["pinch"]>[0];
+type WheelOptions = Parameters<Viewport["wheel"]>[0];
+type DecelerateOptions = Parameters<Viewport["decelerate"]>[0];
+type ClampOptions = Parameters<Viewport["clamp"]>[0];
+type ClampZoomOptions = Parameters<Viewport["clampZoom"]>[0];
+
+export interface UseViewportSetupOptions {
+  viewport: Viewport | null | undefined;
+  zoom?: ViewportZoomOptions | null;
+  center?: ViewportCenterOptions | null;
+  clamp?: PluginOption<ClampOptions>;
+  clampZoom?: PluginOption<ClampZoomOptions>;
+  drag?: PluginOption<DragOptions>;
+  pinch?: PluginOption<PinchOptions>;
+  wheel?: PluginOption<WheelOptions>;
+  decelerate?: PluginOption<DecelerateOptions>;
+}
+
+function shouldEnablePlugin<T>(option: PluginOption<T>): option is T | true {
+  return option !== undefined && option !== false;
+}
+
+export function useViewportSetup({
+  viewport,
+  zoom,
+  center,
+  clamp,
+  clampZoom,
+  drag,
+  pinch,
+  wheel,
+  decelerate,
+}: UseViewportSetupOptions): void {
+  const zoomValue = zoom?.value;
+  const zoomAnimate = zoom?.animate ?? true;
+
+  useEffect(() => {
+    if (!viewport || zoomValue === undefined) return;
+
+    viewport.setZoom(zoomValue, zoomAnimate);
+  }, [viewport, zoomValue, zoomAnimate]);
+
+  const centerX = center?.x;
+  const centerY = center?.y;
+
+  useEffect(() => {
+    if (!viewport || centerX === undefined || centerY === undefined) return;
+
+    viewport.moveCenter(centerX, centerY);
+  }, [viewport, centerX, centerY]);
+
+  useEffect(() => {
+    if (!viewport || clamp === undefined) return;
+
+    viewport.plugins.remove("clamp");
+    if (shouldEnablePlugin(clamp)) {
+      if (clamp === true) {
+        viewport.clamp();
+      } else {
+        viewport.clamp(clamp ?? undefined);
+      }
+    }
+
+    return () => {
+      viewport.plugins.remove("clamp");
+    };
+  }, [viewport, clamp]);
+
+  useEffect(() => {
+    if (!viewport || clampZoom === undefined) return;
+
+    viewport.plugins.remove("clamp-zoom");
+    if (shouldEnablePlugin(clampZoom)) {
+      if (clampZoom === true) {
+        viewport.clampZoom({});
+      } else {
+        viewport.clampZoom(clampZoom ?? undefined);
+      }
+    }
+
+    return () => {
+      viewport.plugins.remove("clamp-zoom");
+    };
+  }, [viewport, clampZoom]);
+
+  useEffect(() => {
+    if (!viewport || drag === undefined) return;
+
+    viewport.plugins.remove("drag");
+    if (shouldEnablePlugin(drag)) {
+      if (drag === true) {
+        viewport.drag();
+      } else {
+        viewport.drag(drag ?? undefined);
+      }
+    }
+
+    return () => {
+      viewport.plugins.remove("drag");
+    };
+  }, [viewport, drag]);
+
+  useEffect(() => {
+    if (!viewport || pinch === undefined) return;
+
+    viewport.plugins.remove("pinch");
+    if (shouldEnablePlugin(pinch)) {
+      if (pinch === true) {
+        viewport.pinch();
+      } else {
+        viewport.pinch(pinch ?? undefined);
+      }
+    }
+
+    return () => {
+      viewport.plugins.remove("pinch");
+    };
+  }, [viewport, pinch]);
+
+  useEffect(() => {
+    if (!viewport || wheel === undefined) return;
+
+    viewport.plugins.remove("wheel");
+    if (shouldEnablePlugin(wheel)) {
+      if (wheel === true) {
+        viewport.wheel();
+      } else {
+        viewport.wheel(wheel ?? undefined);
+      }
+    }
+
+    return () => {
+      viewport.plugins.remove("wheel");
+    };
+  }, [viewport, wheel]);
+
+  useEffect(() => {
+    if (!viewport || decelerate === undefined) return;
+
+    viewport.plugins.remove("decelerate");
+    if (shouldEnablePlugin(decelerate)) {
+      if (decelerate === true) {
+        viewport.decelerate();
+      } else {
+        viewport.decelerate(decelerate ?? undefined);
+      }
+    }
+
+    return () => {
+      viewport.plugins.remove("decelerate");
+    };
+  }, [viewport, decelerate]);
+}


### PR DESCRIPTION
## Summary
- add a reusable `useViewportSetup` hook and watcher utility so viewport consumers can opt into clamp/drag/zoom behaviors as needed
- update `ViewportManager` to compose the new setup, change watcher, and performance monitor hooks for configurable behavior
- fix the worker progression service to import the exported `Citizen` type so type-checking succeeds

## Testing
- npm run lint
- npm run test
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca96ce30cc83259db06b96e928662c