### PR TITLE
Refactor HUD panel registry into dedicated store and hooks

### DIFF
--- a/src/components/game/hud/__tests__/panelRegistryStore.test.ts
+++ b/src/components/game/hud/__tests__/panelRegistryStore.test.ts
@@ -1,0 +1,96 @@
+import type { FC } from 'react';
+import { describe, expect, it } from 'vitest';
+import type { HUDZone } from '../HUDLayoutSystem';
+import {
+  createPanelRegistryStore,
+  type HUDPanelComponent
+} from '../panelRegistryStore';
+
+const DummyPanel: FC = () => null;
+
+function createPanel(id: string, zone: HUDZone, overrides: Partial<HUDPanelComponent> = {}) {
+  return {
+    config: { id, zone },
+    component: DummyPanel,
+    ...overrides
+  } as HUDPanelComponent;
+}
+
+describe('panelRegistryStore', () => {
+  it('registers panels with responsive defaults', () => {
+    const store = createPanelRegistryStore();
+
+    const panel = createPanel('responsive', 'top-left', {
+      config: {
+        id: 'responsive',
+        zone: 'top-left',
+        responsive: { hideOnMobile: true, collapseOnMobile: true }
+      }
+    });
+
+    store.registerPanel(panel, { screenSize: 'mobile' });
+
+    const storedPanel = store.getPanelById('responsive');
+    expect(storedPanel).toBeDefined();
+    expect(storedPanel?.isVisible).toBe(false);
+    expect(storedPanel?.isCollapsed).toBe(true);
+  });
+
+  it('supports toggling visibility and collapse state', () => {
+    const store = createPanelRegistryStore();
+    const panel = createPanel('toggle', 'top-left');
+    store.registerPanel(panel, { screenSize: 'desktop' });
+
+    store.togglePanelVisibility('toggle');
+    expect(store.getPanelById('toggle')?.isVisible).toBe(false);
+
+    store.togglePanelCollapse('toggle');
+    expect(store.getPanelById('toggle')?.isCollapsed).toBe(true);
+  });
+
+  it('updates panel entries with partial data', () => {
+    const store = createPanelRegistryStore();
+    const panel = createPanel('update', 'top-left');
+    store.registerPanel(panel, { screenSize: 'desktop' });
+
+    store.updatePanel('update', { isVisible: false, props: { label: 'Test' } });
+
+    const updated = store.getPanelById('update');
+    expect(updated?.isVisible).toBe(false);
+    expect(updated?.props).toMatchObject({ label: 'Test' });
+  });
+
+  it('reconciles responsive state when screen size changes', () => {
+    const store = createPanelRegistryStore();
+    const panel = createPanel('responsive-change', 'top-left', {
+      config: {
+        id: 'responsive-change',
+        zone: 'top-left',
+        responsive: { hideOnMobile: true, collapseOnMobile: true }
+      }
+    });
+
+    store.registerPanel(panel, { screenSize: 'desktop' });
+    expect(store.getPanelById('responsive-change')?.isVisible).toBe(true);
+
+    store.reconcileResponsiveState('mobile');
+    const reconciled = store.getPanelById('responsive-change');
+    expect(reconciled?.isVisible).toBe(false);
+    expect(reconciled?.isCollapsed).toBe(true);
+  });
+
+  it('returns panels sorted by priority for a zone', () => {
+    const store = createPanelRegistryStore();
+    store.registerPanel(
+      createPanel('low', 'top-left', { config: { id: 'low', zone: 'top-left', priority: 1 } }),
+      { screenSize: 'desktop' }
+    );
+    store.registerPanel(
+      createPanel('high', 'top-left', { config: { id: 'high', zone: 'top-left', priority: 10 } }),
+      { screenSize: 'desktop' }
+    );
+
+    const panels = store.getPanelsForZone('top-left');
+    expect(panels.map(p => p.config.id)).toEqual(['high', 'low']);
+  });
+});

--- a/src/components/game/hud/containers/HUDAutoZone.tsx
+++ b/src/components/game/hud/containers/HUDAutoZone.tsx
@@ -1,0 +1,30 @@
+import { HUDZone } from '../HUDLayoutSystem';
+import { useHUDPanelRegistry } from '../HUDPanelRegistry';
+import { HUDPanelWrapper } from './HUDPanelWrapper';
+
+export interface HUDAutoZoneProps {
+  zone: HUDZone;
+  className?: string;
+}
+
+export function HUDAutoZone({ zone, className = '' }: HUDAutoZoneProps) {
+  const { getPanelsForZone } = useHUDPanelRegistry();
+  const panels = getPanelsForZone(zone);
+
+  if (panels.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={`hud-auto-zone ${className}`} data-zone={zone}>
+      {panels.map(panel => {
+        const Component = panel.component;
+        return (
+          <HUDPanelWrapper key={panel.config.id} panelId={panel.config.id}>
+            <Component {...(panel.props || {})} />
+          </HUDPanelWrapper>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/game/hud/containers/HUDPanelWrapper.tsx
+++ b/src/components/game/hud/containers/HUDPanelWrapper.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from 'react';
+import { useHUDPanelRegistry } from '../HUDPanelRegistry';
+
+export interface HUDPanelWrapperProps {
+  panelId: string;
+  children?: ReactNode;
+  className?: string;
+}
+
+export function HUDPanelWrapper({ panelId, children, className = '' }: HUDPanelWrapperProps) {
+  const { getPanelById } = useHUDPanelRegistry();
+  const panel = getPanelById(panelId);
+
+  if (!panel || !panel.isVisible) {
+    return null;
+  }
+
+  const { config } = panel;
+  const animationClass = config.animation?.enter || 'animate-fade-in';
+  const collapsedClass = panel.isCollapsed ? 'opacity-50 scale-95' : '';
+
+  return (
+    <div
+      className={`${animationClass} ${collapsedClass} ${className} transition-all duration-200`}
+      role={config.accessibility?.role}
+      aria-label={config.accessibility?.ariaLabel}
+      tabIndex={config.accessibility?.tabIndex}
+      data-panel-id={panelId}
+      data-panel-zone={config.zone}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/game/hud/containers/index.ts
+++ b/src/components/game/hud/containers/index.ts
@@ -1,0 +1,2 @@
+export * from './HUDPanelWrapper';
+export * from './HUDAutoZone';

--- a/src/components/game/hud/panelRegistryStore.ts
+++ b/src/components/game/hud/panelRegistryStore.ts
@@ -1,0 +1,215 @@
+import type { ComponentType } from 'react';
+import { HUDZone, ScreenSize } from './HUDLayoutSystem';
+
+export interface HUDPanelConfig {
+  id: string;
+  zone: HUDZone;
+  priority?: number;
+  persistent?: boolean;
+  responsive?: {
+    hideOnMobile?: boolean;
+    hideOnTablet?: boolean;
+    collapseOnMobile?: boolean;
+  };
+  accessibility?: {
+    ariaLabel?: string;
+    role?: string;
+    tabIndex?: number;
+  };
+  animation?: {
+    enter?: string;
+    exit?: string;
+    duration?: number;
+  };
+}
+
+export interface HUDPanelComponent<P extends object = Record<string, never>> {
+  config: HUDPanelConfig;
+  component: ComponentType<P>;
+  props?: Partial<P>;
+  isVisible?: boolean;
+  isCollapsed?: boolean;
+}
+
+type HUDPanelRegistryEntry<P extends object = Record<string, never>> = HUDPanelComponent<P> & {
+  isVisible: boolean;
+  isCollapsed: boolean;
+};
+
+export type AnyHUDPanelRegistryEntry = HUDPanelRegistryEntry<object>;
+
+export type HUDPanelUpdate<P extends object = Record<string, never>> = Partial<
+  Pick<HUDPanelRegistryEntry<P>, 'props' | 'isVisible' | 'isCollapsed'>
+>;
+
+export interface PanelRegistryStore {
+  getPanels(): Map<string, AnyHUDPanelRegistryEntry>;
+  getSnapshot(): Map<string, AnyHUDPanelRegistryEntry>;
+  subscribe(listener: (panels: Map<string, AnyHUDPanelRegistryEntry>) => void): () => void;
+  registerPanel<P extends object>(panel: HUDPanelComponent<P>, options: { screenSize: ScreenSize }): void;
+  unregisterPanel(panelId: string): void;
+  updatePanel<P extends object>(panelId: string, updates: HUDPanelUpdate<P>): void;
+  togglePanelVisibility(panelId: string): void;
+  togglePanelCollapse(panelId: string): void;
+  getPanelsForZone(zone: HUDZone): AnyHUDPanelRegistryEntry[];
+  getPanelById(panelId: string): AnyHUDPanelRegistryEntry | undefined;
+  reconcileResponsiveState(screenSize: ScreenSize): void;
+}
+
+type Listener = (panels: Map<string, AnyHUDPanelRegistryEntry>) => void;
+
+type ResponsiveState = {
+  isVisible: boolean;
+  isCollapsed: boolean;
+};
+
+function deriveResponsiveState(config: HUDPanelConfig, screenSize: ScreenSize): ResponsiveState {
+  const shouldHide =
+    (screenSize === 'mobile' && config.responsive?.hideOnMobile) ||
+    (screenSize === 'tablet' && config.responsive?.hideOnTablet);
+
+  const shouldCollapse = Boolean(screenSize === 'mobile' && config.responsive?.collapseOnMobile);
+
+  return {
+    isVisible: !shouldHide,
+    isCollapsed: shouldCollapse
+  };
+}
+
+function sortPanelsByPriority(panels: Iterable<AnyHUDPanelRegistryEntry>): AnyHUDPanelRegistryEntry[] {
+  return Array.from(panels).sort((a, b) => (b.config.priority || 0) - (a.config.priority || 0));
+}
+
+export function createPanelRegistryStore(
+  initialPanels: Iterable<[string, AnyHUDPanelRegistryEntry]> = []
+): PanelRegistryStore {
+  let panels = new Map<string, AnyHUDPanelRegistryEntry>(initialPanels);
+  const listeners = new Set<Listener>();
+
+  const notify = () => {
+    listeners.forEach(listener => listener(panels));
+  };
+
+  const setPanels = (nextPanels: Map<string, AnyHUDPanelRegistryEntry>) => {
+    if (panels === nextPanels) return;
+    panels = nextPanels;
+    notify();
+  };
+
+  const updatePanelEntry = (
+    panelId: string,
+    updater: (entry: AnyHUDPanelRegistryEntry) => AnyHUDPanelRegistryEntry
+  ) => {
+    const existing = panels.get(panelId);
+    if (!existing) return;
+
+    const nextEntry = updater(existing);
+    if (nextEntry === existing) {
+      return;
+    }
+
+    const nextPanels = new Map(panels);
+    nextPanels.set(panelId, nextEntry);
+    setPanels(nextPanels);
+  };
+
+  const registerPanel = <P extends object>(
+    panel: HUDPanelComponent<P>,
+    { screenSize }: { screenSize: ScreenSize }
+  ) => {
+    const responsiveState = deriveResponsiveState(panel.config, screenSize);
+    const entry: HUDPanelRegistryEntry<P> = {
+      ...panel,
+      isVisible: panel.isVisible ?? responsiveState.isVisible,
+      isCollapsed: panel.isCollapsed ?? responsiveState.isCollapsed
+    };
+
+    const nextPanels = new Map(panels);
+    nextPanels.set(panel.config.id, entry as AnyHUDPanelRegistryEntry);
+    setPanels(nextPanels);
+  };
+
+  const unregisterPanel = (panelId: string) => {
+    if (!panels.has(panelId)) return;
+    const nextPanels = new Map(panels);
+    nextPanels.delete(panelId);
+    setPanels(nextPanels);
+  };
+
+  const updatePanel = <P extends object>(panelId: string, updates: HUDPanelUpdate<P>) => {
+    updatePanelEntry(panelId, panel => ({
+      ...panel,
+      ...updates
+    }));
+  };
+
+  const togglePanelVisibility = (panelId: string) => {
+    updatePanelEntry(panelId, panel => ({
+      ...panel,
+      isVisible: !panel.isVisible
+    }));
+  };
+
+  const togglePanelCollapse = (panelId: string) => {
+    updatePanelEntry(panelId, panel => ({
+      ...panel,
+      isCollapsed: !panel.isCollapsed
+    }));
+  };
+
+  const getPanelsForZone = (zone: HUDZone) => {
+    const zonePanels = Array.from(panels.values()).filter(
+      panel => panel.config.zone === zone && panel.isVisible
+    );
+    return sortPanelsByPriority(zonePanels);
+  };
+
+  const getPanelById = (panelId: string) => panels.get(panelId);
+
+  const reconcileResponsiveState = (screenSize: ScreenSize) => {
+    let changed = false;
+    const nextPanels = new Map(panels);
+
+    panels.forEach((panel, panelId) => {
+      const responsiveState = deriveResponsiveState(panel.config, screenSize);
+      if (
+        panel.isVisible !== responsiveState.isVisible ||
+        panel.isCollapsed !== responsiveState.isCollapsed
+      ) {
+        nextPanels.set(panelId, {
+          ...panel,
+          isVisible: responsiveState.isVisible,
+          isCollapsed: responsiveState.isCollapsed
+        });
+        changed = true;
+      }
+    });
+
+    if (changed) {
+      setPanels(nextPanels);
+    }
+  };
+
+  const subscribe = (listener: Listener) => {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  };
+
+  return {
+    getPanels: () => panels,
+    getSnapshot: () => panels,
+    subscribe,
+    registerPanel,
+    unregisterPanel,
+    updatePanel,
+    togglePanelVisibility,
+    togglePanelCollapse,
+    getPanelsForZone,
+    getPanelById,
+    reconcileResponsiveState
+  };
+}
+
+export type { HUDPanelRegistryEntry };

--- a/src/components/game/hud/useLayoutPanelSync.ts
+++ b/src/components/game/hud/useLayoutPanelSync.ts
@@ -1,0 +1,44 @@
+import { useEffect } from 'react';
+import type { HUDZone, HUDLayoutConfig } from './HUDLayoutSystem';
+import type { PanelRegistryStore } from './panelRegistryStore';
+
+export function useLayoutPanelSync(
+  store: PanelRegistryStore,
+  layout: HUDLayoutConfig,
+  getPanelsInZone: (zone: HUDZone) => string[],
+  registerPanel: (zone: HUDZone, panelId: string, priority?: number) => boolean,
+  unregisterPanel: (zone: HUDZone, panelId: string) => void
+) {
+  useEffect(() => {
+    const syncLayoutWithRegistry = () => {
+      const panels = store.getPanels();
+      const currentPanels = Array.from(panels.values());
+
+      currentPanels.forEach(panel => {
+        const { config, isVisible } = panel;
+        const registeredIds = new Set(getPanelsInZone(config.zone));
+        const isRegistered = registeredIds.has(config.id);
+
+        if (isVisible && !isRegistered) {
+          registerPanel(config.zone, config.id, config.priority);
+        } else if (!isVisible && isRegistered) {
+          unregisterPanel(config.zone, config.id);
+        }
+      });
+
+      const panelIds = new Set(panels.keys());
+      (Object.keys(layout.zones) as HUDZone[]).forEach(zone => {
+        const registeredIds = getPanelsInZone(zone);
+        registeredIds.forEach(id => {
+          if (!panelIds.has(id)) {
+            unregisterPanel(zone, id);
+          }
+        });
+      });
+    };
+
+    const unsubscribe = store.subscribe(syncLayoutWithRegistry);
+    syncLayoutWithRegistry();
+    return unsubscribe;
+  }, [store, layout, getPanelsInZone, registerPanel, unregisterPanel]);
+}

--- a/src/components/game/hud/useResponsivePanelVisibility.ts
+++ b/src/components/game/hud/useResponsivePanelVisibility.ts
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import type { ScreenSize } from './HUDLayoutSystem';
+import type { PanelRegistryStore } from './panelRegistryStore';
+
+export function useResponsivePanelVisibility(store: PanelRegistryStore, screenSize: ScreenSize) {
+  useEffect(() => {
+    const applyResponsiveState = () => {
+      store.reconcileResponsiveState(screenSize);
+    };
+
+    applyResponsiveState();
+    return store.subscribe(applyResponsiveState);
+  }, [store, screenSize]);
+}


### PR DESCRIPTION
## Summary
- extract panel mutation logic into a pure `panelRegistryStore` with imperative helpers and responsive reconciliation support
- update `HUDPanelRegistryProvider` to subscribe to the store, wire new `useResponsivePanelVisibility` and `useLayoutPanelSync` hooks, and delegate layout/visibility syncing
- move the wrapper and auto-zone presenters into `hud/containers/` and add vitest coverage for the store utilities

## Testing
- npm run lint
- npm run test
- CI=1 npm run build (fails: packages/engine/src/simulation/workers/workerProgressionService.ts:2:15 Module '"../citizenBehavior"' declares 'Citizen' locally, but it is not exported.)


------
https://chatgpt.com/codex/tasks/task_e_68ca96c693f8832591d734353861034d