### PR TITLE
Refactor animated citizens visuals

### DIFF
--- a/packages/engine/src/simulation/workers/workerProgressionService.ts
+++ b/packages/engine/src/simulation/workers/workerProgressionService.ts
@@ -1,5 +1,5 @@
 import type { GameTime } from '../../types/gameTime';
-import type { Citizen } from '../citizenBehavior';
+import type { Citizen } from '../citizens/citizen';
 import type { JobRole, WorkerProfile, Workplace } from './types';
 import type { LaborMarket } from './laborMarketService';
 import { calculateWageAdjustment, checkCareerProgression } from './career';

--- a/packages/engine/src/visuals/citizens.ts
+++ b/packages/engine/src/visuals/citizens.ts
@@ -1,0 +1,206 @@
+export type AnimatedCitizenType = 'worker' | 'trader' | 'citizen';
+export type AnimatedVehicleType = 'cart' | 'wagon' | 'boat';
+export type VehicleCargo = 'wood' | 'stone' | 'food' | 'goods' | 'tools';
+
+export interface VisualBuilding {
+  id: string;
+  typeId: string;
+  x: number;
+  y: number;
+  workers: number;
+  level: number;
+}
+
+export interface AnimatedCitizen {
+  id: string;
+  x: number;
+  y: number;
+  targetX: number;
+  targetY: number;
+  speed: number;
+  type: AnimatedCitizenType;
+  buildingId?: string;
+  path?: { x: number; y: number }[];
+  pathIndex?: number;
+  lastActivity?: number;
+  direction?: number;
+}
+
+export interface AnimatedVehicle {
+  id: string;
+  x: number;
+  y: number;
+  targetX: number;
+  targetY: number;
+  speed: number;
+  type: AnimatedVehicleType;
+  cargo?: VehicleCargo;
+  path?: { x: number; y: number }[];
+  pathIndex?: number;
+  direction?: number;
+  lastDelivery?: number;
+}
+
+export interface GenerateAnimatedPopulationOptions {
+  buildings: VisualBuilding[];
+  citizensCount: number;
+  enableTraffic?: boolean;
+  maxVisibleWorkersPerBuilding?: number;
+  maxRoamingCitizens?: number;
+  trafficBuildingTypes?: ReadonlyArray<string>;
+  now?: number;
+  random?: () => number;
+}
+
+export interface AnimatedPopulation {
+  citizens: AnimatedCitizen[];
+  vehicles: AnimatedVehicle[];
+}
+
+const DEFAULT_MAX_VISIBLE_WORKERS = 3;
+const DEFAULT_MAX_ROAMING_CITIZENS = 15;
+const DEFAULT_TRAFFIC_BUILDINGS = ['trade_post', 'storehouse'];
+const DEFAULT_CARGO: VehicleCargo[] = ['wood', 'stone', 'food', 'goods', 'tools'];
+
+function getRandomIndex(length: number, random: () => number): number {
+  if (length <= 0) {
+    return -1;
+  }
+
+  const value = random();
+  return Math.max(0, Math.min(length - 1, Math.floor(value * length)));
+}
+
+function pickRandomBuilding(
+  buildings: VisualBuilding[],
+  random: () => number
+): VisualBuilding | undefined {
+  const index = getRandomIndex(buildings.length, random);
+  if (index === -1) {
+    return undefined;
+  }
+  return buildings[index];
+}
+
+function resolveRandom(random?: () => number): () => number {
+  return typeof random === 'function' ? random : Math.random;
+}
+
+function resolveNow(now?: number): number {
+  return typeof now === 'number' ? now : Date.now();
+}
+
+export function generateAnimatedCitizens(
+  options: GenerateAnimatedPopulationOptions
+): AnimatedCitizen[] {
+  const {
+    buildings,
+    citizensCount,
+    maxVisibleWorkersPerBuilding = DEFAULT_MAX_VISIBLE_WORKERS,
+    maxRoamingCitizens = DEFAULT_MAX_ROAMING_CITIZENS,
+  } = options;
+
+  if (!buildings.length) {
+    return [];
+  }
+
+  const now = resolveNow(options.now);
+  const random = resolveRandom(options.random);
+  const citizens: AnimatedCitizen[] = [];
+
+  buildings.forEach(building => {
+    const workerCount = Math.min(Math.max(0, building.workers ?? 0), maxVisibleWorkersPerBuilding);
+
+    for (let i = 0; i < workerCount; i += 1) {
+      citizens.push({
+        id: `${building.id}-worker-${i}`,
+        x: building.x,
+        y: building.y,
+        targetX: building.x,
+        targetY: building.y,
+        speed: 0.015 + random() * 0.01,
+        type: 'worker',
+        buildingId: building.id,
+        lastActivity: now + random() * 5000,
+        direction: random() * Math.PI * 2,
+      });
+    }
+  });
+
+  const roamingCount = Math.min(Math.max(0, citizensCount), maxRoamingCitizens);
+
+  for (let i = 0; i < roamingCount; i += 1) {
+    const origin = pickRandomBuilding(buildings, random);
+    if (!origin) {
+      break;
+    }
+
+    citizens.push({
+      id: `roaming-${i}`,
+      x: origin.x,
+      y: origin.y,
+      targetX: origin.x,
+      targetY: origin.y,
+      speed: 0.01 + random() * 0.015,
+      type: random() > 0.7 ? 'trader' : 'citizen',
+      lastActivity: now + random() * 8000,
+      direction: random() * Math.PI * 2,
+    });
+  }
+
+  return citizens;
+}
+
+export function generateAnimatedVehicles(
+  options: GenerateAnimatedPopulationOptions
+): AnimatedVehicle[] {
+  const {
+    buildings,
+    trafficBuildingTypes = DEFAULT_TRAFFIC_BUILDINGS,
+  } = options;
+
+  if (!options.enableTraffic) {
+    return [];
+  }
+
+  const random = resolveRandom(options.random);
+  const now = resolveNow(options.now);
+  const vehicles: AnimatedVehicle[] = [];
+  const trafficTargets = buildings.filter(building =>
+    trafficBuildingTypes.includes(building.typeId)
+  );
+
+  trafficTargets.forEach((building, index) => {
+    const typeIndex = index % 3;
+    const vehicleType: AnimatedVehicleType = typeIndex === 0 ? 'cart' : typeIndex === 1 ? 'wagon' : 'boat';
+    const cargo = DEFAULT_CARGO[getRandomIndex(DEFAULT_CARGO.length, random)];
+
+    vehicles.push({
+      id: `vehicle-${building.id}`,
+      x: building.x,
+      y: building.y,
+      targetX: building.x,
+      targetY: building.y,
+      speed: 0.02 + random() * 0.015,
+      type: vehicleType,
+      cargo,
+      lastDelivery: now + random() * 10000,
+      direction: random() * Math.PI * 2,
+    });
+  });
+
+  return vehicles;
+}
+
+export function generateAnimatedPopulation(
+  options: GenerateAnimatedPopulationOptions
+): AnimatedPopulation {
+  if (!options.buildings.length) {
+    return { citizens: [], vehicles: [] };
+  }
+
+  const citizens = generateAnimatedCitizens(options);
+  const vehicles = generateAnimatedVehicles(options);
+
+  return { citizens, vehicles };
+}

--- a/src/components/game/AnimatedCitizensLayer.tsx
+++ b/src/components/game/AnimatedCitizensLayer.tsx
@@ -1,15 +1,12 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import * as PIXI from 'pixi.js';
+import { generateAnimatedPopulation } from '@engine/visuals/citizens';
 import { useGameContext } from './GameContext';
-import {
-  AnimatedCitizen,
-  AnimatedVehicle,
-  Building,
-  Road
-} from './citizens/types';
-import { generatePath } from './citizens/citizenPathfinding';
+import type { Building, Road } from './citizens/types';
+import { gridToIso } from './citizens/citizenPathfinding';
 import { renderCitizen } from './citizens/CitizenRenderer';
 import { renderVehicle } from './citizens/VehicleRenderer';
+import { useSpritePool } from './pixi/useSpritePool';
 
 interface AnimatedCitizensLayerProps {
   buildings: Building[];
@@ -22,182 +19,87 @@ interface AnimatedCitizensLayerProps {
 
 export default function AnimatedCitizensLayer({
   buildings,
-  roads,
-  tileTypes,
   citizensCount,
   enableTraffic = true
-  }: AnimatedCitizensLayerProps) {
-    const { app } = useGameContext();
-    const containerRef = useRef<PIXI.Container | null>(null);
-    const [citizens, setCitizens] = useState<AnimatedCitizen[]>([]);
-    const [vehicles, setVehicles] = useState<AnimatedVehicle[]>([]);
-    const isAnimatingRef = useRef<boolean>(false);
+}: AnimatedCitizensLayerProps) {
+  const { app } = useGameContext();
+  const containerRef = useRef<PIXI.Container | null>(null);
+  const [container, setContainer] = useState<PIXI.Container | null>(null);
 
-  // Initialize citizens based on buildings
   useEffect(() => {
-    if (!buildings.length) return;
-
-    const newCitizens: AnimatedCitizen[] = [];
-    const newVehicles: AnimatedVehicle[] = [];
-
-    // Create citizens for each building with workers
-    buildings.forEach(building => {
-      const workerCount = Math.min(building.workers, 3); // Max 3 visible workers per building
-      
-      for (let i = 0; i < workerCount; i++) {
-        const citizen: AnimatedCitizen = {
-          id: `${building.id}-worker-${i}`,
-          x: building.x,
-          y: building.y,
-          targetX: building.x,
-          targetY: building.y,
-          speed: 0.015 + Math.random() * 0.01,
-          type: 'worker',
-          buildingId: building.id,
-          lastActivity: Date.now() + Math.random() * 5000,
-          direction: Math.random() * Math.PI * 2
-        };
-        newCitizens.push(citizen);
-      }
-    });
-
-    // Create some roaming citizens
-    const roamingCount = Math.min(citizensCount, 15);
-    for (let i = 0; i < roamingCount; i++) {
-      const randomBuilding = buildings[Math.floor(Math.random() * buildings.length)];
-      const citizen: AnimatedCitizen = {
-        id: `roaming-${i}`,
-        x: randomBuilding.x,
-        y: randomBuilding.y,
-        targetX: randomBuilding.x,
-        targetY: randomBuilding.y,
-        speed: 0.01 + Math.random() * 0.015,
-        type: Math.random() > 0.7 ? 'trader' : 'citizen',
-        lastActivity: Date.now() + Math.random() * 8000,
-        direction: Math.random() * Math.PI * 2
-      };
-      newCitizens.push(citizen);
+    if (!app) {
+      return;
     }
 
-    // Create vehicles for trade buildings
-    if (enableTraffic) {
-      buildings.filter(b => b.typeId === 'trade_post' || b.typeId === 'storehouse').forEach((building, index) => {
-        const vehicle: AnimatedVehicle = {
-          id: `vehicle-${building.id}`,
-          x: building.x,
-          y: building.y,
-          targetX: building.x,
-          targetY: building.y,
-          speed: 0.02 + Math.random() * 0.015,
-          type: index % 3 === 0 ? 'cart' : index % 3 === 1 ? 'wagon' : 'boat',
-          cargo: ['wood', 'stone', 'food', 'goods', 'tools'][Math.floor(Math.random() * 5)],
-          lastDelivery: Date.now() + Math.random() * 10000,
-          direction: Math.random() * Math.PI * 2
-        };
-        newVehicles.push(vehicle);
-      });
-    }
-
-    setCitizens(newCitizens);
-    setVehicles(newVehicles);
-  }, [buildings, citizensCount, enableTraffic]);
-
-  // Create PIXI container and sprites
-  useEffect(() => {
-    if (!app) return;
-
-    const container = new PIXI.Container();
-    containerRef.current = container;
-    app.stage.addChild(container);
+    const pixiContainer = new PIXI.Container();
+    containerRef.current = pixiContainer;
+    app.stage.addChild(pixiContainer);
+    setContainer(pixiContainer);
 
     return () => {
-      if (containerRef.current) {
-        app.stage.removeChild(containerRef.current);
-        containerRef.current.destroy();
+      if (containerRef.current === pixiContainer) {
+        containerRef.current = null;
       }
+      if (pixiContainer.parent === app.stage) {
+        app.stage.removeChild(pixiContainer);
+      }
+      pixiContainer.destroy({ children: true });
+      setContainer(current => (current === pixiContainer ? null : current));
     };
   }, [app]);
 
-  // Optimized animation loop with sprite pooling
-  useEffect(() => {
-    if (!containerRef.current || !app) return;
+  const population = useMemo(
+    () =>
+      generateAnimatedPopulation({
+        buildings,
+        citizensCount,
+        enableTraffic
+      }),
+    [buildings, citizensCount, enableTraffic]
+  );
 
-    const container = containerRef.current;
-    let animationId: number;
-    const spritePool = new Map<string, PIXI.Graphics>();
-    const activeSprites = new Set<string>();
-    
-    const animate = () => {
-      activeSprites.clear();
+  const { citizens, vehicles } = population;
 
-      // Update citizen sprites (reuse existing sprites)
-      citizens.forEach(citizen => {
-        const spriteId = `citizen-${citizen.id}`;
-        activeSprites.add(spriteId);
-        
-        let sprite = spritePool.get(spriteId);
-        if (!sprite) {
-          sprite = renderCitizen(citizen);
-          if (sprite) {
-            spritePool.set(spriteId, sprite);
-            container.addChild(sprite);
-          }
-        } else {
-          // Update position and properties without recreating
-          sprite.x = citizen.x;
-          sprite.y = citizen.y;
-          sprite.visible = true;
+  const citizenLayer = useMemo(
+    () => ({
+      items: citizens,
+      getId: (citizen: typeof citizens[number]) => `citizen-${citizen.id}`,
+      create: renderCitizen,
+      update: (sprite: unknown, citizen: typeof citizens[number]) => {
+        const graphics = sprite as PIXI.Graphics;
+        const isoPosition = gridToIso(citizen.x, citizen.y);
+        graphics.position.set(isoPosition.x, isoPosition.y);
+        if (citizen.direction !== undefined) {
+          graphics.rotation = citizen.direction;
         }
-      });
-
-      // Update vehicle sprites (reuse existing sprites)
-      if (enableTraffic) {
-        vehicles.forEach(vehicle => {
-          const spriteId = `vehicle-${vehicle.id}`;
-          activeSprites.add(spriteId);
-          
-          let sprite = spritePool.get(spriteId);
-          if (!sprite) {
-            sprite = renderVehicle(vehicle);
-            if (sprite) {
-              spritePool.set(spriteId, sprite);
-              container.addChild(sprite);
-            }
-          } else {
-            // Update position and properties without recreating
-            sprite.x = vehicle.x;
-            sprite.y = vehicle.y;
-            sprite.visible = true;
-          }
-        });
       }
+    }),
+    [citizens]
+  );
 
-      // Hide unused sprites instead of destroying them
-      spritePool.forEach((sprite, spriteId) => {
-        if (!activeSprites.has(spriteId)) {
-          sprite.visible = false;
+  const vehicleLayer = useMemo(
+    () => ({
+      items: vehicles,
+      enabled: enableTraffic,
+      getId: (vehicle: typeof vehicles[number]) => `vehicle-${vehicle.id}`,
+      create: renderVehicle,
+      update: (sprite: unknown, vehicle: typeof vehicles[number]) => {
+        const graphics = sprite as PIXI.Graphics;
+        const isoPosition = gridToIso(vehicle.x, vehicle.y);
+        graphics.position.set(isoPosition.x, isoPosition.y);
+        if (vehicle.direction !== undefined) {
+          graphics.rotation = vehicle.direction;
         }
-      });
-
-      animationId = requestAnimationFrame(animate);
-    };
-
-    animate();
-
-    return () => {
-      if (animationId) {
-        cancelAnimationFrame(animationId);
       }
-      // Clean up sprite pool
-      spritePool.forEach(sprite => {
-        if (sprite.parent) {
-          sprite.parent.removeChild(sprite);
-        }
-        sprite.destroy();
-      });
-      spritePool.clear();
-    };
-  }, [citizens, vehicles, enableTraffic]);
+    }),
+    [vehicles, enableTraffic]
+  );
+
+  useSpritePool({
+    app: app ?? null,
+    container,
+    layers: [citizenLayer, vehicleLayer]
+  });
 
   return null;
 }

--- a/src/components/game/citizens/types.ts
+++ b/src/components/game/citizens/types.ts
@@ -1,4 +1,9 @@
 import * as PIXI from "pixi.js";
+import type {
+  AnimatedCitizen as EngineAnimatedCitizen,
+  AnimatedVehicle as EngineAnimatedVehicle,
+  VisualBuilding,
+} from "@engine/visuals/citizens";
 
 export interface BuildingRef {
   id: string;
@@ -61,44 +66,9 @@ export interface CitizensLayerProps {
   dayLengthSeconds?: number;
 }
 
-export interface AnimatedCitizen {
-  id: string;
-  x: number;
-  y: number;
-  targetX: number;
-  targetY: number;
-  speed: number;
-  type: 'worker' | 'trader' | 'citizen';
-  buildingId?: string;
-  path?: { x: number; y: number }[];
-  pathIndex?: number;
-  lastActivity?: number;
-  direction?: number;
-}
-
-export interface AnimatedVehicle {
-  id: string;
-  x: number;
-  y: number;
-  targetX: number;
-  targetY: number;
-  speed: number;
-  type: 'cart' | 'wagon' | 'boat';
-  cargo?: string;
-  path?: { x: number; y: number }[];
-  pathIndex?: number;
-  direction?: number;
-  lastDelivery?: number;
-}
-
-export interface Building {
-  id: string;
-  typeId: string;
-  x: number;
-  y: number;
-  workers: number;
-  level: number;
-}
+export type AnimatedCitizen = EngineAnimatedCitizen;
+export type AnimatedVehicle = EngineAnimatedVehicle;
+export type Building = VisualBuilding;
 
 export interface Road {
   x: number;

--- a/src/components/game/pixi/useSpritePool.ts
+++ b/src/components/game/pixi/useSpritePool.ts
@@ -1,0 +1,89 @@
+import { useEffect, useRef } from 'react';
+import type { Application, Container } from 'pixi.js';
+
+export interface SpritePoolLayer<Item> {
+  items: readonly Item[];
+  enabled?: boolean;
+  getId: (item: Item) => string;
+  create: (item: Item) => unknown;
+  update?: (sprite: unknown, item: Item) => void;
+}
+
+export interface UseSpritePoolOptions {
+  app: Application | null;
+  container: Container | null;
+  layers: Array<SpritePoolLayer<any>>;
+}
+
+export function useSpritePool({ app, container, layers }: UseSpritePoolOptions): void {
+  const layersRef = useRef(layers);
+
+  useEffect(() => {
+    layersRef.current = layers;
+  }, [layers]);
+
+  useEffect(() => {
+    if (!app || !container) {
+      return undefined;
+    }
+
+    let frameId: number | undefined;
+    const spritePool = new Map<string, any>();
+    const activeSprites = new Set<string>();
+
+    const tick = () => {
+      activeSprites.clear();
+
+      layersRef.current.forEach(layer => {
+        if (layer.enabled === false) {
+          return;
+        }
+
+        layer.items.forEach(item => {
+          const id = layer.getId(item);
+          activeSprites.add(id);
+
+          let sprite = spritePool.get(id);
+          if (!sprite) {
+            const created = layer.create(item);
+            if (!created) {
+              return;
+            }
+            sprite = created;
+            spritePool.set(id, sprite);
+            container.addChild(sprite);
+          } else {
+            sprite.visible = true;
+          }
+
+          layer.update?.(sprite, item);
+        });
+      });
+
+      spritePool.forEach((sprite, id) => {
+        if (!activeSprites.has(id)) {
+          sprite.visible = false;
+        }
+      });
+
+      frameId = requestAnimationFrame(tick);
+    };
+
+    frameId = requestAnimationFrame(tick);
+
+    return () => {
+      if (frameId) {
+        cancelAnimationFrame(frameId);
+      }
+
+      spritePool.forEach(sprite => {
+        if (sprite.parent === container) {
+          container.removeChild(sprite);
+        }
+        sprite.destroy();
+      });
+      spritePool.clear();
+      activeSprites.clear();
+    };
+  }, [app, container]);
+}


### PR DESCRIPTION
## Summary
- move citizen and vehicle animation data creation into a shared @engine/visuals helper so UI can reuse simulation-friendly rules
- add a reusable useSpritePool hook that handles pooled PIXI sprite updates for arbitrary render/update pairs
- refactor AnimatedCitizensLayer to rely on the engine helper and sprite pool hook while wiring the PIXI container in React
- re-export animated citizen vehicle types from the engine helper and align worker progression imports with the new module

## Testing
- npm run lint
- npm run test
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca96d7127c8325a2f24a7151768b81