### PR TITLE
Refactor isometric grid setup into reusable hooks

### DIFF
--- a/packages/engine/src/simulation/citizenAI.ts
+++ b/packages/engine/src/simulation/citizenAI.ts
@@ -14,7 +14,7 @@ import {
   selectBestPattern,
   type PatternEvaluationState
 } from './ai/patternEngine';
-import { BehaviorHistoryStore } from './ai/stores/behaviorHistoryStore';
+import { BehaviorHistoryStore, type BehaviorHistoryEntry } from './ai/stores/behaviorHistoryStore';
 import {
   RelationshipStore,
   type CitizenRelationshipRecord
@@ -53,6 +53,23 @@ export class CitizenAI {
     BEHAVIOR_PATTERNS.forEach(pattern => {
       this.behaviorPatterns.set(pattern.id, pattern);
     });
+  }
+
+  getCitizenState(citizenId: string): {
+    profile: CitizenProfile;
+    currentGoal: PathfindingGoal | undefined;
+    lastBehavior: BehaviorHistoryEntry | undefined;
+  } | null {
+    const profile = this.profiles.get(citizenId);
+    if (!profile) {
+      return null;
+    }
+
+    return {
+      profile,
+      currentGoal: this.currentGoals.get(citizenId),
+      lastBehavior: this.historyStore.getLast(citizenId),
+    };
   }
 
   initializeCitizen(citizen: Citizen): CitizenProfile {

--- a/src/components/game/IsometricGrid.tsx
+++ b/src/components/game/IsometricGrid.tsx
@@ -1,14 +1,15 @@
 "use client";
 
-import { useCallback, useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import * as PIXI from "pixi.js";
-import { useGameContext } from "./GameContext";
-import logger from "@/lib/logger";
-import { gridToWorld, TILE_COLORS } from "@/lib/isometric";
-import { createTileSprite, getTileTexture, type GridTile } from "./grid/TileRenderer";
-import { TileOverlay } from "./grid/TileOverlay";
 
-type VisibilityUpdateOptions = { overlayUpdate?: boolean; animationTime?: number };
+import { useGameContext } from "./GameContext";
+import type { GridTile } from "./grid/TileRenderer";
+import {
+  useIsometricGridSetup,
+  type VisibilityUpdateOptions,
+} from "./grid/useIsometricGridSetup";
+import { useIsometricViewportBounds } from "./grid/useIsometricViewportBounds";
 
 interface IsometricGridProps {
   gridSize: number;
@@ -28,256 +29,24 @@ export default function IsometricGrid({
   onTileClick,
 }: IsometricGridProps) {
   const { viewport, app } = useGameContext();
-  const gridContainerRef = useRef<PIXI.Container | null>(null);
-  const tilesRef = useRef<Map<string, GridTile>>(new Map());
-  const centeredRef = useRef<boolean>(false);
-  const initializedRef = useRef<boolean>(false);
-  const overlayManagerRef = useRef<TileOverlay | null>(null);
   const updateVisibilityRef = useRef<((options?: VisibilityUpdateOptions) => void) | null>(null);
-  const tileTypesRef = useRef<string[][]>(tileTypes);
-  const onTileHoverRef = useRef<typeof onTileHover>(onTileHover);
-  const onTileClickRef = useRef<typeof onTileClick>(onTileClick);
-  useEffect(() => {
-    tileTypesRef.current = tileTypes;
-  }, [tileTypes]);
-  useEffect(() => {
-    onTileHoverRef.current = onTileHover;
-  }, [onTileHover]);
-  useEffect(() => {
-    onTileClickRef.current = onTileClick;
-  }, [onTileClick]);
-  // no extra refs needed for min zoom snapping; we prevent underflow by clamping minScale to fit
 
-  const updateTileSprite = useCallback(
-    (gridTile: GridTile, nextType: string) => {
-      if (!app?.renderer) {
-        logger.warn(
-          `[TILE_UPDATE] Renderer unavailable when attempting to update tile ${gridTile.x},${gridTile.y}`
-        );
-        return;
-      }
-
-      if (gridTile.sprite.destroyed) {
-        logger.warn(
-          `[TILE_UPDATE] Attempted to update destroyed tile ${gridTile.x},${gridTile.y}`
-        );
-        return;
-      }
-
-      const tileKey = `${gridTile.x},${gridTile.y}`;
-      const previousType = gridTile.tileType;
-
-      const nextTexture = getTileTexture(
-        nextType,
-        tileWidth,
-        tileHeight,
-        app.renderer,
-        tileKey
-      );
-
-      if (gridTile.sprite.texture !== nextTexture) {
-        gridTile.sprite.texture = nextTexture;
-        gridTile.sprite.texture.updateUvs();
-      }
-
-      gridTile.tileType = nextType;
-
-      if (gridTile.overlay && gridTile.overlay.destroyed) {
-        logger.warn(
-          `[TILE_UPDATE] Overlay for tile ${tileKey} was destroyed prior to update and cannot be reused.`
-        );
-      }
-
-      logger.debug(
-        `[TILE_UPDATE] Updated tile ${tileKey} type from ${previousType} to ${nextType}`
-      );
+  const { gridContainerRef, tilesRef, overlayManagerRef } = useIsometricGridSetup({
+    app,
+    viewport,
+    gridSize,
+    tileWidth,
+    tileHeight,
+    tileTypes,
+    onTileHover,
+    onTileClick,
+    requestOverlayUpdate: (options) => {
+      updateVisibilityRef.current?.(options);
     },
-    [app, tileHeight, tileWidth]
-  );
+  });
 
-  // Initialize grid
-  useEffect(() => {
-    logger.debug('IsometricGrid useEffect triggered, viewport:', viewport);
-    if (!viewport) {
-      logger.warn('IsometricGrid: No viewport available');
-      return;
-    }
-    if (!app?.renderer) {
-      logger.warn('IsometricGrid: No renderer available');
-      return;
-    }
-    if (initializedRef.current) {
-      // Avoid re-initializing the grid if already set up
-      return;
-    }
-    initializedRef.current = true;
+  useIsometricViewportBounds({ viewport, gridSize, tileWidth, tileHeight });
 
-    logger.debug('Creating grid container and tiles...');
-    const gridContainer = new PIXI.Container();
-    gridContainer.name = 'isometric-grid';
-    // ensure overlays can be drawn above tiles in order
-    gridContainer.sortableChildren = true;
-    gridContainer.zIndex = 100; // base layer under buildings
-    // enable leave detection for hover overlay
-      (gridContainer as unknown as { eventMode: string }).eventMode = 'static';
-    viewport.addChild(gridContainer);
-    gridContainerRef.current = gridContainer;
-
-    // Create initial grid tiles
-    const tiles = new Map<string, GridTile>();
-    const initialTileTypes = tileTypesRef.current;
-
-    for (let x = 0; x < gridSize; x++) {
-      for (let y = 0; y < gridSize; y++) {
-        const tile = createTileSprite(
-          x,
-          y,
-          gridContainer,
-          tileWidth,
-          tileHeight,
-          initialTileTypes,
-          app.renderer,
-        );
-        const key = `${x},${y}`;
-        tiles.set(key, tile);
-        gridContainer.addChild(tile.sprite);
-      }
-    }
-    
-    logger.debug(`Created ${tiles.size} tiles for ${gridSize}x${gridSize} grid`);
-    logger.debug('Grid container children count:', gridContainer.children.length);
-    tilesRef.current = tiles;
-
-    overlayManagerRef.current = new TileOverlay(gridContainer, {
-      tileWidth,
-      tileHeight,
-      getTileType: (x, y) => tileTypesRef.current[y]?.[x],
-      onTileHover: (x, y, tileType) => {
-        onTileHoverRef.current?.(x, y, tileType);
-      },
-      onTileClick: (x, y, tileType) => {
-        onTileClickRef.current?.(x, y, tileType);
-      },
-    });
-
-    // Compute world bounds for clamping based on isometric grid extents
-    // For an isometric grid, we need to find the actual world bounds of all tiles
-    const topLeft = gridToWorld(0, 0, tileWidth, tileHeight);
-    const topRight = gridToWorld(gridSize - 1, 0, tileWidth, tileHeight);
-    const bottomLeft = gridToWorld(0, gridSize - 1, tileWidth, tileHeight);
-    const bottomRight = gridToWorld(gridSize - 1, gridSize - 1, tileWidth, tileHeight);
-    
-    const allX = [topLeft.worldX, topRight.worldX, bottomLeft.worldX, bottomRight.worldX];
-    const allY = [topLeft.worldY, topRight.worldY, bottomLeft.worldY, bottomRight.worldY];
-    
-    // Center the viewport using the geometric center of the grid bounds
-    // This ensures the entire grid is properly centered in view
-    const gridCenterX = (Math.min(...allX) + Math.max(...allX)) / 2;
-    const gridCenterY = (Math.min(...allY) + Math.max(...allY)) / 2;
-    
-    // Apply zoom first, then center, and only once
-    if (!centeredRef.current) {
-      viewport.setZoom(1.5);
-      viewport.moveCenter(gridCenterX, gridCenterY);
-      centeredRef.current = true;
-      logger.debug(`Centered viewport on geometric center at (${gridCenterX}, ${gridCenterY})`);
-    }
-
-    const halfW = tileWidth / 2;
-    const halfH = tileHeight / 2;
-    const basePadX = tileWidth * 1.5;
-    const basePadY = tileHeight * 1.5;
-    
-    const worldMinX = Math.min(...allX) - halfW;
-    const worldMaxX = Math.max(...allX) + halfW;
-    const worldMinY = Math.min(...allY) - halfH;
-    const worldMaxY = Math.max(...allY) + halfH;
-
-    const updateClamp = () => {
-      // Static world clamps with a modest padding; independent of scale to avoid jitter
-      const minX = worldMinX - basePadX;
-      const maxX = worldMaxX + basePadX;
-      const minY = worldMinY - basePadY;
-      const maxY = worldMaxY + basePadY;
-      // Center content when world is smaller than screen to avoid blank quadrants
-      viewport.clamp({ left: minX, right: maxX, top: minY, bottom: maxY, underflow: 'center' });
-
-      // Compute a reasonable min zoom once (fit ~50% of grid), adjust on resize only
-      const worldW = (worldMaxX - worldMinX + tileWidth);
-      const worldH = (worldMaxY - worldMinY + tileHeight);
-      const fitScale = Math.min(
-        (viewport.screenWidth || 1) / Math.max(worldW, 1),
-        (viewport.screenHeight || 1) / Math.max(worldH, 1)
-      );
-      // Prevent zooming out beyond full fit so the world never underflows the screen
-      const minScale = Math.max(0.25, Math.min(2, fitScale));
-      viewport.clampZoom({ minScale, maxScale: 3 });
-    };
-
-    updateClamp();
-    const onResize = () => updateClamp();
-    window.addEventListener('resize', onResize);
-
-    // Cleanup function
-    return () => {
-      overlayManagerRef.current?.destroy();
-      overlayManagerRef.current = null;
-      if (gridContainer.parent) {
-        gridContainer.parent.removeChild(gridContainer);
-      }
-      gridContainer.destroy({ children: true });
-      viewport.off('zoomed', updateClamp);
-      window.removeEventListener('resize', onResize);
-      tilesRef.current.clear();
-      centeredRef.current = false;
-      initializedRef.current = false;
-    };
-  }, [viewport, app, gridSize, tileWidth, tileHeight]);
-
-  // Dynamically add missing tiles when gridSize grows
-  useEffect(() => {
-    const gridContainer = gridContainerRef.current;
-    if (!gridContainer || !app?.renderer) return;
-    const tiles = tilesRef.current;
-    let added = 0;
-    for (let x = 0; x < gridSize; x++) {
-      for (let y = 0; y < gridSize; y++) {
-        const key = `${x},${y}`;
-        if (!tiles.has(key)) {
-          const tile = createTileSprite(x, y, gridContainer, tileWidth, tileHeight, tileTypes, app.renderer);
-          tiles.set(key, tile);
-          gridContainer.addChild(tile.sprite);
-          added++;
-        }
-      }
-    }
-    if (added > 0) {
-      logger.debug(`IsometricGrid: added ${added} tiles after gridSize changed to ${gridSize}`);
-      updateVisibilityRef.current?.({ overlayUpdate: true });
-    }
-  }, [app, gridSize, tileWidth, tileHeight, tileTypes]);
-
-  // Refresh tile graphics when tileTypes change
-  useEffect(() => {
-    const gridContainer = gridContainerRef.current;
-    if (!gridContainer || !app?.renderer) return;
-    const tiles = tilesRef.current;
-    let updates = 0;
-    tiles.forEach((gridTile) => {
-      const rawType = tileTypes[gridTile.y]?.[gridTile.x];
-      const nextType = rawType ?? "unknown";
-      if (nextType !== gridTile.tileType) {
-        updateTileSprite(gridTile, nextType);
-        updates++;
-      }
-    });
-    if (updates > 0) {
-      logger.debug(`IsometricGrid: updated ${updates} tiles due to tileTypes change`);
-      updateVisibilityRef.current?.({ overlayUpdate: true });
-    }
-  }, [app, tileTypes, tileWidth, tileHeight, updateTileSprite]);
-
-  // Performance optimization: Viewport culling and LOD + lightweight animations
   useEffect(() => {
     if (!viewport || !gridContainerRef.current || !app?.ticker) return;
 
@@ -297,7 +66,6 @@ export default function IsometricGrid({
       const scale = viewport.scale.x;
       const tiles = tilesRef.current;
 
-      // Get viewport bounds for culling
       const bounds = viewport.getVisibleBounds();
       const padding = Math.max(tileWidth, tileHeight) * 2; // Add padding for smooth scrolling
 
@@ -309,21 +77,18 @@ export default function IsometricGrid({
       const frameTime = animationTime ?? overlayAnimationTime;
 
       tiles.forEach((tile) => {
-        // Viewport culling - only show tiles in visible area
         const isInViewport =
           tile.worldX >= visibleLeft &&
           tile.worldX <= visibleRight &&
           tile.worldY >= visibleTop &&
           tile.worldY <= visibleBottom;
 
-        // LOD - hide tiles when zoomed out too far
         const shouldShowTile = scale > 0.15 && isInViewport;
 
         if (tile.sprite.visible !== shouldShowTile) {
           tile.sprite.visible = shouldShowTile;
         }
 
-        // Lightweight tile animations via overlay
         const overlay = tile.overlay;
         if (overlay) {
           overlay.visible = shouldShowTile;
@@ -384,7 +149,6 @@ export default function IsometricGrid({
     isTickerActive = true;
     app.ticker.add(tick);
 
-    // Initial update to populate overlay textures and visibility states
     updateVisibilityAndLOD({ overlayUpdate: true, animationTime: overlayAnimationTime });
 
     return () => {
@@ -398,9 +162,9 @@ export default function IsometricGrid({
         updateVisibilityRef.current = null;
       }
     };
-  }, [viewport, app, tileWidth, tileHeight]);
+  }, [viewport, app, tileWidth, tileHeight, gridContainerRef, tilesRef, overlayManagerRef]);
 
-  return null; // This component doesn't render React elements
+  return null;
 }
 
 export type { IsometricGridProps, GridTile };

--- a/src/components/game/grid/__tests__/useIsometricGridSetup.test.ts
+++ b/src/components/game/grid/__tests__/useIsometricGridSetup.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as PIXI from "pixi.js";
+
+import { updateGridTileTexture } from "../useIsometricGridSetup";
+import type { GridTile } from "../TileRenderer";
+
+const { getTileTextureMock } = vi.hoisted(() => ({
+  getTileTextureMock: vi.fn(),
+}));
+
+vi.mock("../TileRenderer", () => ({
+  getTileTexture: getTileTextureMock,
+  createTileSprite: vi.fn(),
+}));
+
+vi.mock("../TileOverlay", () => ({
+  TileOverlay: class {
+    destroy = vi.fn();
+  },
+}));
+
+describe("useIsometricGridSetup", () => {
+  beforeEach(() => {
+    getTileTextureMock.mockReset();
+  });
+
+  it("updates the sprite texture and tile type when the renderer is available", () => {
+    const sprite = {
+      texture: { updateUvs: vi.fn() },
+      destroyed: false,
+      visible: true,
+    } as unknown as PIXI.Sprite;
+
+    const gridTile: GridTile = {
+      x: 2,
+      y: 3,
+      worldX: 0,
+      worldY: 0,
+      tileType: "grass",
+      sprite,
+      dispose: vi.fn(),
+    };
+
+    const nextTexture = { updateUvs: vi.fn() } as unknown as PIXI.RenderTexture;
+    getTileTextureMock.mockReturnValue(nextTexture);
+
+    const renderer = {} as PIXI.Renderer;
+
+    const updated = updateGridTileTexture({
+      gridTile,
+      nextType: "water",
+      tileWidth: 64,
+      tileHeight: 32,
+      renderer,
+    });
+
+    expect(updated).toBe(true);
+    expect(getTileTextureMock).toHaveBeenCalledWith(
+      "water",
+      64,
+      32,
+      renderer,
+      "2,3",
+    );
+    expect(gridTile.sprite.texture).toBe(nextTexture);
+    expect(gridTile.tileType).toBe("water");
+  });
+
+  it("returns false when attempting to update a destroyed sprite", () => {
+    const sprite = {
+      texture: { updateUvs: vi.fn() },
+      destroyed: true,
+      visible: true,
+    } as unknown as PIXI.Sprite;
+
+    const gridTile: GridTile = {
+      x: 0,
+      y: 0,
+      worldX: 0,
+      worldY: 0,
+      tileType: "grass",
+      sprite,
+      dispose: vi.fn(),
+    };
+
+    const updated = updateGridTileTexture({
+      gridTile,
+      nextType: "forest",
+      tileWidth: 64,
+      tileHeight: 32,
+      renderer: {} as PIXI.Renderer,
+    });
+
+    expect(updated).toBe(false);
+    expect(gridTile.tileType).toBe("grass");
+  });
+});

--- a/src/components/game/grid/__tests__/useIsometricViewportBounds.test.ts
+++ b/src/components/game/grid/__tests__/useIsometricViewportBounds.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  calculateClampSettings,
+  computeIsometricWorldBounds,
+} from "../useIsometricViewportBounds";
+
+describe("useIsometricViewportBounds helpers", () => {
+  it("computes world bounds for an isometric grid", () => {
+    const bounds = computeIsometricWorldBounds({ gridSize: 2, tileWidth: 64, tileHeight: 32 });
+
+    expect(bounds).toEqual({
+      minX: -32,
+      maxX: 32,
+      minY: 0,
+      maxY: 32,
+      centerX: 0,
+      centerY: 16,
+    });
+  });
+
+  it("derives clamp rectangles and min zoom from the computed bounds", () => {
+    const bounds = computeIsometricWorldBounds({ gridSize: 2, tileWidth: 64, tileHeight: 32 });
+    const mockViewport = {
+      screenWidth: 800,
+      screenHeight: 600,
+      clamp: vi.fn(),
+      clampZoom: vi.fn(),
+    };
+
+    const settings = calculateClampSettings(bounds, mockViewport, 64, 32);
+
+    expect(settings.clampRect).toEqual({ left: -160, right: 160, top: -64, bottom: 96 });
+    expect(settings.minScale).toBe(2);
+    expect(settings.maxScale).toBe(3);
+  });
+});

--- a/src/components/game/grid/useIsometricGridSetup.ts
+++ b/src/components/game/grid/useIsometricGridSetup.ts
@@ -1,0 +1,278 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import type { MutableRefObject } from "react";
+import * as PIXI from "pixi.js";
+import type { Viewport } from "pixi-viewport";
+
+import logger from "@/lib/logger";
+
+import { TileOverlay } from "./TileOverlay";
+import { createTileSprite, getTileTexture, type GridTile } from "./TileRenderer";
+
+export type VisibilityUpdateOptions = {
+  overlayUpdate?: boolean;
+  animationTime?: number;
+};
+
+interface UpdateTileSpriteParams {
+  gridTile: GridTile;
+  nextType: string;
+  tileWidth: number;
+  tileHeight: number;
+  renderer: PIXI.Renderer | null | undefined;
+}
+
+export function updateGridTileTexture({
+  gridTile,
+  nextType,
+  tileWidth,
+  tileHeight,
+  renderer,
+}: UpdateTileSpriteParams): boolean {
+  if (!renderer) {
+    logger.warn(
+      `[TILE_UPDATE] Renderer unavailable when attempting to update tile ${gridTile.x},${gridTile.y}`,
+    );
+    return false;
+  }
+
+  if (gridTile.sprite.destroyed) {
+    logger.warn(
+      `[TILE_UPDATE] Attempted to update destroyed tile ${gridTile.x},${gridTile.y}`,
+    );
+    return false;
+  }
+
+  const tileKey = `${gridTile.x},${gridTile.y}`;
+  const previousType = gridTile.tileType;
+
+  const nextTexture = getTileTexture(nextType, tileWidth, tileHeight, renderer, tileKey);
+
+  if (gridTile.sprite.texture !== nextTexture) {
+    gridTile.sprite.texture = nextTexture;
+    gridTile.sprite.texture.updateUvs();
+  }
+
+  gridTile.tileType = nextType;
+
+  if (gridTile.overlay && gridTile.overlay.destroyed) {
+    logger.warn(
+      `[TILE_UPDATE] Overlay for tile ${tileKey} was destroyed prior to update and cannot be reused.`,
+    );
+  }
+
+  logger.debug(`[TILE_UPDATE] Updated tile ${tileKey} type from ${previousType} to ${nextType}`);
+
+  return previousType !== nextType;
+}
+
+interface UseIsometricGridSetupParams {
+  app: PIXI.Application | null | undefined;
+  viewport: Viewport | null | undefined;
+  gridSize: number;
+  tileWidth: number;
+  tileHeight: number;
+  tileTypes: string[][];
+  onTileHover?: (x: number, y: number, tileType?: string) => void;
+  onTileClick?: (x: number, y: number, tileType?: string) => void;
+  requestOverlayUpdate: (options?: VisibilityUpdateOptions) => void;
+}
+
+interface UseIsometricGridSetupResult {
+  gridContainerRef: MutableRefObject<PIXI.Container | null>;
+  tilesRef: MutableRefObject<Map<string, GridTile>>;
+  overlayManagerRef: MutableRefObject<TileOverlay | null>;
+}
+
+export function useIsometricGridSetup({
+  app,
+  viewport,
+  gridSize,
+  tileWidth,
+  tileHeight,
+  tileTypes,
+  onTileHover,
+  onTileClick,
+  requestOverlayUpdate,
+}: UseIsometricGridSetupParams): UseIsometricGridSetupResult {
+  const gridContainerRef = useRef<PIXI.Container | null>(null);
+  const tilesRef = useRef<Map<string, GridTile>>(new Map());
+  const overlayManagerRef = useRef<TileOverlay | null>(null);
+  const initializedRef = useRef(false);
+
+  const tileTypesRef = useRef<string[][]>(tileTypes);
+  const onTileHoverRef = useRef<typeof onTileHover>(onTileHover);
+  const onTileClickRef = useRef<typeof onTileClick>(onTileClick);
+  const requestOverlayUpdateRef = useRef(requestOverlayUpdate);
+
+  useEffect(() => {
+    tileTypesRef.current = tileTypes;
+  }, [tileTypes]);
+
+  useEffect(() => {
+    onTileHoverRef.current = onTileHover;
+  }, [onTileHover]);
+
+  useEffect(() => {
+    onTileClickRef.current = onTileClick;
+  }, [onTileClick]);
+
+  useEffect(() => {
+    requestOverlayUpdateRef.current = requestOverlayUpdate;
+  }, [requestOverlayUpdate]);
+
+  const updateTileSprite = useCallback(
+    (gridTile: GridTile, nextType: string) => {
+      return updateGridTileTexture({
+        gridTile,
+        nextType,
+        tileWidth,
+        tileHeight,
+        renderer: app?.renderer,
+      });
+    },
+    [app, tileHeight, tileWidth],
+  );
+
+  useEffect(() => {
+    if (!viewport) {
+      logger.warn("useIsometricGridSetup: No viewport available");
+      return;
+    }
+
+    if (!app?.renderer) {
+      logger.warn("useIsometricGridSetup: No renderer available");
+      return;
+    }
+
+    if (initializedRef.current) {
+      return;
+    }
+
+    initializedRef.current = true;
+
+    const gridContainer = new PIXI.Container();
+    gridContainer.name = "isometric-grid";
+    gridContainer.sortableChildren = true;
+    gridContainer.zIndex = 100;
+    (gridContainer as unknown as { eventMode: string }).eventMode = "static";
+
+    viewport.addChild(gridContainer);
+    gridContainerRef.current = gridContainer;
+
+    const tiles = new Map<string, GridTile>();
+    const initialTileTypes = tileTypesRef.current;
+
+    for (let x = 0; x < gridSize; x++) {
+      for (let y = 0; y < gridSize; y++) {
+        const tile = createTileSprite(
+          x,
+          y,
+          gridContainer,
+          tileWidth,
+          tileHeight,
+          initialTileTypes,
+          app.renderer,
+        );
+        const key = `${x},${y}`;
+        tiles.set(key, tile);
+        gridContainer.addChild(tile.sprite);
+      }
+    }
+
+    logger.debug(`Created ${tiles.size} tiles for ${gridSize}x${gridSize} grid`);
+    logger.debug("Grid container children count:", gridContainer.children.length);
+    tilesRef.current = tiles;
+
+    overlayManagerRef.current = new TileOverlay(gridContainer, {
+      tileWidth,
+      tileHeight,
+      getTileType: (x, y) => tileTypesRef.current[y]?.[x],
+      onTileHover: (x, y, tileType) => {
+        onTileHoverRef.current?.(x, y, tileType);
+      },
+      onTileClick: (x, y, tileType) => {
+        onTileClickRef.current?.(x, y, tileType);
+      },
+    });
+
+    return () => {
+      overlayManagerRef.current?.destroy();
+      overlayManagerRef.current = null;
+      if (gridContainer.parent) {
+        gridContainer.parent.removeChild(gridContainer);
+      }
+      gridContainer.destroy({ children: true });
+      tilesRef.current.clear();
+      gridContainerRef.current = null;
+      initializedRef.current = false;
+    };
+  }, [viewport, app, gridSize, tileWidth, tileHeight]);
+
+  useEffect(() => {
+    const gridContainer = gridContainerRef.current;
+    if (!gridContainer || !app?.renderer) return;
+
+    const tiles = tilesRef.current;
+    let added = 0;
+
+    for (let x = 0; x < gridSize; x++) {
+      for (let y = 0; y < gridSize; y++) {
+        const key = `${x},${y}`;
+        if (!tiles.has(key)) {
+          const tile = createTileSprite(
+            x,
+            y,
+            gridContainer,
+            tileWidth,
+            tileHeight,
+            tileTypes,
+            app.renderer,
+          );
+          tiles.set(key, tile);
+          gridContainer.addChild(tile.sprite);
+          added++;
+        }
+      }
+    }
+
+    if (added > 0) {
+      logger.debug(`useIsometricGridSetup: added ${added} tiles after gridSize changed to ${gridSize}`);
+      requestOverlayUpdateRef.current({ overlayUpdate: true });
+    }
+  }, [app, gridSize, tileHeight, tileTypes, tileWidth]);
+
+  useEffect(() => {
+    const gridContainer = gridContainerRef.current;
+    if (!gridContainer || !app?.renderer) return;
+
+    const tiles = tilesRef.current;
+    let updates = 0;
+
+    tiles.forEach((gridTile) => {
+      const rawType = tileTypes[gridTile.y]?.[gridTile.x];
+      const nextType = rawType ?? "unknown";
+      if (nextType !== gridTile.tileType) {
+        updateTileSprite(gridTile, nextType);
+        updates++;
+      }
+    });
+
+    if (updates > 0) {
+      logger.debug(`useIsometricGridSetup: updated ${updates} tiles due to tileTypes change`);
+      requestOverlayUpdateRef.current({ overlayUpdate: true });
+    }
+  }, [app, tileTypes, tileHeight, tileWidth, updateTileSprite]);
+
+  return useMemo(
+    () => ({
+      gridContainerRef,
+      tilesRef,
+      overlayManagerRef,
+    }),
+    [],
+  );
+}
+
+export type { UseIsometricGridSetupResult };

--- a/src/components/game/grid/useIsometricViewportBounds.ts
+++ b/src/components/game/grid/useIsometricViewportBounds.ts
@@ -1,0 +1,157 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { Viewport } from "pixi-viewport";
+
+import logger from "@/lib/logger";
+import { gridToWorld } from "@/lib/isometric";
+
+interface ViewportBoundsOptions {
+  viewport: Viewport | null | undefined;
+  gridSize: number;
+  tileWidth: number;
+  tileHeight: number;
+}
+
+export interface IsometricWorldBounds {
+  minX: number;
+  maxX: number;
+  minY: number;
+  maxY: number;
+  centerX: number;
+  centerY: number;
+}
+
+export function computeIsometricWorldBounds({
+  gridSize,
+  tileWidth,
+  tileHeight,
+}: Omit<ViewportBoundsOptions, "viewport">): IsometricWorldBounds {
+  if (gridSize <= 0) {
+    return { minX: 0, maxX: 0, minY: 0, maxY: 0, centerX: 0, centerY: 0 };
+  }
+
+  const topLeft = gridToWorld(0, 0, tileWidth, tileHeight);
+  const topRight = gridToWorld(gridSize - 1, 0, tileWidth, tileHeight);
+  const bottomLeft = gridToWorld(0, gridSize - 1, tileWidth, tileHeight);
+  const bottomRight = gridToWorld(gridSize - 1, gridSize - 1, tileWidth, tileHeight);
+
+  const allX = [topLeft.worldX, topRight.worldX, bottomLeft.worldX, bottomRight.worldX];
+  const allY = [topLeft.worldY, topRight.worldY, bottomLeft.worldY, bottomRight.worldY];
+
+  const minX = Math.min(...allX);
+  const maxX = Math.max(...allX);
+  const minY = Math.min(...allY);
+  const maxY = Math.max(...allY);
+
+  return {
+    minX,
+    maxX,
+    minY,
+    maxY,
+    centerX: (minX + maxX) / 2,
+    centerY: (minY + maxY) / 2,
+  };
+}
+
+export interface ClampSettings {
+  clampRect: { left: number; right: number; top: number; bottom: number };
+  minScale: number;
+  maxScale: number;
+}
+
+export function calculateClampSettings(
+  bounds: IsometricWorldBounds,
+  viewport: Pick<Viewport, "screenWidth" | "screenHeight" | "clamp" | "clampZoom">,
+  tileWidth: number,
+  tileHeight: number,
+): ClampSettings {
+  const halfW = tileWidth / 2;
+  const halfH = tileHeight / 2;
+  const basePadX = tileWidth * 1.5;
+  const basePadY = tileHeight * 1.5;
+
+  const worldMinX = bounds.minX - halfW;
+  const worldMaxX = bounds.maxX + halfW;
+  const worldMinY = bounds.minY - halfH;
+  const worldMaxY = bounds.maxY + halfH;
+
+  const clampRect = {
+    left: worldMinX - basePadX,
+    right: worldMaxX + basePadX,
+    top: worldMinY - basePadY,
+    bottom: worldMaxY + basePadY,
+  };
+
+  const worldW = worldMaxX - worldMinX + tileWidth;
+  const worldH = worldMaxY - worldMinY + tileHeight;
+
+  const fitScale = Math.min(
+    (viewport.screenWidth || 1) / Math.max(worldW, 1),
+    (viewport.screenHeight || 1) / Math.max(worldH, 1),
+  );
+
+  const minScale = Math.max(0.25, Math.min(2, fitScale));
+
+  return {
+    clampRect,
+    minScale,
+    maxScale: 3,
+  };
+}
+
+export function useIsometricViewportBounds({
+  viewport,
+  gridSize,
+  tileWidth,
+  tileHeight,
+}: ViewportBoundsOptions) {
+  const centeredRef = useRef(false);
+
+  useEffect(() => {
+    if (!viewport) {
+      logger.warn("useIsometricViewportBounds: No viewport available");
+      return;
+    }
+
+    if (gridSize <= 0) {
+      logger.warn("useIsometricViewportBounds: gridSize must be positive");
+      return;
+    }
+
+    const bounds = computeIsometricWorldBounds({ gridSize, tileWidth, tileHeight });
+
+    if (!centeredRef.current) {
+      viewport.setZoom(1.5);
+      viewport.moveCenter(bounds.centerX, bounds.centerY);
+      centeredRef.current = true;
+      logger.debug(
+        `useIsometricViewportBounds: centered viewport at (${bounds.centerX}, ${bounds.centerY})`,
+      );
+    }
+
+    const updateClamp = () => {
+      const { clampRect, minScale, maxScale } = calculateClampSettings(
+        bounds,
+        viewport,
+        tileWidth,
+        tileHeight,
+      );
+
+      viewport.clamp({ ...clampRect, underflow: "center" });
+      viewport.clampZoom({ minScale, maxScale });
+    };
+
+    updateClamp();
+
+    const onResize = () => updateClamp();
+    window.addEventListener("resize", onResize);
+    viewport.on("zoomed", updateClamp);
+
+    return () => {
+      window.removeEventListener("resize", onResize);
+      viewport.off("zoomed", updateClamp);
+      centeredRef.current = false;
+    };
+  }, [viewport, gridSize, tileWidth, tileHeight]);
+}


### PR DESCRIPTION
## Summary
- introduce `useIsometricGridSetup` to manage PIXI container creation, tile seeding, and texture refreshes for the isometric grid
- add `useIsometricViewportBounds` to centralize viewport centering and clamp math and wire both hooks into `IsometricGrid`
- cover the new utilities with unit tests and expose `CitizenAI.getCitizenState` so behavior logic can query initialization state

## Testing
- npm run lint
- npm run test
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca9e350f808325986f23ebf1e3bacc