### PR TITLE
Refactor visual effects system into modular managers

### DIFF
--- a/packages/engine/src/simulation/citizenAI.ts
+++ b/packages/engine/src/simulation/citizenAI.ts
@@ -69,6 +69,10 @@ export class CitizenAI {
     return this.profiles.get(citizenId);
   }
 
+  getCitizenState(citizenId: string): CitizenProfile | undefined {
+    return this.getProfile(citizenId);
+  }
+
   makeDecision(
     citizen: Citizen,
     gameTimeOrCycle: GameTime | number,

--- a/packages/engine/src/simulation/effects/__tests__/activityEffectsManager.test.ts
+++ b/packages/engine/src/simulation/effects/__tests__/activityEffectsManager.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ActivityEffectsManager } from '../activityEffectsManager';
+import { createMockGameState, createMockBuilding, createMockCitizen } from '../testUtils';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('ActivityEffectsManager', () => {
+  it('expires activity indicators after their duration', () => {
+    const manager = new ActivityEffectsManager();
+    const state = createMockGameState({
+      buildings: [createMockBuilding({ utilityEfficiency: 0.9 })],
+      citizens: []
+    });
+
+    vi.spyOn(Math, 'random').mockReturnValue(0.01);
+
+    manager.generate(state);
+    expect(manager.getIndicators()).toHaveLength(1);
+
+    manager.update(3000);
+    expect(manager.getIndicators()).toHaveLength(0);
+  });
+
+  it('does not create indicators when thresholds are unmet', () => {
+    const manager = new ActivityEffectsManager();
+    const state = createMockGameState({
+      buildings: [createMockBuilding({ utilityEfficiency: 0.6 })],
+      citizens: [createMockCitizen({ mood: { happiness: 55, stress: 40, energy: 60, motivation: 50 } })]
+    });
+
+    vi.spyOn(Math, 'random').mockReturnValue(0.0);
+
+    manager.generate(state);
+    expect(manager.getIndicators()).toHaveLength(0);
+  });
+});

--- a/packages/engine/src/simulation/effects/__tests__/constructionEffectsManager.test.ts
+++ b/packages/engine/src/simulation/effects/__tests__/constructionEffectsManager.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ConstructionEffectsManager } from '../constructionEffectsManager';
+import { createMockGameState, createMockBuilding } from '../testUtils';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('ConstructionEffectsManager', () => {
+  it('removes animations when their duration elapses', () => {
+    const manager = new ConstructionEffectsManager();
+    const state = createMockGameState({
+      buildings: [createMockBuilding({ id: 'b1', condition: 'poor', utilityEfficiency: 0.6 })]
+    });
+
+    vi.spyOn(Math, 'random').mockReturnValue(0.01);
+
+    const startTime = 1_000;
+    manager.generate(state, startTime);
+    expect(manager.getAnimations()).toHaveLength(1);
+
+    const animation = manager.getAnimations()[0];
+    const completionTime = startTime + animation.duration + 1;
+    manager.update(completionTime);
+    expect(manager.getAnimations()).toHaveLength(0);
+  });
+
+  it('skips generation when no buildings meet thresholds', () => {
+    const manager = new ConstructionEffectsManager();
+    const state = createMockGameState({
+      buildings: [createMockBuilding({ condition: 'good', utilityEfficiency: 0.5 })]
+    });
+
+    vi.spyOn(Math, 'random').mockReturnValue(0.0);
+
+    manager.generate(state, 500);
+    expect(manager.getAnimations()).toHaveLength(0);
+  });
+});

--- a/packages/engine/src/simulation/effects/__tests__/trafficEffectsManager.test.ts
+++ b/packages/engine/src/simulation/effects/__tests__/trafficEffectsManager.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createMockGameState, createMockBuilding, createMockCitizen } from '../testUtils';
+import { TrafficEffectsManager } from '../trafficEffectsManager';
+import type { GameTime } from '../../../types/gameTime';
+
+const midday: GameTime = {
+  year: 1,
+  month: 1,
+  day: 1,
+  hour: 12,
+  minute: 0,
+  totalMinutes: 12 * 60,
+  timeOfDay: 'midday',
+  dayProgress: 0.5,
+  season: 'spring'
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('TrafficEffectsManager', () => {
+  it('removes traffic flows once their duration expires', () => {
+    const manager = new TrafficEffectsManager();
+    const state = createMockGameState({
+      buildings: [
+        createMockBuilding({ id: 'b1', workers: 10, utilityEfficiency: 0.9 }),
+        createMockBuilding({ id: 'b2', workers: 8, utilityEfficiency: 0.95 })
+      ],
+      citizens: [
+        createMockCitizen({ id: 'c1' }),
+        createMockCitizen({ id: 'c2' })
+      ]
+    });
+
+    vi.spyOn(Math, 'random').mockReturnValue(0.01);
+
+    manager.generate(state, midday);
+    expect(manager.getFlows().length).toBeGreaterThan(0);
+
+    manager.update(5000);
+    expect(manager.getFlows()).toHaveLength(0);
+  });
+
+  it('does not generate traffic when intensity thresholds are not met', () => {
+    const manager = new TrafficEffectsManager();
+    const state = createMockGameState({
+      buildings: [createMockBuilding({ workers: 0, utilityEfficiency: 0.2 })],
+      citizens: []
+    });
+
+    vi.spyOn(Math, 'random').mockReturnValue(0.0);
+
+    manager.generate(state, midday);
+    expect(manager.getFlows()).toHaveLength(0);
+  });
+});

--- a/packages/engine/src/simulation/effects/__tests__/weatherEffectsManager.test.ts
+++ b/packages/engine/src/simulation/effects/__tests__/weatherEffectsManager.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { GameTime } from '../../../types/gameTime';
+import { WeatherEffectsManager } from '../weatherEffectsManager';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const springMorning: GameTime = {
+  year: 1,
+  month: 3,
+  day: 10,
+  hour: 9,
+  minute: 0,
+  totalMinutes: 9 * 60,
+  timeOfDay: 'morning',
+  dayProgress: 0.25,
+  season: 'spring'
+};
+
+describe('WeatherEffectsManager', () => {
+  it('removes weather effects after duration completes', () => {
+    const manager = new WeatherEffectsManager();
+
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+
+    manager.generate(springMorning);
+    expect(manager.getEffects()).toHaveLength(1);
+
+    manager.update(20000);
+    expect(manager.getEffects()).toHaveLength(0);
+  });
+
+  it('respects weather chance thresholds before generating', () => {
+    const manager = new WeatherEffectsManager();
+
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+
+    manager.generate(springMorning);
+    expect(manager.getEffects()).toHaveLength(0);
+  });
+});

--- a/packages/engine/src/simulation/effects/activityEffectsManager.ts
+++ b/packages/engine/src/simulation/effects/activityEffectsManager.ts
@@ -1,0 +1,149 @@
+import type { VisualEffectsGameState, ActivityIndicator, ActivityEffectsConfig } from './types';
+
+const DEFAULT_ACTIVITY_CONFIG: ActivityEffectsConfig = {
+  enabled: true,
+  maxIndicators: 30
+};
+
+export class ActivityEffectsManager {
+  private indicators: Map<string, ActivityIndicator> = new Map();
+  private config: ActivityEffectsConfig = { ...DEFAULT_ACTIVITY_CONFIG };
+  private effectIdCounter = 0;
+
+  constructor(config?: Partial<ActivityEffectsConfig>) {
+    if (config) {
+      this.updateConfig(config);
+    }
+  }
+
+  updateConfig(config: Partial<ActivityEffectsConfig>): void {
+    this.config = { ...this.config, ...config };
+  }
+
+  update(elapsedMs: number): void {
+    if (!this.config.enabled || this.indicators.size === 0) {
+      return;
+    }
+
+    const toRemove: string[] = [];
+
+    for (const [id, indicator] of this.indicators) {
+      indicator.duration -= elapsedMs;
+      if (indicator.duration <= 0) {
+        toRemove.push(id);
+      }
+    }
+
+    toRemove.forEach(id => this.indicators.delete(id));
+  }
+
+  generate(gameState: VisualEffectsGameState): void {
+    if (!this.config.enabled || this.indicators.size >= this.config.maxIndicators) {
+      return;
+    }
+
+    gameState.buildings.forEach(building => {
+      if (building.utilityEfficiency > 0.7 && Math.random() < 0.08) {
+        this.createActivityIndicator({
+          position: { x: building.x, y: building.y },
+          type: 'productivity',
+          value: building.utilityEfficiency,
+          trend: building.utilityEfficiency > 0.8 ? 'increasing' : 'stable',
+          duration: 2000 + Math.random() * 1000
+        });
+      }
+    });
+
+    if (gameState.citizens.length > 0 && Math.random() < 0.05) {
+      const avgHappiness =
+        gameState.citizens.reduce((sum, citizen) => sum + (citizen.mood?.happiness || 50), 0) /
+        Math.max(gameState.citizens.length, 1);
+
+      if (avgHappiness > 60) {
+        this.createActivityIndicator({
+          position: this.getRandomCityPosition(),
+          type: 'happiness',
+          value: avgHappiness / 100,
+          trend: avgHappiness > 70 ? 'increasing' : 'stable',
+          duration: 3000 + Math.random() * 2000
+        });
+      }
+    }
+
+    const tradeActivity = this.calculateTradeActivity(gameState);
+    if (tradeActivity > 0.5 && Math.random() < 0.06) {
+      this.createActivityIndicator({
+        position: this.getRandomCityPosition(),
+        type: 'trade',
+        value: tradeActivity,
+        trend: 'increasing',
+        duration: 2500 + Math.random() * 1500
+      });
+    }
+  }
+
+  getIndicators(): ActivityIndicator[] {
+    return Array.from(this.indicators.values());
+  }
+
+  clear(): void {
+    this.indicators.clear();
+  }
+
+  private createActivityIndicator(params: {
+    position: { x: number; y: number };
+    type: ActivityIndicator['type'];
+    value: number;
+    trend: ActivityIndicator['trend'];
+    duration: number;
+  }): string {
+    const id = `activity_${this.effectIdCounter++}`;
+
+    const config = {
+      productivity: { color: '#00aa44', icon: 'gear', animation: 'spin' as const },
+      happiness: { color: '#ffaa00', icon: 'smile', animation: 'bounce' as const },
+      trade: { color: '#4488ff', icon: 'exchange', animation: 'pulse' as const },
+      growth: { color: '#aa44ff', icon: 'arrow-up', animation: 'float' as const },
+      maintenance: { color: '#ff8844', icon: 'wrench', animation: 'glow' as const }
+    } satisfies Record<ActivityIndicator['type'], { color: string; icon: string; animation: ActivityIndicator['animation'] }>;
+
+    this.indicators.set(id, {
+      id,
+      position: params.position,
+      type: params.type,
+      value: params.value,
+      trend: params.trend,
+      color: config[params.type].color,
+      icon: config[params.type].icon,
+      animation: config[params.type].animation,
+      intensity: params.value,
+      duration: params.duration
+    });
+
+    return id;
+  }
+
+  private calculateTradeActivity(gameState: VisualEffectsGameState): number {
+    const tradeBuildings = gameState.buildings.filter(
+      building => building.typeId === 'trade_post' || building.typeId === 'market'
+    );
+
+    if (tradeBuildings.length === 0) {
+      return 0;
+    }
+
+    const totalEfficiency = tradeBuildings.reduce(
+      (sum, building) => sum + building.utilityEfficiency,
+      0
+    );
+
+    return Math.min(totalEfficiency / tradeBuildings.length, 1);
+  }
+
+  private getRandomCityPosition(): { x: number; y: number } {
+    return {
+      x: 20 + Math.random() * 60,
+      y: 20 + Math.random() * 60
+    };
+  }
+}

--- a/packages/engine/src/simulation/effects/constructionEffectsManager.ts
+++ b/packages/engine/src/simulation/effects/constructionEffectsManager.ts
@@ -1,0 +1,112 @@
+import type { VisualEffectsGameState, ConstructionAnimation, ConstructionEffectsConfig } from './types';
+
+const DEFAULT_CONSTRUCTION_CONFIG: ConstructionEffectsConfig = {
+  enabled: true,
+  maxAnimations: 20
+};
+
+export class ConstructionEffectsManager {
+  private animations: Map<string, ConstructionAnimation> = new Map();
+  private config: ConstructionEffectsConfig = { ...DEFAULT_CONSTRUCTION_CONFIG };
+
+  constructor(config?: Partial<ConstructionEffectsConfig>) {
+    if (config) {
+      this.updateConfig(config);
+    }
+  }
+
+  updateConfig(config: Partial<ConstructionEffectsConfig>): void {
+    this.config = { ...this.config, ...config };
+  }
+
+  update(currentTime: number): void {
+    if (!this.config.enabled || this.animations.size === 0) {
+      return;
+    }
+
+    const toRemove: string[] = [];
+
+    for (const [id, animation] of this.animations) {
+      const elapsed = currentTime - animation.startTime;
+      animation.progress = Math.min(elapsed / animation.duration, 1);
+
+      if (animation.progress >= 1) {
+        toRemove.push(id);
+      }
+    }
+
+    toRemove.forEach(id => this.animations.delete(id));
+  }
+
+  generate(gameState: VisualEffectsGameState, currentTime: number): void {
+    if (!this.config.enabled || this.animations.size >= this.config.maxAnimations) {
+      return;
+    }
+
+    gameState.buildings.forEach(building => {
+      const animationId = `construction_${building.id}`;
+
+      if ((building.condition === 'poor' || building.condition === 'critical') && !this.animations.has(animationId)) {
+        if (Math.random() < 0.1) {
+          this.createConstructionAnimation({
+            buildingId: building.id,
+            position: { x: building.x, y: building.y },
+            type: 'repairing',
+            duration: 8000 + Math.random() * 5000,
+            startTime: currentTime
+          });
+        }
+      }
+
+      if (building.utilityEfficiency > 0.8 && !this.animations.has(animationId)) {
+        if (Math.random() < 0.05) {
+          this.createConstructionAnimation({
+            buildingId: building.id,
+            position: { x: building.x, y: building.y },
+            type: 'upgrading',
+            duration: 12000 + Math.random() * 8000,
+            startTime: currentTime
+          });
+        }
+      }
+    });
+  }
+
+  getAnimations(): ConstructionAnimation[] {
+    return Array.from(this.animations.values());
+  }
+
+  clear(): void {
+    this.animations.clear();
+  }
+
+  private createConstructionAnimation(params: {
+    buildingId: string;
+    position: { x: number; y: number };
+    type: ConstructionAnimation['type'];
+    duration: number;
+    startTime: number;
+  }): string {
+    const id = `construction_${params.buildingId}`;
+
+    const effects: Record<ConstructionAnimation['type'], ConstructionAnimation['effects']> = {
+      building: { dust: true, sparks: false, machinery: true, workers: 3 },
+      upgrading: { dust: false, sparks: true, machinery: true, workers: 2 },
+      repairing: { dust: true, sparks: true, machinery: false, workers: 2 },
+      demolishing: { dust: true, sparks: false, machinery: true, workers: 1 }
+    };
+
+    this.animations.set(id, {
+      id,
+      buildingId: params.buildingId,
+      position: params.position,
+      type: params.type,
+      progress: 0,
+      effects: effects[params.type],
+      duration: params.duration,
+      startTime: params.startTime
+    });
+
+    return id;
+  }
+}

--- a/packages/engine/src/simulation/effects/testUtils.ts
+++ b/packages/engine/src/simulation/effects/testUtils.ts
@@ -1,0 +1,167 @@
+import type { SimResources } from '../../index';
+import type { SimulatedBuilding } from '../buildingSimulation';
+import type { Citizen } from '../citizens/citizen';
+import type { VisualEffectsGameState } from './types';
+import type { WorkerProfile, JobRole } from '../workers/types';
+
+export function createMockBuilding(overrides: Partial<SimulatedBuilding> = {}): SimulatedBuilding {
+  const base: SimulatedBuilding = {
+    id: 'building-1',
+    typeId: 'house',
+    x: 10,
+    y: 10,
+    level: 1,
+    workers: 5,
+    condition: 'good',
+    lastMaintenance: 0,
+    maintenanceDebt: 0,
+    utilityEfficiency: 0.85,
+    traits: {}
+  };
+
+  return { ...base, ...overrides };
+}
+
+export function createMockResources(overrides: Partial<SimResources> = {}): SimResources {
+  const base: SimResources = {
+    grain: 100,
+    coin: 100,
+    mana: 50,
+    favor: 10,
+    workers: 50,
+    wood: 80,
+    planks: 40
+  };
+
+  return { ...base, ...overrides };
+}
+
+function createMockJobRole(overrides: Partial<JobRole> = {}): JobRole {
+  const base: JobRole = {
+    id: 'laborer',
+    title: 'Laborer',
+    category: 'production',
+    requiredSkills: {},
+    baseWage: 10,
+    maxLevel: 3,
+    responsibilities: ['General labor'],
+    workload: 40,
+    prestige: 20
+  };
+
+  return { ...base, ...overrides };
+}
+
+export function createMockWorker(overrides: Partial<WorkerProfile> = {}): WorkerProfile {
+  const base: WorkerProfile = {
+    citizenId: 'citizen-1',
+    currentRole: createMockJobRole(),
+    experienceLevel: 10,
+    careerLevel: 1,
+    specializations: [],
+    certifications: [],
+    efficiency: 70,
+    reliability: 65,
+    teamwork: 60,
+    innovation: 55,
+    jobSatisfaction: 60,
+    workplaceRelationships: [],
+    promotionReadiness: 15,
+    trainingProgress: {},
+    careerGoals: {
+      targetLevel: 2,
+      timeframe: 12
+    },
+    shiftType: 'day',
+    hoursPerWeek: 40,
+    overtimeHours: 5,
+    vacationDays: 10,
+    sickDays: 2,
+    currentWage: 15,
+    bonuses: 0,
+    benefits: {
+      healthcare: true,
+      retirement: false,
+      training: true,
+      flexibleHours: false
+    },
+    performanceReviews: [],
+    burnoutRisk: 20,
+    workLifeBalance: 65,
+    stressLevel: 35
+  };
+
+  return { ...base, ...overrides };
+}
+
+export function createMockCitizen(overrides: Partial<Citizen> = {}): Citizen {
+  const base: Citizen = {
+    id: 'citizen-1',
+    name: 'Aerin',
+    age: 28,
+    gender: 'other',
+    personality: {
+      ambition: 0.6,
+      sociability: 0.5,
+      industriousness: 0.7,
+      contentment: 0.5,
+      curiosity: 0.4
+    },
+    needs: {
+      food: 60,
+      shelter: 70,
+      social: 50,
+      purpose: 55,
+      safety: 65
+    },
+    mood: {
+      happiness: 65,
+      stress: 30,
+      energy: 70,
+      motivation: 60
+    },
+    homeId: 'home-1',
+    workId: 'building-1',
+    jobTitle: 'Laborer',
+    skills: {},
+    relationships: [],
+    familyMembers: [],
+    schedule: {
+      sleep: { start: 22, end: 6 },
+      work: { start: 9, end: 17 },
+      meals: [
+        { time: 7, duration: 1 },
+        { time: 12, duration: 1 },
+        { time: 19, duration: 1 }
+      ],
+      leisure: [{ start: 18, end: 20, activity: 'relaxing' }],
+      social: []
+    },
+    goals: {
+      careerAspiration: 'stable_work',
+      socialGoals: [],
+      materialGoals: [],
+      personalGrowth: []
+    },
+    currentActivity: 'working',
+    location: { x: 15, y: 15 },
+    lastActivityChange: 0,
+    wealth: 200,
+    income: 15,
+    expenses: 8,
+    lifeEvents: []
+  };
+
+  return { ...base, ...overrides };
+}
+
+export function createMockGameState(overrides: Partial<VisualEffectsGameState> = {}): VisualEffectsGameState {
+  const base: VisualEffectsGameState = {
+    buildings: [createMockBuilding()],
+    citizens: [createMockCitizen()],
+    workers: [createMockWorker()],
+    resources: createMockResources()
+  };
+
+  return { ...base, ...overrides };
+}

--- a/packages/engine/src/simulation/effects/trafficEffectsManager.ts
+++ b/packages/engine/src/simulation/effects/trafficEffectsManager.ts
@@ -1,0 +1,172 @@
+import type { GameTime } from '../../types/gameTime';
+import type { VisualEffectsGameState, TrafficFlow, TrafficEffectsConfig } from './types';
+
+const DEFAULT_TRAFFIC_CONFIG: TrafficEffectsConfig = {
+  enabled: true,
+  maxFlows: 50
+};
+
+export class TrafficEffectsManager {
+  private flows: Map<string, TrafficFlow> = new Map();
+  private config: TrafficEffectsConfig = { ...DEFAULT_TRAFFIC_CONFIG };
+  private effectIdCounter = 0;
+
+  constructor(config?: Partial<TrafficEffectsConfig>) {
+    if (config) {
+      this.updateConfig(config);
+    }
+  }
+
+  updateConfig(config: Partial<TrafficEffectsConfig>): void {
+    this.config = { ...this.config, ...config };
+  }
+
+  update(elapsedMs: number): void {
+    if (!this.config.enabled || this.flows.size === 0) {
+      return;
+    }
+
+    const toRemove: string[] = [];
+
+    for (const [id, flow] of this.flows) {
+      flow.duration -= elapsedMs;
+      if (flow.duration <= 0) {
+        toRemove.push(id);
+      }
+    }
+
+    toRemove.forEach(id => this.flows.delete(id));
+  }
+
+  generate(gameState: VisualEffectsGameState, gameTime: GameTime): void {
+    if (!this.config.enabled || this.flows.size >= this.config.maxFlows) {
+      return;
+    }
+
+    const activeBuildings = gameState.buildings.filter(
+      building => building.condition !== 'critical' && building.utilityEfficiency > 0.3
+    );
+
+    if (activeBuildings.length === 0) {
+      return;
+    }
+
+    const trafficDensity = activeBuildings.reduce((total, building) => {
+      const utilityEff = building.utilityEfficiency || 0.8;
+      return total + (building.workers || 0) * utilityEff;
+    }, 0);
+
+    const timeMultiplier = this.getTimeActivityMultiplier(gameTime);
+    const trafficIntensity =
+      Math.min((gameState.citizens.length + trafficDensity) / 100, 1) * timeMultiplier;
+
+    if (Math.random() < trafficIntensity * 0.3) {
+      this.createTrafficFlow({
+        from: this.getRandomBuildingPosition(activeBuildings),
+        to: this.getRandomBuildingPosition(activeBuildings),
+        type: 'pedestrian',
+        intensity: trafficIntensity,
+        duration: 3000 + Math.random() * 2000
+      });
+    }
+
+    const tradeActivity = this.calculateTradeActivity(gameState);
+    if (Math.random() < tradeActivity * 0.2) {
+      this.createTrafficFlow({
+        from: this.getRandomBuildingPosition(activeBuildings),
+        to: this.getRandomBuildingPosition(activeBuildings),
+        type: 'goods',
+        intensity: tradeActivity,
+        duration: 4000 + Math.random() * 3000
+      });
+    }
+  }
+
+  getFlows(): TrafficFlow[] {
+    return Array.from(this.flows.values());
+  }
+
+  clear(): void {
+    this.flows.clear();
+  }
+
+  private createTrafficFlow(params: {
+    from: { x: number; y: number };
+    to: { x: number; y: number };
+    type: TrafficFlow['type'];
+    intensity: number;
+    duration: number;
+  }): string {
+    const id = `traffic_${this.effectIdCounter++}`;
+
+    const colors: Record<TrafficFlow['type'], string> = {
+      pedestrian: '#4a90e2',
+      goods: '#f5a623',
+      construction: '#ff8800',
+      emergency: '#ff4444'
+    };
+
+    const speeds: Record<TrafficFlow['type'], number> = {
+      pedestrian: 1.0,
+      goods: 0.7,
+      construction: 0.5,
+      emergency: 2.0
+    };
+
+    this.flows.set(id, {
+      id,
+      from: params.from,
+      to: params.to,
+      intensity: params.intensity,
+      type: params.type,
+      color: colors[params.type],
+      speed: speeds[params.type],
+      particles: Math.floor(params.intensity * 10) + 3,
+      duration: params.duration
+    });
+
+    return id;
+  }
+
+  private getTimeActivityMultiplier(gameTime: GameTime): number {
+    const hourMultipliers: Record<string, number> = {
+      dawn: 0.3,
+      morning: 0.8,
+      midday: 1.0,
+      afternoon: 0.9,
+      evening: 0.7,
+      night: 0.2
+    };
+
+    return hourMultipliers[gameTime.timeOfDay] ?? 0.5;
+  }
+
+  private calculateTradeActivity(gameState: VisualEffectsGameState): number {
+    const tradeBuildings = gameState.buildings.filter(
+      building => building.typeId === 'trade_post' || building.typeId === 'market'
+    );
+
+    if (tradeBuildings.length === 0) {
+      return 0;
+    }
+
+    const totalEfficiency = tradeBuildings.reduce(
+      (sum, building) => sum + building.utilityEfficiency,
+      0
+    );
+
+    return Math.min(totalEfficiency / tradeBuildings.length, 1);
+  }
+
+  private getRandomBuildingPosition(buildings: VisualEffectsGameState['buildings']): {
+    x: number;
+    y: number;
+  } {
+    if (buildings.length === 0) {
+      return { x: Math.random() * 100, y: Math.random() * 100 };
+    }
+
+    const building = buildings[Math.floor(Math.random() * buildings.length)];
+    return { x: building.x, y: building.y };
+  }
+}

--- a/packages/engine/src/simulation/effects/types.ts
+++ b/packages/engine/src/simulation/effects/types.ts
@@ -1,0 +1,87 @@
+import type { SimResources } from '../../index';
+import type { SimulatedBuilding } from '../buildingSimulation';
+import type { Citizen } from '../citizens/citizen';
+import type { WorkerProfile } from '../workers/types';
+
+export interface VisualEffectsGameState {
+  buildings: SimulatedBuilding[];
+  citizens: Citizen[];
+  workers: WorkerProfile[];
+  resources: SimResources;
+}
+
+export interface TrafficFlow {
+  id: string;
+  from: { x: number; y: number };
+  to: { x: number; y: number };
+  intensity: number;
+  type: 'pedestrian' | 'goods' | 'construction' | 'emergency';
+  color: string;
+  speed: number;
+  particles: number;
+  duration: number;
+}
+
+export interface ConstructionAnimation {
+  id: string;
+  buildingId: string;
+  position: { x: number; y: number };
+  type: 'building' | 'upgrading' | 'repairing' | 'demolishing';
+  progress: number;
+  effects: {
+    dust: boolean;
+    sparks: boolean;
+    machinery: boolean;
+    workers: number;
+  };
+  duration: number;
+  startTime: number;
+}
+
+export interface ActivityIndicator {
+  id: string;
+  position: { x: number; y: number };
+  type: 'productivity' | 'happiness' | 'trade' | 'growth' | 'maintenance';
+  value: number;
+  trend: 'increasing' | 'decreasing' | 'stable';
+  color: string;
+  icon: string;
+  animation: 'pulse' | 'bounce' | 'glow' | 'float' | 'spin';
+  intensity: number;
+  duration: number;
+}
+
+export interface WeatherEffect {
+  id: string;
+  type: 'rain' | 'snow' | 'fog' | 'wind' | 'sunshine' | 'storm';
+  intensity: number;
+  coverage: { x: number; y: number; width: number; height: number };
+  particles: number;
+  color: string;
+  duration: number;
+  effects: {
+    visibility: number;
+    movement: number;
+    mood: number;
+  };
+}
+
+export interface TrafficEffectsConfig {
+  enabled: boolean;
+  maxFlows: number;
+}
+
+export interface ConstructionEffectsConfig {
+  enabled: boolean;
+  maxAnimations: number;
+}
+
+export interface ActivityEffectsConfig {
+  enabled: boolean;
+  maxIndicators: number;
+}
+
+export interface WeatherEffectsConfig {
+  enabled: boolean;
+  maxConcurrent: number;
+}

--- a/packages/engine/src/simulation/effects/weatherEffectsManager.ts
+++ b/packages/engine/src/simulation/effects/weatherEffectsManager.ts
@@ -1,0 +1,133 @@
+import type { GameTime } from '../../types/gameTime';
+import type { WeatherEffect, WeatherEffectsConfig } from './types';
+
+const DEFAULT_WEATHER_CONFIG: WeatherEffectsConfig = {
+  enabled: true,
+  maxConcurrent: 3
+};
+
+export class WeatherEffectsManager {
+  private effects: Map<string, WeatherEffect> = new Map();
+  private config: WeatherEffectsConfig = { ...DEFAULT_WEATHER_CONFIG };
+  private effectIdCounter = 0;
+
+  constructor(config?: Partial<WeatherEffectsConfig>) {
+    if (config) {
+      this.updateConfig(config);
+    }
+  }
+
+  updateConfig(config: Partial<WeatherEffectsConfig>): void {
+    this.config = { ...this.config, ...config };
+  }
+
+  update(elapsedMs: number): void {
+    if (!this.config.enabled || this.effects.size === 0) {
+      return;
+    }
+
+    const toRemove: string[] = [];
+
+    for (const [id, effect] of this.effects) {
+      effect.duration -= elapsedMs;
+      if (effect.duration <= 0) {
+        toRemove.push(id);
+      }
+    }
+
+    toRemove.forEach(id => this.effects.delete(id));
+  }
+
+  generate(gameTime: GameTime): void {
+    if (!this.config.enabled || this.effects.size >= this.config.maxConcurrent) {
+      return;
+    }
+
+    const weatherChance = this.getWeatherChance(gameTime);
+    if (Math.random() >= weatherChance) {
+      return;
+    }
+
+    const weatherType = this.selectWeatherType(gameTime);
+    this.createWeatherEffect({
+      type: weatherType,
+      intensity: 0.3 + Math.random() * 0.4,
+      coverage: { x: 0, y: 0, width: 100, height: 100 },
+      duration: 10000 + Math.random() * 20000
+    });
+  }
+
+  getEffects(): WeatherEffect[] {
+    return Array.from(this.effects.values());
+  }
+
+  clear(): void {
+    this.effects.clear();
+  }
+
+  private createWeatherEffect(params: {
+    type: WeatherEffect['type'];
+    intensity: number;
+    coverage: WeatherEffect['coverage'];
+    duration: number;
+  }): string {
+    const id = `weather_${this.effectIdCounter++}`;
+
+    const config = {
+      rain: { color: '#6699cc', particles: 100, visibility: 0.8, movement: 0.9, mood: -0.1 },
+      snow: { color: '#ffffff', particles: 80, visibility: 0.7, movement: 0.8, mood: 0.05 },
+      fog: { color: '#cccccc', particles: 50, visibility: 0.5, movement: 0.9, mood: -0.05 },
+      wind: { color: '#aaaaaa', particles: 30, visibility: 1.0, movement: 1.2, mood: 0 },
+      sunshine: { color: '#ffdd44', particles: 20, visibility: 1.0, movement: 1.0, mood: 0.15 },
+      storm: { color: '#444466', particles: 150, visibility: 0.6, movement: 0.7, mood: -0.2 }
+    } satisfies Record<WeatherEffect['type'], {
+      color: string;
+      particles: number;
+      visibility: number;
+      movement: number;
+      mood: number;
+    }>;
+
+    const typeConfig = config[params.type];
+
+    this.effects.set(id, {
+      id,
+      type: params.type,
+      intensity: params.intensity,
+      coverage: params.coverage,
+      particles: Math.floor(typeConfig.particles * params.intensity),
+      color: typeConfig.color,
+      duration: params.duration,
+      effects: {
+        visibility: typeConfig.visibility,
+        movement: typeConfig.movement,
+        mood: typeConfig.mood * params.intensity
+      }
+    });
+
+    return id;
+  }
+
+  private getWeatherChance(gameTime: GameTime): number {
+    const seasonMultipliers: Record<string, number> = {
+      spring: 0.003,
+      summer: 0.002,
+      autumn: 0.004,
+      winter: 0.005
+    };
+
+    return seasonMultipliers[gameTime.season] ?? 0.003;
+  }
+
+  private selectWeatherType(gameTime: GameTime): WeatherEffect['type'] {
+    const seasonWeather: Record<string, WeatherEffect['type'][]> = {
+      spring: ['rain', 'wind', 'sunshine'],
+      summer: ['sunshine', 'wind', 'storm'],
+      autumn: ['rain', 'fog', 'wind'],
+      winter: ['snow', 'fog', 'wind']
+    };
+
+    const options = seasonWeather[gameTime.season] ?? ['wind'];
+    return options[Math.floor(Math.random() * options.length)];
+  }
+}

--- a/packages/engine/src/simulation/visualEffectsSystem.ts
+++ b/packages/engine/src/simulation/visualEffectsSystem.ts
@@ -1,82 +1,37 @@
-import type { SimResources } from '../index';
+import type { GameTime } from '../types/gameTime';
+import { ActivityEffectsManager } from './effects/activityEffectsManager';
+import { ConstructionEffectsManager } from './effects/constructionEffectsManager';
+import type {
+  ActivityIndicator,
+  ConstructionAnimation,
+  TrafficFlow,
+  VisualEffectsGameState,
+  WeatherEffect
+} from './effects/types';
+import { WeatherEffectsManager } from './effects/weatherEffectsManager';
+import { TrafficEffectsManager } from './effects/trafficEffectsManager';
 import type { SimulatedBuilding } from './buildingSimulation';
 import type { Citizen } from './citizens/citizen';
+import type { SimResources } from '../index';
 import type { WorkerProfile } from './workers/types';
 
-export interface TrafficFlow {
-  id: string;
-  from: { x: number; y: number };
-  to: { x: number; y: number };
-  intensity: number; // 0-1
-  type: 'pedestrian' | 'goods' | 'construction' | 'emergency';
-  color: string;
-  speed: number;
-  particles: number;
-  duration: number;
-}
+export type { TrafficFlow, ConstructionAnimation, ActivityIndicator, WeatherEffect } from './effects/types';
 
-export interface ConstructionAnimation {
-  id: string;
-  buildingId: string;
-  position: { x: number; y: number };
-  type: 'building' | 'upgrading' | 'repairing' | 'demolishing';
-  progress: number; // 0-1
-  effects: {
-    dust: boolean;
-    sparks: boolean;
-    machinery: boolean;
-    workers: number;
-  };
-  duration: number;
-  startTime: number;
-}
-
-export interface ActivityIndicator {
-  id: string;
-  position: { x: number; y: number };
-  type: 'productivity' | 'happiness' | 'trade' | 'growth' | 'maintenance';
-  value: number;
-  trend: 'increasing' | 'decreasing' | 'stable';
-  color: string;
-  icon: string;
-  animation: 'pulse' | 'bounce' | 'glow' | 'float' | 'spin';
-  intensity: number; // 0-1
-  duration: number;
-}
-
-export interface WeatherEffect {
-  id: string;
-  type: 'rain' | 'snow' | 'fog' | 'wind' | 'sunshine' | 'storm';
-  intensity: number; // 0-1
-  coverage: { x: number; y: number; width: number; height: number };
-  particles: number;
-  color: string;
-  duration: number;
-  effects: {
-    visibility: number; // 0-1
-    movement: number; // speed modifier
-    mood: number; // citizen mood modifier
-  };
-}
-
-interface GameTime {
-  totalMinutes: number;
-  day: number;
-  hour: number;
-  minute: number;
-  season: string;
-  timeOfDay: 'dawn' | 'morning' | 'midday' | 'afternoon' | 'evening' | 'night';
+interface VisualEffectsUpdateState {
+  buildings: SimulatedBuilding[];
+  citizens: Citizen[];
+  workers: WorkerProfile[];
+  resources: SimResources;
 }
 
 export class VisualEffectsSystem {
-  private trafficFlows: Map<string, TrafficFlow> = new Map();
-  private constructionAnimations: Map<string, ConstructionAnimation> = new Map();
-  private activityIndicators: Map<string, ActivityIndicator> = new Map();
-  private weatherEffects: Map<string, WeatherEffect> = new Map();
-  private effectIdCounter = 0;
+  private readonly trafficManager = new TrafficEffectsManager();
+  private readonly constructionManager = new ConstructionEffectsManager();
+  private readonly activityManager = new ActivityEffectsManager();
+  private readonly weatherManager = new WeatherEffectsManager();
+
   private lastUpdateTime = 0;
 
-  // Configuration
   private config = {
     trafficEnabled: true,
     constructionEnabled: true,
@@ -85,464 +40,56 @@ export class VisualEffectsSystem {
     maxTrafficFlows: 50,
     maxConstructionAnimations: 20,
     maxActivityIndicators: 30,
-    updateInterval: 100, // ms
+    maxWeatherEffects: 3,
+    updateInterval: 100
   };
 
-  updateEffects(gameTime: GameTime, gameState: {
-    buildings: SimulatedBuilding[];
-    citizens: Citizen[];
-    workers: WorkerProfile[];
-    resources: SimResources;
-  }): void {
+  constructor() {
+    this.syncManagerConfig();
+  }
+
+  updateEffects(gameTime: GameTime, gameState: VisualEffectsUpdateState): void {
     const currentTime = Date.now();
-    if (currentTime - this.lastUpdateTime < this.config.updateInterval) {
+    const elapsed = this.lastUpdateTime === 0 ? this.config.updateInterval : currentTime - this.lastUpdateTime;
+
+    if (elapsed < this.config.updateInterval) {
       return;
     }
+
     this.lastUpdateTime = currentTime;
 
-    // Update existing effects
-    this.updateTrafficFlows();
-    this.updateConstructionAnimations();
-    this.updateActivityIndicators();
-    this.updateWeatherEffects();
-
-    // Generate new effects based on game state
-    this.generateTrafficFromActivity(gameState, gameTime);
-    this.generateConstructionAnimations(gameState);
-    this.generateActivityIndicators(gameState);
-    this.generateWeatherEffects(gameTime);
-  }
-
-  private updateTrafficFlows(): void {
-    const toRemove: string[] = [];
-    
-    for (const [id, flow] of this.trafficFlows) {
-      flow.duration -= this.config.updateInterval;
-      if (flow.duration <= 0) {
-        toRemove.push(id);
-      }
-    }
-    
-    toRemove.forEach(id => this.trafficFlows.delete(id));
-  }
-
-  private updateConstructionAnimations(): void {
-    const toRemove: string[] = [];
-    
-    for (const [id, animation] of this.constructionAnimations) {
-      const elapsed = Date.now() - animation.startTime;
-      animation.progress = Math.min(elapsed / animation.duration, 1);
-      
-      if (animation.progress >= 1) {
-        toRemove.push(id);
-      }
-    }
-    
-    toRemove.forEach(id => this.constructionAnimations.delete(id));
-  }
-
-  private updateActivityIndicators(): void {
-    const toRemove: string[] = [];
-    
-    for (const [id, indicator] of this.activityIndicators) {
-      indicator.duration -= this.config.updateInterval;
-      if (indicator.duration <= 0) {
-        toRemove.push(id);
-      }
-    }
-    
-    toRemove.forEach(id => this.activityIndicators.delete(id));
-  }
-
-  private updateWeatherEffects(): void {
-    const toRemove: string[] = [];
-    
-    for (const [id, effect] of this.weatherEffects) {
-      effect.duration -= this.config.updateInterval;
-      if (effect.duration <= 0) {
-        toRemove.push(id);
-      }
-    }
-    
-    toRemove.forEach(id => this.weatherEffects.delete(id));
-  }
-
-  private generateTrafficFromActivity(gameState: {
-    buildings: SimulatedBuilding[];
-    citizens: Citizen[];
-    workers: WorkerProfile[];
-    resources: SimResources;
-  }, gameTime: GameTime): void {
-    if (!this.config.trafficEnabled || this.trafficFlows.size >= this.config.maxTrafficFlows) {
-      return;
-    }
-
-    // Generate traffic between active buildings
-    const activeBuildings = gameState.buildings.filter(b => 
-      b.condition !== 'critical' && b.utilityEfficiency > 0.3
-    );
-
-    // Generate traffic based on citizen activity and building workers
-    const trafficDensity = activeBuildings.reduce((total, building) => {
-      const utilityEff = building.utilityEfficiency || 0.8;
-      return total + (building.workers || 0) * utilityEff;
-    }, 0);
-
-    // Create pedestrian traffic based on time of day and building activity
-    const timeMultiplier = this.getTimeActivityMultiplier(gameTime);
-    const trafficIntensity =
-      Math.min((gameState.citizens.length + trafficDensity) / 100, 1) *
-      timeMultiplier;
-
-    if (Math.random() < trafficIntensity * 0.3) {
-      this.createTrafficFlow({
-        from: this.getRandomBuildingPosition(activeBuildings),
-        to: this.getRandomBuildingPosition(activeBuildings),
-        type: 'pedestrian',
-        intensity: trafficIntensity,
-        duration: 3000 + Math.random() * 2000
-      });
-    }
-
-    // Create goods traffic based on trade activity
-    const tradeActivity = this.calculateTradeActivity(gameState);
-    if (Math.random() < tradeActivity * 0.2) {
-      this.createTrafficFlow({
-        from: this.getRandomBuildingPosition(activeBuildings),
-        to: this.getRandomBuildingPosition(activeBuildings),
-        type: 'goods',
-        intensity: tradeActivity,
-        duration: 4000 + Math.random() * 3000
-      });
-    }
-  }
-
-  private generateConstructionAnimations(gameState: {
-    buildings: SimulatedBuilding[];
-    citizens: Citizen[];
-    workers: WorkerProfile[];
-    resources: SimResources;
-  }): void {
-    if (!this.config.constructionEnabled || this.constructionAnimations.size >= this.config.maxConstructionAnimations) {
-      return;
-    }
-
-    // Find buildings under construction or repair
-    gameState.buildings.forEach(building => {
-      const animationId = `construction_${building.id}`;
-      
-      // Check if building needs repair
-      if (building.condition === 'poor' || building.condition === 'critical') {
-        if (!this.constructionAnimations.has(animationId) && Math.random() < 0.1) {
-          this.createConstructionAnimation({
-            buildingId: building.id,
-            position: { x: building.x, y: building.y },
-            type: 'repairing',
-            duration: 8000 + Math.random() * 5000
-          });
-        }
-      }
-      
-      // Check for upgrades (high efficiency buildings)
-      if (building.utilityEfficiency > 0.8 && Math.random() < 0.05) {
-        if (!this.constructionAnimations.has(animationId)) {
-          this.createConstructionAnimation({
-            buildingId: building.id,
-            position: { x: building.x, y: building.y },
-            type: 'upgrading',
-            duration: 12000 + Math.random() * 8000
-          });
-        }
-      }
-    });
-  }
-
-  private generateActivityIndicators(gameState: {
-    buildings: SimulatedBuilding[];
-    citizens: Citizen[];
-    workers: WorkerProfile[];
-    resources: SimResources;
-  }): void {
-    if (!this.config.activityEnabled || this.activityIndicators.size >= this.config.maxActivityIndicators) {
-      return;
-    }
-
-    // Generate productivity indicators
-    gameState.buildings.forEach(building => {
-      if (building.utilityEfficiency > 0.7 && Math.random() < 0.08) {
-        this.createActivityIndicator({
-          position: { x: building.x, y: building.y },
-          type: 'productivity',
-          value: building.utilityEfficiency,
-          trend: building.utilityEfficiency > 0.8 ? 'increasing' : 'stable',
-          duration: 2000 + Math.random() * 1000
-        });
-      }
-    });
-
-    // Generate happiness indicators based on citizen mood
-    if (gameState.citizens.length > 0 && Math.random() < 0.05) {
-      // Calculate citizen happiness effect on activity
-      const avgHappiness = gameState.citizens.reduce((sum, citizen) => {
-        return sum + (citizen.mood?.happiness || 50);
-      }, 0) / Math.max(gameState.citizens.length, 1);
-      
-      if (avgHappiness > 60) {
-        this.createActivityIndicator({
-          position: this.getRandomCityPosition(),
-          type: 'happiness',
-          value: avgHappiness / 100,
-          trend: avgHappiness > 70 ? 'increasing' : 'stable',
-          duration: 3000 + Math.random() * 2000
-        });
-      }
-    }
-
-    // Generate trade indicators
-    const tradeActivity = this.calculateTradeActivity(gameState);
-    if (tradeActivity > 0.5 && Math.random() < 0.06) {
-      this.createActivityIndicator({
-        position: this.getRandomCityPosition(),
-        type: 'trade',
-        value: tradeActivity,
-        trend: 'increasing',
-        duration: 2500 + Math.random() * 1500
-      });
-    }
-  }
-
-  private generateWeatherEffects(gameTime: GameTime): void {
-    if (!this.config.weatherEnabled) return;
-
-    // Generate weather based on season and time
-    const weatherChance = this.getWeatherChance(gameTime);
-    
-    if (Math.random() < weatherChance && this.weatherEffects.size < 3) {
-      const weatherType = this.selectWeatherType(gameTime);
-      this.createWeatherEffect({
-        type: weatherType,
-        intensity: 0.3 + Math.random() * 0.4,
-        coverage: { x: 0, y: 0, width: 100, height: 100 },
-        duration: 10000 + Math.random() * 20000
-      });
-    }
-  }
-
-  private createTrafficFlow(params: {
-    from: { x: number; y: number };
-    to: { x: number; y: number };
-    type: 'pedestrian' | 'goods' | 'construction' | 'emergency';
-    intensity: number;
-    duration: number;
-  }): string {
-    const id = `traffic_${this.effectIdCounter++}`;
-    
-    const colors = {
-      pedestrian: '#4a90e2',
-      goods: '#f5a623',
-      construction: '#ff8800',
-      emergency: '#ff4444'
+    const effectsGameState: VisualEffectsGameState = {
+      buildings: gameState.buildings,
+      citizens: gameState.citizens,
+      workers: gameState.workers,
+      resources: gameState.resources
     };
 
-    const speeds = {
-      pedestrian: 1.0,
-      goods: 0.7,
-      construction: 0.5,
-      emergency: 2.0
-    };
+    this.trafficManager.update(elapsed);
+    this.constructionManager.update(currentTime);
+    this.activityManager.update(elapsed);
+    this.weatherManager.update(elapsed);
 
-    this.trafficFlows.set(id, {
-      id,
-      from: params.from,
-      to: params.to,
-      intensity: params.intensity,
-      type: params.type,
-      color: colors[params.type],
-      speed: speeds[params.type],
-      particles: Math.floor(params.intensity * 10) + 3,
-      duration: params.duration
-    });
-
-    return id;
+    this.trafficManager.generate(effectsGameState, gameTime);
+    this.constructionManager.generate(effectsGameState, currentTime);
+    this.activityManager.generate(effectsGameState);
+    this.weatherManager.generate(gameTime);
   }
 
-  private createConstructionAnimation(params: {
-    buildingId: string;
-    position: { x: number; y: number };
-    type: 'building' | 'upgrading' | 'repairing' | 'demolishing';
-    duration: number;
-  }): string {
-    const id = `construction_${params.buildingId}`;
-    
-    const effects = {
-      building: { dust: true, sparks: false, machinery: true, workers: 3 },
-      upgrading: { dust: false, sparks: true, machinery: true, workers: 2 },
-      repairing: { dust: true, sparks: true, machinery: false, workers: 2 },
-      demolishing: { dust: true, sparks: false, machinery: true, workers: 1 }
-    };
-
-    this.constructionAnimations.set(id, {
-      id,
-      buildingId: params.buildingId,
-      position: params.position,
-      type: params.type,
-      progress: 0,
-      effects: effects[params.type],
-      duration: params.duration,
-      startTime: Date.now()
-    });
-
-    return id;
-  }
-
-  private createActivityIndicator(params: {
-    position: { x: number; y: number };
-    type: 'productivity' | 'happiness' | 'trade' | 'growth' | 'maintenance';
-    value: number;
-    trend: 'increasing' | 'decreasing' | 'stable';
-    duration: number;
-  }): string {
-    const id = `activity_${this.effectIdCounter++}`;
-    
-    const config = {
-      productivity: { color: '#00aa44', icon: 'gear', animation: 'spin' as const },
-      happiness: { color: '#ffaa00', icon: 'smile', animation: 'bounce' as const },
-      trade: { color: '#4488ff', icon: 'exchange', animation: 'pulse' as const },
-      growth: { color: '#aa44ff', icon: 'arrow-up', animation: 'float' as const },
-      maintenance: { color: '#ff8844', icon: 'wrench', animation: 'glow' as const }
-    };
-
-    this.activityIndicators.set(id, {
-      id,
-      position: params.position,
-      type: params.type,
-      value: params.value,
-      trend: params.trend,
-      color: config[params.type].color,
-      icon: config[params.type].icon,
-      animation: config[params.type].animation,
-      intensity: params.value,
-      duration: params.duration
-    });
-
-    return id;
-  }
-
-  private createWeatherEffect(params: {
-    type: 'rain' | 'snow' | 'fog' | 'wind' | 'sunshine' | 'storm';
-    intensity: number;
-    coverage: { x: number; y: number; width: number; height: number };
-    duration: number;
-  }): string {
-    const id = `weather_${this.effectIdCounter++}`;
-    
-    const config = {
-      rain: { color: '#6699cc', particles: 100, visibility: 0.8, movement: 0.9, mood: -0.1 },
-      snow: { color: '#ffffff', particles: 80, visibility: 0.7, movement: 0.8, mood: 0.05 },
-      fog: { color: '#cccccc', particles: 50, visibility: 0.5, movement: 0.9, mood: -0.05 },
-      wind: { color: '#aaaaaa', particles: 30, visibility: 1.0, movement: 1.2, mood: 0 },
-      sunshine: { color: '#ffdd44', particles: 20, visibility: 1.0, movement: 1.0, mood: 0.15 },
-      storm: { color: '#444466', particles: 150, visibility: 0.6, movement: 0.7, mood: -0.2 }
-    };
-
-    const typeConfig = config[params.type];
-    
-    this.weatherEffects.set(id, {
-      id,
-      type: params.type,
-      intensity: params.intensity,
-      coverage: params.coverage,
-      particles: Math.floor(typeConfig.particles * params.intensity),
-      color: typeConfig.color,
-      duration: params.duration,
-      effects: {
-        visibility: typeConfig.visibility,
-        movement: typeConfig.movement,
-        mood: typeConfig.mood * params.intensity
-      }
-    });
-
-    return id;
-  }
-
-  // Helper methods
-  private getTimeActivityMultiplier(gameTime: GameTime): number {
-    const hourMultipliers = {
-      dawn: 0.3,
-      morning: 0.8,
-      midday: 1.0,
-      afternoon: 0.9,
-      evening: 0.7,
-      night: 0.2
-    };
-    return hourMultipliers[gameTime.timeOfDay] || 0.5;
-  }
-
-  private calculateTradeActivity(gameState: {
-    buildings: SimulatedBuilding[];
-    citizens: Citizen[];
-    workers: WorkerProfile[];
-    resources: SimResources;
-  }): number {
-    const tradeBuildings = gameState.buildings.filter(b => 
-      b.typeId === 'trade_post' || b.typeId === 'market'
-    );
-    const totalEfficiency = tradeBuildings.reduce((sum, b) => sum + b.utilityEfficiency, 0);
-    return Math.min(totalEfficiency / tradeBuildings.length || 0, 1);
-  }
-
-  private getRandomBuildingPosition(buildings: SimulatedBuilding[]): { x: number; y: number } {
-    if (buildings.length === 0) {
-      return { x: Math.random() * 100, y: Math.random() * 100 };
-    }
-    const building = buildings[Math.floor(Math.random() * buildings.length)];
-    return { x: building.x, y: building.y };
-  }
-
-  private getRandomCityPosition(): { x: number; y: number } {
-    return {
-      x: 20 + Math.random() * 60,
-      y: 20 + Math.random() * 60
-    };
-  }
-
-  private getWeatherChance(gameTime: GameTime): number {
-    const seasonMultipliers = {
-      spring: 0.003,
-      summer: 0.002,
-      autumn: 0.004,
-      winter: 0.005
-    };
-    return seasonMultipliers[gameTime.season as keyof typeof seasonMultipliers] || 0.003;
-  }
-
-  private selectWeatherType(gameTime: GameTime): 'rain' | 'snow' | 'fog' | 'wind' | 'sunshine' | 'storm' {
-    const seasonWeather = {
-      spring: ['rain', 'wind', 'sunshine'],
-      summer: ['sunshine', 'wind', 'storm'],
-      autumn: ['rain', 'fog', 'wind'],
-      winter: ['snow', 'fog', 'wind']
-    };
-    
-    const options = seasonWeather[gameTime.season as keyof typeof seasonWeather] || ['wind'];
-    return options[Math.floor(Math.random() * options.length)] as WeatherEffect['type'];
-  }
-
-  // Public getters
   getTrafficFlows(): TrafficFlow[] {
-    return Array.from(this.trafficFlows.values());
+    return this.trafficManager.getFlows();
   }
 
   getConstructionAnimations(): ConstructionAnimation[] {
-    return Array.from(this.constructionAnimations.values());
+    return this.constructionManager.getAnimations();
   }
 
   getActivityIndicators(): ActivityIndicator[] {
-    return Array.from(this.activityIndicators.values());
+    return this.activityManager.getIndicators();
   }
 
   getWeatherEffects(): WeatherEffect[] {
-    return Array.from(this.weatherEffects.values());
+    return this.weatherManager.getEffects();
   }
 
   getAllVisualEffects(): {
@@ -559,37 +106,58 @@ export class VisualEffectsSystem {
     };
   }
 
-  // Configuration methods
   updateConfig(newConfig: Partial<typeof this.config>): void {
     this.config = { ...this.config, ...newConfig };
+    this.syncManagerConfig();
   }
 
   getConfig(): typeof this.config {
     return { ...this.config };
   }
 
-  // Cleanup methods
   clearAllEffects(): void {
-    this.trafficFlows.clear();
-    this.constructionAnimations.clear();
-    this.activityIndicators.clear();
-    this.weatherEffects.clear();
+    this.trafficManager.clear();
+    this.constructionManager.clear();
+    this.activityManager.clear();
+    this.weatherManager.clear();
   }
 
   clearEffectsByType(type: 'traffic' | 'construction' | 'activity' | 'weather'): void {
     switch (type) {
       case 'traffic':
-        this.trafficFlows.clear();
+        this.trafficManager.clear();
         break;
       case 'construction':
-        this.constructionAnimations.clear();
+        this.constructionManager.clear();
         break;
       case 'activity':
-        this.activityIndicators.clear();
+        this.activityManager.clear();
         break;
       case 'weather':
-        this.weatherEffects.clear();
+        this.weatherManager.clear();
         break;
     }
+  }
+
+  private syncManagerConfig(): void {
+    this.trafficManager.updateConfig({
+      enabled: this.config.trafficEnabled,
+      maxFlows: this.config.maxTrafficFlows
+    });
+
+    this.constructionManager.updateConfig({
+      enabled: this.config.constructionEnabled,
+      maxAnimations: this.config.maxConstructionAnimations
+    });
+
+    this.activityManager.updateConfig({
+      enabled: this.config.activityEnabled,
+      maxIndicators: this.config.maxActivityIndicators
+    });
+
+    this.weatherManager.updateConfig({
+      enabled: this.config.weatherEnabled,
+      maxConcurrent: this.config.maxWeatherEffects
+    });
   }
 }


### PR DESCRIPTION
## Summary
- replace the monolithic visual effects system with an orchestrator that delegates to dedicated traffic, construction, activity, and weather effect managers
- add modular manager implementations plus shared effect typings and test helpers to encapsulate configuration and state handling per effect family
- cover each manager with unit tests for expiration and generation thresholds and expose a citizen AI getter required by the behavior system

## Testing
- npm run lint
- npm run test
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca9e36b6688325b76ec74d4cb36a23