### PR TITLE
Refactor HUD responsive atoms into shared UI package

### DIFF
--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -5,3 +5,4 @@ export { Tooltip } from './Tooltip';
 export * from './resources';
 export * from './categories';
 export * from './settings';
+export * from './responsive';

--- a/packages/ui/src/responsive/ResponsiveButton.tsx
+++ b/packages/ui/src/responsive/ResponsiveButton.tsx
@@ -1,0 +1,61 @@
+import React, { type ReactNode } from 'react';
+import type { ResponsiveScreenSize } from './types';
+
+type ResponsiveButtonSize = 'xs' | 'sm' | 'md';
+type ResponsiveButtonVariant = 'primary' | 'secondary' | 'danger' | 'success';
+
+export interface ResponsiveButtonProps {
+  screenSize: ResponsiveScreenSize;
+  children: ReactNode;
+  onClick?: () => void;
+  className?: string;
+  variant?: ResponsiveButtonVariant;
+  size?: Partial<Record<ResponsiveScreenSize, ResponsiveButtonSize>>;
+  disabled?: boolean;
+  fullWidth?: boolean;
+}
+
+const sizeClasses = {
+  xs: 'px-2 py-1 text-xs',
+  sm: 'px-3 py-1.5 text-sm',
+  md: 'px-4 py-2 text-sm'
+} as const;
+
+const variantClasses = {
+  primary: 'bg-blue-600 hover:bg-blue-700 text-white',
+  secondary: 'bg-gray-700 hover:bg-gray-600 text-gray-100',
+  danger: 'bg-red-600 hover:bg-red-700 text-white',
+  success: 'bg-green-600 hover:bg-green-700 text-white'
+} as const;
+
+export function ResponsiveButton({
+  screenSize,
+  children,
+  onClick,
+  className = '',
+  variant = 'primary',
+  size = { mobile: 'xs', tablet: 'sm', desktop: 'sm', wide: 'md' },
+  disabled = false,
+  fullWidth = false
+}: ResponsiveButtonProps) {
+  const currentSize = size[screenSize] ?? 'sm';
+  const widthClass = fullWidth ? 'w-full' : '';
+  const disabledClass = disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer';
+
+  return (
+    <button
+      onClick={disabled ? undefined : onClick}
+      className={`
+        ${sizeClasses[currentSize]}
+        ${variantClasses[variant]}
+        ${widthClass}
+        ${disabledClass}
+        rounded font-medium transition-colors duration-200
+        ${className}
+      `.replace(/\s+/g, ' ').trim()}
+      disabled={disabled}
+    >
+      {children}
+    </button>
+  );
+}

--- a/packages/ui/src/responsive/ResponsiveGrid.tsx
+++ b/packages/ui/src/responsive/ResponsiveGrid.tsx
@@ -1,0 +1,40 @@
+import React, { type ReactNode } from 'react';
+import type { ResponsiveScreenSize } from './types';
+
+export interface ResponsiveGridProps {
+  screenSize: ResponsiveScreenSize;
+  children: ReactNode;
+  className?: string;
+  columns?: Partial<Record<ResponsiveScreenSize, number>>;
+  gap?: 'sm' | 'md' | 'lg';
+}
+
+const gapClasses = {
+  sm: 'gap-2',
+  md: 'gap-3',
+  lg: 'gap-4'
+} as const;
+
+const columnClasses: Record<number, string> = {
+  1: 'grid-cols-1',
+  2: 'grid-cols-2',
+  3: 'grid-cols-3',
+  4: 'grid-cols-4'
+};
+
+export function ResponsiveGrid({
+  screenSize,
+  children,
+  className = '',
+  columns = { mobile: 1, tablet: 2, desktop: 2, wide: 3 },
+  gap = 'md'
+}: ResponsiveGridProps) {
+  const currentColumns = columns[screenSize] ?? 1;
+  const gridClasses = columnClasses[currentColumns] ?? columnClasses[1];
+
+  return (
+    <div className={`grid ${gridClasses} ${gapClasses[gap]} ${className}`.trim()}>
+      {children}
+    </div>
+  );
+}

--- a/packages/ui/src/responsive/ResponsiveIcon.tsx
+++ b/packages/ui/src/responsive/ResponsiveIcon.tsx
@@ -1,0 +1,33 @@
+import React, { type ReactNode } from 'react';
+import type { ResponsiveScreenSize } from './types';
+
+type ResponsiveIconSize = 'xs' | 'sm' | 'md' | 'lg';
+
+export interface ResponsiveIconProps {
+  screenSize: ResponsiveScreenSize;
+  children: ReactNode;
+  className?: string;
+  size?: Partial<Record<ResponsiveScreenSize, ResponsiveIconSize>>;
+}
+
+const sizeClasses = {
+  xs: 'w-3 h-3',
+  sm: 'w-4 h-4',
+  md: 'w-5 h-5',
+  lg: 'w-6 h-6'
+} as const;
+
+export function ResponsiveIcon({
+  screenSize,
+  children,
+  className = '',
+  size = { mobile: 'sm', tablet: 'sm', desktop: 'md', wide: 'md' }
+}: ResponsiveIconProps) {
+  const currentSize = size[screenSize] ?? 'sm';
+
+  return (
+    <span className={`inline-flex ${sizeClasses[currentSize]} ${className}`.trim()}>
+      {children}
+    </span>
+  );
+}

--- a/packages/ui/src/responsive/ResponsivePanel.tsx
+++ b/packages/ui/src/responsive/ResponsivePanel.tsx
@@ -1,0 +1,124 @@
+import React, { forwardRef, type ReactNode } from 'react';
+import type { ResponsiveScreenSize } from './types';
+
+export interface ResponsivePanelProps {
+  screenSize: ResponsiveScreenSize;
+  children: ReactNode;
+  className?: string;
+  variant?: 'default' | 'compact' | 'minimal';
+  collapsible?: boolean;
+  isCollapsed?: boolean;
+  onToggleCollapse?: () => void;
+  title?: string;
+  icon?: ReactNode;
+  actions?: ReactNode;
+  priority?: 'low' | 'medium' | 'high';
+}
+
+export const ResponsivePanel = forwardRef<HTMLDivElement, ResponsivePanelProps>((
+  {
+    screenSize,
+    children,
+    className = '',
+    variant = 'default',
+    collapsible = false,
+    isCollapsed = false,
+    onToggleCollapse,
+    title,
+    icon,
+    actions,
+    priority = 'medium'
+  },
+  ref
+) => {
+  const baseClasses = 'bg-gray-800/90 backdrop-blur-sm border border-gray-700 rounded-lg shadow-sm pointer-events-auto';
+
+  const sizeClasses: Record<ResponsiveScreenSize, Record<'default' | 'compact' | 'minimal', string>> = {
+    mobile: {
+      default: 'p-2 text-xs',
+      compact: 'p-1.5 text-xs',
+      minimal: 'p-1 text-xs'
+    },
+    tablet: {
+      default: 'p-3 text-sm',
+      compact: 'p-2 text-xs',
+      minimal: 'p-1.5 text-xs'
+    },
+    desktop: {
+      default: 'p-3 text-sm',
+      compact: 'p-2 text-sm',
+      minimal: 'p-2 text-xs'
+    },
+    wide: {
+      default: 'p-4 text-sm',
+      compact: 'p-3 text-sm',
+      minimal: 'p-2 text-sm'
+    }
+  };
+
+  const priorityClasses = {
+    low: 'opacity-90',
+    medium: 'opacity-95',
+    high: 'opacity-100 ring-1 ring-blue-400/30'
+  } as const;
+
+  const collapseClasses = isCollapsed ? 'scale-95 opacity-75' : '';
+
+  const responsiveClasses = [
+    baseClasses,
+    sizeClasses[screenSize][variant],
+    priorityClasses[priority],
+    collapseClasses,
+    'transition-all duration-200'
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div
+      ref={ref}
+      className={`${responsiveClasses} ${className}`.trim()}
+      data-variant={variant}
+      data-screen-size={screenSize}
+      data-priority={priority}
+    >
+      {(title || collapsible || actions) && (
+        <div className="flex items-center justify-between mb-2 pb-1 border-b border-gray-700">
+          <div className="flex items-center gap-2">
+            {icon && <span className="text-gray-400">{icon}</span>}
+            {title && (
+              <h3 className="font-medium text-gray-200 truncate">
+                {title}
+              </h3>
+            )}
+          </div>
+          <div className="flex items-center gap-1">
+            {actions}
+            {collapsible && (
+              <button
+                onClick={onToggleCollapse}
+                className="p-1 rounded hover:bg-gray-700 text-gray-400 hover:text-gray-200 transition-colors"
+                aria-label={isCollapsed ? 'Expand panel' : 'Collapse panel'}
+              >
+                <svg
+                  className={`w-3 h-3 transition-transform ${isCollapsed ? 'rotate-180' : ''}`}
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                </svg>
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+
+      <div className={isCollapsed ? 'hidden' : 'block'}>
+        {children}
+      </div>
+    </div>
+  );
+});
+
+ResponsivePanel.displayName = 'ResponsivePanel';

--- a/packages/ui/src/responsive/ResponsiveStack.tsx
+++ b/packages/ui/src/responsive/ResponsiveStack.tsx
@@ -1,0 +1,42 @@
+import React, { type ReactNode } from 'react';
+import type { ResponsiveScreenSize } from './types';
+
+export interface ResponsiveStackProps {
+  screenSize: ResponsiveScreenSize;
+  children: ReactNode;
+  className?: string;
+  direction?: Partial<Record<ResponsiveScreenSize, 'vertical' | 'horizontal'>>;
+  gap?: 'sm' | 'md' | 'lg';
+  align?: 'start' | 'center' | 'end' | 'stretch';
+}
+
+const gapClasses = {
+  sm: 'gap-2',
+  md: 'gap-3',
+  lg: 'gap-4'
+} as const;
+
+const alignClasses = {
+  start: 'items-start',
+  center: 'items-center',
+  end: 'items-end',
+  stretch: 'items-stretch'
+} as const;
+
+export function ResponsiveStack({
+  screenSize,
+  children,
+  className = '',
+  direction = { mobile: 'vertical', tablet: 'vertical', desktop: 'vertical', wide: 'vertical' },
+  gap = 'md',
+  align = 'stretch'
+}: ResponsiveStackProps) {
+  const currentDirection = direction[screenSize] ?? 'vertical';
+  const flexDirection = currentDirection === 'horizontal' ? 'flex-row' : 'flex-col';
+
+  return (
+    <div className={`flex ${flexDirection} ${gapClasses[gap]} ${alignClasses[align]} ${className}`.trim()}>
+      {children}
+    </div>
+  );
+}

--- a/packages/ui/src/responsive/ResponsiveText.tsx
+++ b/packages/ui/src/responsive/ResponsiveText.tsx
@@ -1,0 +1,55 @@
+import React, { type ReactNode } from 'react';
+import type { ResponsiveScreenSize } from './types';
+
+type ResponsiveTextSize = 'xs' | 'sm' | 'base' | 'lg';
+type ResponsiveTextWeight = 'normal' | 'medium' | 'semibold' | 'bold';
+type ResponsiveTextColor = 'primary' | 'secondary' | 'muted' | 'danger' | 'success' | 'warning';
+
+export interface ResponsiveTextProps {
+  screenSize: ResponsiveScreenSize;
+  children: ReactNode;
+  className?: string;
+  size?: Partial<Record<ResponsiveScreenSize, ResponsiveTextSize>>;
+  weight?: ResponsiveTextWeight;
+  color?: ResponsiveTextColor;
+}
+
+const sizeClasses = {
+  xs: 'text-xs',
+  sm: 'text-sm',
+  base: 'text-base',
+  lg: 'text-lg'
+} as const;
+
+const weightClasses = {
+  normal: 'font-normal',
+  medium: 'font-medium',
+  semibold: 'font-semibold',
+  bold: 'font-bold'
+} as const;
+
+const colorClasses = {
+  primary: 'text-gray-200',
+  secondary: 'text-gray-300',
+  muted: 'text-gray-400',
+  danger: 'text-red-400',
+  success: 'text-green-400',
+  warning: 'text-yellow-400'
+} as const;
+
+export function ResponsiveText({
+  screenSize,
+  children,
+  className = '',
+  size = { mobile: 'xs', tablet: 'sm', desktop: 'sm', wide: 'base' },
+  weight = 'normal',
+  color = 'primary'
+}: ResponsiveTextProps) {
+  const currentSize = size[screenSize] ?? 'sm';
+
+  return (
+    <span className={`${sizeClasses[currentSize]} ${weightClasses[weight]} ${colorClasses[color]} ${className}`.trim()}>
+      {children}
+    </span>
+  );
+}

--- a/packages/ui/src/responsive/__tests__/responsiveAtoms.test.tsx
+++ b/packages/ui/src/responsive/__tests__/responsiveAtoms.test.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import {
+  ResponsivePanel,
+  ResponsiveGrid,
+  ResponsiveStack,
+  ResponsiveText,
+  ResponsiveButton,
+  ResponsiveIcon
+} from '../index';
+
+describe('responsive atoms', () => {
+  it('applies screen size variants for ResponsivePanel', () => {
+    const markup = renderToStaticMarkup(
+      <ResponsivePanel
+        screenSize="mobile"
+        variant="compact"
+        priority="high"
+        collapsible
+        isCollapsed
+        title="Status"
+      >
+        <span>Hidden</span>
+      </ResponsivePanel>
+    );
+
+    expect(markup).toContain('data-variant="compact"');
+    expect(markup).toContain('data-priority="high"');
+    expect(markup).toContain('p-1.5 text-xs');
+    expect(markup).toContain('ring-1 ring-blue-400/30');
+    expect(markup).toContain('scale-95 opacity-75');
+    expect(markup).toContain('Status');
+  });
+
+  it('calculates grid columns and gap responsively', () => {
+    const markup = renderToStaticMarkup(
+      <ResponsiveGrid screenSize="desktop" columns={{ desktop: 3 }} gap="lg">
+        <div />
+        <div />
+        <div />
+      </ResponsiveGrid>
+    );
+
+    expect(markup).toContain('grid-cols-3');
+    expect(markup).toContain('gap-4');
+  });
+
+  it('switches stack direction based on screen size', () => {
+    const markup = renderToStaticMarkup(
+      <ResponsiveStack
+        screenSize="mobile"
+        direction={{ mobile: 'horizontal' }}
+        gap="sm"
+        align="center"
+      >
+        <span>A</span>
+        <span>B</span>
+      </ResponsiveStack>
+    );
+
+    expect(markup).toContain('flex-row');
+    expect(markup).toContain('gap-2');
+    expect(markup).toContain('items-center');
+  });
+
+  it('applies typography classes responsively', () => {
+    const markup = renderToStaticMarkup(
+      <ResponsiveText
+        screenSize="wide"
+        size={{ wide: 'lg' }}
+        weight="bold"
+        color="success"
+      >
+        Growth
+      </ResponsiveText>
+    );
+
+    expect(markup).toContain('text-lg');
+    expect(markup).toContain('font-bold');
+    expect(markup).toContain('text-green-400');
+  });
+
+  it('combines button variants and layout modifiers', () => {
+    const markup = renderToStaticMarkup(
+      <ResponsiveButton
+        screenSize="wide"
+        variant="danger"
+        size={{ wide: 'md' }}
+        disabled
+        fullWidth
+      >
+        Delete
+      </ResponsiveButton>
+    );
+
+    expect(markup).toContain('bg-red-600');
+    expect(markup).toContain('px-4 py-2 text-sm');
+    expect(markup).toContain('w-full');
+    expect(markup).toContain('opacity-50 cursor-not-allowed');
+    expect(markup).toContain('disabled');
+  });
+
+  it('renders icon sizing classes', () => {
+    const markup = renderToStaticMarkup(
+      <ResponsiveIcon screenSize="desktop" size={{ desktop: 'lg' }}>
+        <svg />
+      </ResponsiveIcon>
+    );
+
+    expect(markup).toContain('w-6 h-6');
+  });
+});

--- a/packages/ui/src/responsive/index.ts
+++ b/packages/ui/src/responsive/index.ts
@@ -1,0 +1,13 @@
+export * from './types';
+export { ResponsivePanel } from './ResponsivePanel';
+export type { ResponsivePanelProps } from './ResponsivePanel';
+export { ResponsiveGrid } from './ResponsiveGrid';
+export type { ResponsiveGridProps } from './ResponsiveGrid';
+export { ResponsiveStack } from './ResponsiveStack';
+export type { ResponsiveStackProps } from './ResponsiveStack';
+export { ResponsiveText } from './ResponsiveText';
+export type { ResponsiveTextProps } from './ResponsiveText';
+export { ResponsiveButton } from './ResponsiveButton';
+export type { ResponsiveButtonProps } from './ResponsiveButton';
+export { ResponsiveIcon } from './ResponsiveIcon';
+export type { ResponsiveIconProps } from './ResponsiveIcon';

--- a/packages/ui/src/responsive/types.ts
+++ b/packages/ui/src/responsive/types.ts
@@ -1,0 +1,1 @@
+export type ResponsiveScreenSize = 'mobile' | 'tablet' | 'desktop' | 'wide';

--- a/src/components/game/hud/ResponsiveHUDPanels.tsx
+++ b/src/components/game/hud/ResponsiveHUDPanels.tsx
@@ -1,364 +1,68 @@
-import React, { forwardRef, ReactNode } from 'react';
+import { forwardRef } from 'react';
+import {
+  ResponsivePanel as ResponsivePanelPrimitive,
+  type ResponsivePanelProps as ResponsivePanelPrimitiveProps,
+  ResponsiveGrid as ResponsiveGridPrimitive,
+  type ResponsiveGridProps as ResponsiveGridPrimitiveProps,
+  ResponsiveStack as ResponsiveStackPrimitive,
+  type ResponsiveStackProps as ResponsiveStackPrimitiveProps,
+  ResponsiveText as ResponsiveTextPrimitive,
+  type ResponsiveTextProps as ResponsiveTextPrimitiveProps,
+  ResponsiveButton as ResponsiveButtonPrimitive,
+  type ResponsiveButtonProps as ResponsiveButtonPrimitiveProps,
+  ResponsiveIcon as ResponsiveIconPrimitive,
+  type ResponsiveIconProps as ResponsiveIconPrimitiveProps
+} from '@arcane/ui/responsive';
 import { useHUDLayout } from './HUDLayoutSystem';
 
-// Base responsive panel props
-export interface ResponsivePanelProps {
-  children: ReactNode;
-  className?: string;
-  variant?: 'default' | 'compact' | 'minimal';
-  collapsible?: boolean;
-  isCollapsed?: boolean;
-  onToggleCollapse?: () => void;
-  title?: string;
-  icon?: ReactNode;
-  actions?: ReactNode;
-  priority?: 'low' | 'medium' | 'high';
-}
+type WithoutScreenSize<P extends { screenSize: unknown }> = Omit<P, 'screenSize'>;
 
-// Responsive panel base component
-export const ResponsivePanel = forwardRef<HTMLDivElement, ResponsivePanelProps>((
-  { 
-    children, 
-    className = '', 
-    variant = 'default',
-    collapsible = false,
-    isCollapsed = false,
-    onToggleCollapse,
-    title,
-    icon,
-    actions,
-    priority = 'medium'
-  }, 
-  ref
-) => {
+export const ResponsivePanel = forwardRef<HTMLDivElement, WithoutScreenSize<ResponsivePanelPrimitiveProps>>((props, ref) => {
   const { screenSize } = useHUDLayout();
-  
-  // Responsive styling based on screen size and variant
-  const getResponsiveClasses = () => {
-    const baseClasses = 'bg-gray-800/90 backdrop-blur-sm border border-gray-700 rounded-lg shadow-sm pointer-events-auto';
-    
-    const sizeClasses = {
-      mobile: {
-        default: 'p-2 text-xs',
-        compact: 'p-1.5 text-xs',
-        minimal: 'p-1 text-xs'
-      },
-      tablet: {
-        default: 'p-3 text-sm',
-        compact: 'p-2 text-xs',
-        minimal: 'p-1.5 text-xs'
-      },
-      desktop: {
-        default: 'p-3 text-sm',
-        compact: 'p-2 text-sm',
-        minimal: 'p-2 text-xs'
-      },
-      wide: {
-        default: 'p-4 text-sm',
-        compact: 'p-3 text-sm',
-        minimal: 'p-2 text-sm'
-      }
-    };
-
-    const priorityClasses = {
-      low: 'opacity-90',
-      medium: 'opacity-95',
-      high: 'opacity-100 ring-1 ring-blue-400/30'
-    };
-
-    const collapseClasses = isCollapsed ? 'scale-95 opacity-75' : '';
-    
-    return `${baseClasses} ${sizeClasses[screenSize][variant]} ${priorityClasses[priority]} ${collapseClasses} transition-all duration-200`;
-  };
-
-  const responsiveClasses = getResponsiveClasses();
-
-  return (
-    <div 
-      ref={ref}
-      className={`${responsiveClasses} ${className}`}
-      data-variant={variant}
-      data-screen-size={screenSize}
-      data-priority={priority}
-    >
-      {(title || collapsible || actions) && (
-        <div className="flex items-center justify-between mb-2 pb-1 border-b border-gray-700">
-          <div className="flex items-center gap-2">
-            {icon && <span className="text-gray-400">{icon}</span>}
-            {title && (
-              <h3 className="font-medium text-gray-200 truncate">
-                {title}
-              </h3>
-            )}
-          </div>
-          <div className="flex items-center gap-1">
-            {actions}
-            {collapsible && (
-              <button
-                onClick={onToggleCollapse}
-                className="p-1 rounded hover:bg-gray-700 text-gray-400 hover:text-gray-200 transition-colors"
-                aria-label={isCollapsed ? 'Expand panel' : 'Collapse panel'}
-              >
-                <svg 
-                  className={`w-3 h-3 transition-transform ${isCollapsed ? 'rotate-180' : ''}`} 
-                  fill="none" 
-                  stroke="currentColor" 
-                  viewBox="0 0 24 24"
-                >
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                </svg>
-              </button>
-            )}
-          </div>
-        </div>
-      )}
-      
-      <div className={`${isCollapsed ? 'hidden' : 'block'}`}>
-        {children}
-      </div>
-    </div>
-  );
+  return <ResponsivePanelPrimitive ref={ref} screenSize={screenSize} {...props} />;
 });
 
 ResponsivePanel.displayName = 'ResponsivePanel';
 
-// Responsive grid container for panels
-interface ResponsiveGridProps {
-  children: ReactNode;
-  className?: string;
-  columns?: {
-    mobile?: number;
-    tablet?: number;
-    desktop?: number;
-    wide?: number;
-  };
-  gap?: 'sm' | 'md' | 'lg';
-}
-
-export function ResponsiveGrid({ 
-  children, 
-  className = '', 
-  columns = { mobile: 1, tablet: 2, desktop: 2, wide: 3 },
-  gap = 'md'
-}: ResponsiveGridProps) {
+export function ResponsiveGrid(props: WithoutScreenSize<ResponsiveGridPrimitiveProps>) {
   const { screenSize } = useHUDLayout();
-  
-  const gapClasses = {
-    sm: 'gap-2',
-    md: 'gap-3',
-    lg: 'gap-4'
-  };
-  
-  const columnClasses: Record<number, string> = {
-    1: 'grid-cols-1',
-    2: 'grid-cols-2',
-    3: 'grid-cols-3',
-    4: 'grid-cols-4'
-  };
-  
-  const currentColumns = columns[screenSize] || 1;
-  
-  return (
-    <div className={`grid ${columnClasses[currentColumns]} ${gapClasses[gap]} ${className}`}>
-      {children}
-    </div>
-  );
+  return <ResponsiveGridPrimitive screenSize={screenSize} {...props} />;
 }
 
-// Responsive stack container
-interface ResponsiveStackProps {
-  children: ReactNode;
-  className?: string;
-  direction?: {
-    mobile?: 'vertical' | 'horizontal';
-    tablet?: 'vertical' | 'horizontal';
-    desktop?: 'vertical' | 'horizontal';
-    wide?: 'vertical' | 'horizontal';
-  };
-  gap?: 'sm' | 'md' | 'lg';
-  align?: 'start' | 'center' | 'end' | 'stretch';
-}
-
-export function ResponsiveStack({ 
-  children, 
-  className = '', 
-  direction = { mobile: 'vertical', tablet: 'vertical', desktop: 'vertical', wide: 'vertical' },
-  gap = 'md',
-  align = 'stretch'
-}: ResponsiveStackProps) {
+export function ResponsiveStack(props: WithoutScreenSize<ResponsiveStackPrimitiveProps>) {
   const { screenSize } = useHUDLayout();
-  
-  const gapClasses = {
-    sm: 'gap-2',
-    md: 'gap-3',
-    lg: 'gap-4'
-  };
-  
-  const alignClasses = {
-    start: 'items-start',
-    center: 'items-center',
-    end: 'items-end',
-    stretch: 'items-stretch'
-  };
-  
-  const currentDirection = direction[screenSize] || 'vertical';
-  const flexDirection = currentDirection === 'horizontal' ? 'flex-row' : 'flex-col';
-  
-  return (
-    <div className={`flex ${flexDirection} ${gapClasses[gap]} ${alignClasses[align]} ${className}`}>
-      {children}
-    </div>
-  );
+  return <ResponsiveStackPrimitive screenSize={screenSize} {...props} />;
 }
 
-// Responsive text component
-interface ResponsiveTextProps {
-  children: ReactNode;
-  className?: string;
-  size?: {
-    mobile?: 'xs' | 'sm' | 'base' | 'lg';
-    tablet?: 'xs' | 'sm' | 'base' | 'lg';
-    desktop?: 'xs' | 'sm' | 'base' | 'lg';
-    wide?: 'xs' | 'sm' | 'base' | 'lg';
-  };
-  weight?: 'normal' | 'medium' | 'semibold' | 'bold';
-  color?: 'primary' | 'secondary' | 'muted' | 'danger' | 'success' | 'warning';
-}
-
-export function ResponsiveText({ 
-  children, 
-  className = '', 
-  size = { mobile: 'xs', tablet: 'sm', desktop: 'sm', wide: 'base' },
-  weight = 'normal',
-  color = 'primary'
-}: ResponsiveTextProps) {
+export function ResponsiveText(props: WithoutScreenSize<ResponsiveTextPrimitiveProps>) {
   const { screenSize } = useHUDLayout();
-  
-  const sizeClasses = {
-    xs: 'text-xs',
-    sm: 'text-sm',
-    base: 'text-base',
-    lg: 'text-lg'
-  };
-  
-  const weightClasses = {
-    normal: 'font-normal',
-    medium: 'font-medium',
-    semibold: 'font-semibold',
-    bold: 'font-bold'
-  };
-  
-  const colorClasses = {
-    primary: 'text-gray-200',
-    secondary: 'text-gray-300',
-    muted: 'text-gray-400',
-    danger: 'text-red-400',
-    success: 'text-green-400',
-    warning: 'text-yellow-400'
-  };
-  
-  const currentSize = size[screenSize] || 'sm';
-  
-  return (
-    <span className={`${sizeClasses[currentSize]} ${weightClasses[weight]} ${colorClasses[color]} ${className}`}>
-      {children}
-    </span>
-  );
+  return <ResponsiveTextPrimitive screenSize={screenSize} {...props} />;
 }
 
-// Responsive button component
-interface ResponsiveButtonProps {
-  children: ReactNode;
-  onClick?: () => void;
-  className?: string;
-  variant?: 'primary' | 'secondary' | 'danger' | 'success';
-  size?: {
-    mobile?: 'xs' | 'sm' | 'md';
-    tablet?: 'xs' | 'sm' | 'md';
-    desktop?: 'xs' | 'sm' | 'md';
-    wide?: 'xs' | 'sm' | 'md';
-  };
-  disabled?: boolean;
-  fullWidth?: boolean;
-}
-
-export function ResponsiveButton({ 
-  children, 
-  onClick, 
-  className = '', 
-  variant = 'primary',
-  size = { mobile: 'xs', tablet: 'sm', desktop: 'sm', wide: 'md' },
-  disabled = false,
-  fullWidth = false
-}: ResponsiveButtonProps) {
+export function ResponsiveButton(props: WithoutScreenSize<ResponsiveButtonPrimitiveProps>) {
   const { screenSize } = useHUDLayout();
-  
-  const sizeClasses = {
-    xs: 'px-2 py-1 text-xs',
-    sm: 'px-3 py-1.5 text-sm',
-    md: 'px-4 py-2 text-sm'
-  };
-  
-  const variantClasses = {
-    primary: 'bg-blue-600 hover:bg-blue-700 text-white',
-    secondary: 'bg-gray-700 hover:bg-gray-600 text-gray-100',
-    danger: 'bg-red-600 hover:bg-red-700 text-white',
-    success: 'bg-green-600 hover:bg-green-700 text-white'
-  };
-  
-  const currentSize = size[screenSize] || 'sm';
-  const widthClass = fullWidth ? 'w-full' : '';
-  const disabledClass = disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer';
-  
-  return (
-    <button
-      onClick={disabled ? undefined : onClick}
-      className={`
-        ${sizeClasses[currentSize]} 
-        ${variantClasses[variant]} 
-        ${widthClass} 
-        ${disabledClass} 
-        rounded font-medium transition-colors duration-200 
-        ${className}
-      `}
-      disabled={disabled}
-    >
-      {children}
-    </button>
-  );
+  return <ResponsiveButtonPrimitive screenSize={screenSize} {...props} />;
 }
 
-// Responsive icon component
-interface ResponsiveIconProps {
-  children: ReactNode;
-  className?: string;
-  size?: {
-    mobile?: 'xs' | 'sm' | 'md' | 'lg';
-    tablet?: 'xs' | 'sm' | 'md' | 'lg';
-    desktop?: 'xs' | 'sm' | 'md' | 'lg';
-    wide?: 'xs' | 'sm' | 'md' | 'lg';
-  };
-}
-
-export function ResponsiveIcon({ 
-  children, 
-  className = '', 
-  size = { mobile: 'sm', tablet: 'sm', desktop: 'md', wide: 'md' }
-}: ResponsiveIconProps) {
+export function ResponsiveIcon(props: WithoutScreenSize<ResponsiveIconPrimitiveProps>) {
   const { screenSize } = useHUDLayout();
-  
-  const sizeClasses = {
-    xs: 'w-3 h-3',
-    sm: 'w-4 h-4',
-    md: 'w-5 h-5',
-    lg: 'w-6 h-6'
-  };
-  
-  const currentSize = size[screenSize] || 'sm';
-  
-  return (
-    <span className={`inline-flex ${sizeClasses[currentSize]} ${className}`}>
-      {children}
-    </span>
-  );
+  return <ResponsiveIconPrimitive screenSize={screenSize} {...props} />;
 }
+
+export {
+  ResponsivePanelPrimitive,
+  ResponsiveGridPrimitive,
+  ResponsiveStackPrimitive,
+  ResponsiveTextPrimitive,
+  ResponsiveButtonPrimitive,
+  ResponsiveIconPrimitive
+};
+
+export type {
+  ResponsivePanelPrimitiveProps as ResponsivePanelProps,
+  ResponsiveGridPrimitiveProps as ResponsiveGridProps,
+  ResponsiveStackPrimitiveProps as ResponsiveStackProps,
+  ResponsiveTextPrimitiveProps as ResponsiveTextProps,
+  ResponsiveButtonPrimitiveProps as ResponsiveButtonProps,
+  ResponsiveIconPrimitiveProps as ResponsiveIconProps
+};

--- a/src/components/game/hud/panels/ModularActionPanel.tsx
+++ b/src/components/game/hud/panels/ModularActionPanel.tsx
@@ -1,6 +1,13 @@
 import React, { useState } from 'react';
-import { ResponsivePanel, ResponsiveButton, ResponsiveStack, ResponsiveIcon } from '../ResponsiveHUDPanels';
+import {
+  ResponsivePanel,
+  ResponsiveButton,
+  ResponsiveStack,
+  ResponsiveIcon,
+  type ResponsiveScreenSize
+} from '@arcane/ui/responsive';
 import { useHUDPanel } from '../HUDPanelRegistry';
+import { useHUDLayout } from '../HUDLayoutSystem';
 
 interface ModularActionPanelProps {
   onOpenCouncil?: () => void;
@@ -23,9 +30,10 @@ interface ActionItemProps {
   disabled?: boolean;
   badge?: string | number;
   active?: boolean;
+  screenSize: ResponsiveScreenSize;
 }
 
-function ActionItem({ label, onClick, icon, variant = 'default', disabled = false, badge, active = false }: ActionItemProps) {
+function ActionItem({ label, onClick, icon, variant = 'default', disabled = false, badge, active = false, screenSize }: ActionItemProps) {
   const getButtonVariant = () => {
     if (disabled) return 'secondary';
     if (active) return 'success';
@@ -37,7 +45,7 @@ function ActionItem({ label, onClick, icon, variant = 'default', disabled = fals
       return (
         <div className="flex items-center justify-center gap-1">
           {icon && (
-            <ResponsiveIcon size={{ mobile: 'sm', tablet: 'sm', desktop: 'md', wide: 'md' }}>
+            <ResponsiveIcon screenSize={screenSize} size={{ mobile: 'sm', tablet: 'sm', desktop: 'md', wide: 'md' }}>
               {icon}
             </ResponsiveIcon>
           )}
@@ -54,7 +62,7 @@ function ActionItem({ label, onClick, icon, variant = 'default', disabled = fals
       <div className="flex items-center justify-between w-full">
         <div className="flex items-center gap-2">
           {icon && (
-            <ResponsiveIcon size={{ mobile: 'xs', tablet: 'sm', desktop: 'sm', wide: 'md' }}>
+            <ResponsiveIcon screenSize={screenSize} size={{ mobile: 'xs', tablet: 'sm', desktop: 'sm', wide: 'md' }}>
               {icon}
             </ResponsiveIcon>
           )}
@@ -71,6 +79,7 @@ function ActionItem({ label, onClick, icon, variant = 'default', disabled = fals
 
   return (
     <ResponsiveButton
+      screenSize={screenSize}
       onClick={onClick}
       variant={getButtonVariant()}
       size={{ mobile: 'xs', tablet: 'sm', desktop: 'sm', wide: 'md' }}
@@ -128,6 +137,7 @@ export function ModularActionPanel({
   isLeylineDrawing = false
 }: ModularActionPanelProps) {
   const [isCollapsed, setIsCollapsed] = useState(false);
+  const { screenSize } = useHUDLayout();
   
   // Register this panel with the HUD system
   useHUDPanel({
@@ -183,6 +193,7 @@ export function ModularActionPanel({
 
   return (
     <ResponsivePanel
+      screenSize={screenSize}
       title={variant === 'minimal' ? 'Act' : 'Actions'}
       icon={titleIcon}
       variant={variant}
@@ -217,7 +228,8 @@ export function ModularActionPanel({
           </button>
         </div>
       )}
-      <ResponsiveStack 
+      <ResponsiveStack
+        screenSize={screenSize}
         direction={{
           mobile: variant === 'minimal' ? 'horizontal' : 'vertical',
           tablet: variant === 'minimal' ? 'horizontal' : 'vertical',
@@ -237,6 +249,7 @@ export function ModularActionPanel({
             disabled={!action.onClick}
             badge={getActionBadge(action.key)}
             active={Boolean(action.active)}
+            screenSize={screenSize}
           />
         ))}
       </ResponsiveStack>

--- a/src/components/game/hud/panels/ModularMiniMapPanel.tsx
+++ b/src/components/game/hud/panels/ModularMiniMapPanel.tsx
@@ -1,8 +1,9 @@
 import React, { useMemo, useState, useEffect } from 'react';
-import { ResponsivePanel, ResponsiveButton } from '../ResponsiveHUDPanels';
+import { ResponsivePanel, ResponsiveButton } from '@arcane/ui/responsive';
 import { useHUDPanel } from '../HUDPanelRegistry';
 import MiniMap from '../../MiniMap';
 import { useGameContext } from '../../GameContext';
+import { useHUDLayout } from '../HUDLayoutSystem';
 
 export interface MiniMapDescriptor {
   gridSize: number;
@@ -69,6 +70,7 @@ export function ModularMiniMapPanel({
 
   const { viewport } = useGameContext();
   const [followSelection, setFollowSelection] = useState(false);
+  const { screenSize } = useHUDLayout();
 
   const handleRecenter = () => {
     if (!viewport) return;
@@ -104,6 +106,7 @@ export function ModularMiniMapPanel({
 
   return (
     <ResponsivePanel
+      screenSize={screenSize}
       title={variant === 'minimal' ? 'Map' : 'Mini Map'}
       icon={(
         <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -122,6 +125,7 @@ export function ModularMiniMapPanel({
         {variant !== 'minimal' && (
           <div className="flex flex-col gap-2">
             <ResponsiveButton
+              screenSize={screenSize}
               onClick={handleRecenter}
               variant="secondary"
               size={{ mobile: 'xs', tablet: 'xs', desktop: 'sm', wide: 'sm' }}
@@ -129,6 +133,7 @@ export function ModularMiniMapPanel({
               Recenter
             </ResponsiveButton>
             <ResponsiveButton
+              screenSize={screenSize}
               onClick={() => setFollowSelection((v: boolean) => !v)}
               variant={followSelection ? 'primary' : 'secondary'}
               size={{ mobile: 'xs', tablet: 'xs', desktop: 'sm', wide: 'sm' }}
@@ -136,6 +141,7 @@ export function ModularMiniMapPanel({
               {followSelection ? 'Following' : 'Follow Sel.'}
             </ResponsiveButton>
             <ResponsiveButton
+              screenSize={screenSize}
               onClick={() => viewport?.setZoom((viewport.scale.x || 1) * 1.1, true)}
               variant="secondary"
               size={{ mobile: 'xs', tablet: 'xs', desktop: 'sm', wide: 'sm' }}
@@ -143,6 +149,7 @@ export function ModularMiniMapPanel({
               Zoom +
             </ResponsiveButton>
             <ResponsiveButton
+              screenSize={screenSize}
               onClick={() => viewport?.setZoom((viewport.scale.x || 1) * 0.9, true)}
               variant="secondary"
               size={{ mobile: 'xs', tablet: 'xs', desktop: 'sm', wide: 'sm' }}

--- a/src/components/game/hud/panels/ModularQuestPanel.tsx
+++ b/src/components/game/hud/panels/ModularQuestPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
-import { ResponsivePanel } from '../ResponsiveHUDPanels';
+import { ResponsivePanel } from '@arcane/ui/responsive';
 import { useHUDPanel } from '../HUDPanelRegistry';
+import { useHUDLayout } from '../HUDLayoutSystem';
 
 interface ModularQuestPanelProps {
   completed: Record<string, boolean>;
@@ -20,6 +21,7 @@ const QUESTS: Array<{ id: string; text: string }> = [
 export default function ModularQuestPanel({ completed, variant = 'default', collapsible = true }: ModularQuestPanelProps) {
   // Default to collapsed; users can peek as needed
   const [isCollapsed, setIsCollapsed] = useState(true);
+  const { screenSize } = useHUDLayout();
 
   useHUDPanel({
     config: {
@@ -48,6 +50,7 @@ export default function ModularQuestPanel({ completed, variant = 'default', coll
 
   return (
     <ResponsivePanel
+      screenSize={screenSize}
       title={variant !== 'minimal' ? `Quests` : `Q`}
       icon={titleIcon}
       variant={variant}

--- a/src/components/game/hud/panels/ModularResourcePanel.tsx
+++ b/src/components/game/hud/panels/ModularResourcePanel.tsx
@@ -1,6 +1,13 @@
 import React, { useState } from 'react';
-import { ResponsivePanel, ResponsiveText, ResponsiveGrid, ResponsiveIcon } from '../ResponsiveHUDPanels';
+import {
+  ResponsivePanel,
+  ResponsiveText,
+  ResponsiveGrid,
+  ResponsiveIcon,
+  type ResponsiveScreenSize
+} from '@arcane/ui/responsive';
 import { useHUDPanel } from '../HUDPanelRegistry';
+import { useHUDLayout } from '../HUDLayoutSystem';
 import type { GameResources, WorkforceInfo } from '../types';
 
 interface ModularResourcePanelProps {
@@ -19,23 +26,26 @@ interface ResourceItemProps {
   danger?: boolean;
   icon?: React.ReactNode;
   variant?: 'default' | 'compact' | 'minimal';
+  screenSize: ResponsiveScreenSize;
 }
 
-function ResourceItem({ label, value, delta, danger, icon, variant = 'default' }: ResourceItemProps) {
+function ResourceItem({ label, value, delta, danger, icon, variant = 'default', screenSize }: ResourceItemProps) {
   const showDelta = typeof delta === 'number' && delta !== 0;
-  
+
   return (
     <div className="flex items-center justify-between gap-2 px-2 py-1 rounded hover:bg-white/5 transition-colors">
       <div className="flex items-center gap-2 min-w-0 flex-1">
         {icon && (
-          <ResponsiveIcon 
+          <ResponsiveIcon
+            screenSize={screenSize}
             size={{ mobile: 'xs', tablet: 'sm', desktop: 'sm', wide: 'md' }}
             className="text-gray-400 flex-shrink-0"
           >
             {icon}
           </ResponsiveIcon>
         )}
-        <ResponsiveText 
+        <ResponsiveText
+          screenSize={screenSize}
           size={{ mobile: 'xs', tablet: 'xs', desktop: 'sm', wide: 'sm' }}
           weight="medium"
           color={danger ? 'danger' : 'primary'}
@@ -46,7 +56,8 @@ function ResourceItem({ label, value, delta, danger, icon, variant = 'default' }
       </div>
       
       <div className="flex items-center gap-1 flex-shrink-0">
-        <ResponsiveText 
+        <ResponsiveText
+          screenSize={screenSize}
           size={{ mobile: 'xs', tablet: 'xs', desktop: 'sm', wide: 'sm' }}
           weight="semibold"
           color={danger ? 'danger' : 'primary'}
@@ -54,9 +65,10 @@ function ResourceItem({ label, value, delta, danger, icon, variant = 'default' }
         >
           {value.toLocaleString()}
         </ResponsiveText>
-        
+
         {showDelta && (
-          <ResponsiveText 
+          <ResponsiveText
+            screenSize={screenSize}
             size={{ mobile: 'xs', tablet: 'xs', desktop: 'xs', wide: 'sm' }}
             color={delta! > 0 ? 'success' : 'danger'}
             className="tabular-nums"
@@ -69,24 +81,35 @@ function ResourceItem({ label, value, delta, danger, icon, variant = 'default' }
   );
 }
 
-function WorkforceSection({ workforce, variant }: { workforce: WorkforceInfo; variant: 'default' | 'compact' | 'minimal' }) {
+function WorkforceSection({
+  workforce,
+  variant,
+  screenSize
+}: {
+  workforce: WorkforceInfo;
+  variant: 'default' | 'compact' | 'minimal';
+  screenSize: ResponsiveScreenSize;
+}) {
   if (variant === 'minimal') return null;
-  
+
   return (
     <div className="mt-3 pt-2 border-t border-gray-700">
-      <ResponsiveGrid 
+      <ResponsiveGrid
+        screenSize={screenSize}
         columns={{ mobile: 1, tablet: 2, desktop: 2, wide: 2 }}
         gap="sm"
       >
         <div className="text-center">
-          <ResponsiveText 
+          <ResponsiveText
+            screenSize={screenSize}
             size={{ mobile: 'xs', tablet: 'xs', desktop: 'xs', wide: 'sm' }}
             color="muted"
             className="block mb-1"
           >
             Workforce
           </ResponsiveText>
-          <ResponsiveText 
+          <ResponsiveText
+            screenSize={screenSize}
             size={{ mobile: 'xs', tablet: 'sm', desktop: 'sm', wide: 'sm' }}
             weight="medium"
             className="tabular-nums"
@@ -94,16 +117,18 @@ function WorkforceSection({ workforce, variant }: { workforce: WorkforceInfo; va
             {workforce.idle}/{workforce.total}
           </ResponsiveText>
         </div>
-        
+
         <div className="text-center">
-          <ResponsiveText 
+          <ResponsiveText
+            screenSize={screenSize}
             size={{ mobile: 'xs', tablet: 'xs', desktop: 'xs', wide: 'sm' }}
             color="muted"
             className="block mb-1"
           >
             Needed
           </ResponsiveText>
-          <ResponsiveText 
+          <ResponsiveText
+            screenSize={screenSize}
             size={{ mobile: 'xs', tablet: 'sm', desktop: 'sm', wide: 'sm' }}
             weight="medium"
             className="tabular-nums"
@@ -160,15 +185,16 @@ const resourceIcons = {
   )
 };
 
-export function ModularResourcePanel({ 
-  resources, 
-  workforce, 
-  changes, 
-  shortages, 
+export function ModularResourcePanel({
+  resources,
+  workforce,
+  changes,
+  shortages,
   variant = 'default',
-  collapsible = true 
+  collapsible = true
 }: ModularResourcePanelProps) {
   const [isCollapsed, setIsCollapsed] = useState(false);
+  const { screenSize } = useHUDLayout();
   
   // Register this panel with the HUD system
   useHUDPanel({
@@ -201,6 +227,7 @@ export function ModularResourcePanel({
 
   return (
     <ResponsivePanel
+      screenSize={screenSize}
       title={variant !== 'minimal' ? 'Resources' : 'Res'}
       icon={titleIcon}
       variant={variant}
@@ -211,73 +238,81 @@ export function ModularResourcePanel({
       className="min-w-0"
     >
       <div className="space-y-1">
-        <ResourceItem 
-          label="Grain" 
-          value={resources.grain} 
-          delta={changes.grain} 
+        <ResourceItem
+          screenSize={screenSize}
+          label="Grain"
+          value={resources.grain}
+          delta={changes.grain}
           danger={!!shortages?.grain}
           icon={resourceIcons.grain}
           variant={variant}
         />
-        <ResourceItem 
-          label="Wood" 
-          value={resources.wood} 
-          delta={changes.wood} 
+        <ResourceItem
+          screenSize={screenSize}
+          label="Wood"
+          value={resources.wood}
+          delta={changes.wood}
           danger={!!shortages?.wood}
           icon={resourceIcons.wood}
           variant={variant}
         />
-        <ResourceItem 
-          label="Planks" 
-          value={resources.planks} 
-          delta={changes.planks} 
+        <ResourceItem
+          screenSize={screenSize}
+          label="Planks"
+          value={resources.planks}
+          delta={changes.planks}
           danger={!!shortages?.planks}
           icon={resourceIcons.planks}
           variant={variant}
         />
-        <ResourceItem 
-          label="Coin" 
-          value={resources.coin} 
-          delta={changes.coin} 
+        <ResourceItem
+          screenSize={screenSize}
+          label="Coin"
+          value={resources.coin}
+          delta={changes.coin}
           danger={!!shortages?.coin}
           icon={resourceIcons.coin}
           variant={variant}
         />
-        <ResourceItem 
-          label="Mana" 
-          value={resources.mana} 
-          delta={changes.mana} 
+        <ResourceItem
+          screenSize={screenSize}
+          label="Mana"
+          value={resources.mana}
+          delta={changes.mana}
           danger={!!shortages?.mana}
           icon={resourceIcons.mana}
           variant={variant}
         />
-        <ResourceItem 
-          label="Favor" 
-          value={resources.favor} 
-          delta={changes.favor} 
+        <ResourceItem
+          screenSize={screenSize}
+          label="Favor"
+          value={resources.favor}
+          delta={changes.favor}
           danger={!!shortages?.favor}
           icon={resourceIcons.favor}
           variant={variant}
         />
-        <ResourceItem 
-          label="Unrest" 
-          value={resources.unrest} 
-          delta={changes.unrest} 
+        <ResourceItem
+          screenSize={screenSize}
+          label="Unrest"
+          value={resources.unrest}
+          delta={changes.unrest}
           danger={resources.unrest >= 80}
           icon={resourceIcons.unrest}
           variant={variant}
         />
-        <ResourceItem 
-          label="Threat" 
-          value={resources.threat} 
-          delta={changes.threat} 
+        <ResourceItem
+          screenSize={screenSize}
+          label="Threat"
+          value={resources.threat}
+          delta={changes.threat}
           danger={resources.threat >= 70}
           icon={resourceIcons.threat}
           variant={variant}
         />
       </div>
-      
-      <WorkforceSection workforce={workforce} variant={variant} />
+
+      <WorkforceSection workforce={workforce} variant={variant} screenSize={screenSize} />
     </ResponsivePanel>
   );
 }

--- a/src/components/game/hud/panels/ModularSkillTreePanel.tsx
+++ b/src/components/game/hud/panels/ModularSkillTreePanel.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { ResponsivePanel, ResponsiveButton } from '../ResponsiveHUDPanels';
+import { ResponsivePanel, ResponsiveButton } from '@arcane/ui/responsive';
 import { useHUDPanel } from '../HUDPanelRegistry';
+import { useHUDLayout } from '../HUDLayoutSystem';
 import { generateSkillTree } from '../../skills/generate';
 import type { SkillNode } from '../../skills/types';
 import { collectUnlockBlockers } from '../../skills/unlock';
@@ -34,6 +35,7 @@ export function ModularSkillTreePanel({ seed = 12345, onUnlock, variant = 'compa
     component: ModularSkillTreePanel,
     props: { seed: effectiveSeed, variant }
   });
+  const { screenSize } = useHUDLayout();
   const tree = useMemo(() => generateSkillTree(effectiveSeed), [effectiveSeed]);
   const [query, setQuery] = useState('');
   const [showAll, setShowAll] = useState(false);
@@ -127,6 +129,7 @@ export function ModularSkillTreePanel({ seed = 12345, onUnlock, variant = 'compa
 
   return (
     <ResponsivePanel
+      screenSize={screenSize}
       title={variant === 'minimal' ? 'Skills' : 'Skill Tree'}
       icon={(
         <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -261,9 +264,10 @@ export function ModularSkillTreePanel({ seed = 12345, onUnlock, variant = 'compa
                   </div>
                 </div>
                 <div className="flex-shrink-0">
-                  <ResponsiveButton 
-                    onClick={() => handleUnlock(n)} 
-                    variant='primary' 
+                  <ResponsiveButton
+                    screenSize={screenSize}
+                    onClick={() => handleUnlock(n)}
+                    variant='primary'
                     size={{ mobile: 'xs', tablet: 'xs', desktop: 'sm', wide: 'sm' }}
                     className="shadow-sm hover:shadow-md transition-shadow"
                   >

--- a/src/components/game/hud/panels/ModularTimePanel.tsx
+++ b/src/components/game/hud/panels/ModularTimePanel.tsx
@@ -1,6 +1,14 @@
 import React, { useState } from 'react';
-import { ResponsivePanel, ResponsiveText, ResponsiveGrid, ResponsiveButton, ResponsiveIcon } from '../ResponsiveHUDPanels';
+import {
+  ResponsivePanel,
+  ResponsiveText,
+  ResponsiveGrid,
+  ResponsiveButton,
+  ResponsiveIcon,
+  type ResponsiveScreenSize
+} from '@arcane/ui/responsive';
 import { useHUDPanel } from '../HUDPanelRegistry';
+import { useHUDLayout } from '../HUDLayoutSystem';
 import type { GameTime } from '../types';
 
 interface ModularTimePanelProps {
@@ -20,29 +28,33 @@ interface TimeDisplayProps {
   value: string | number;
   variant?: 'default' | 'compact' | 'minimal';
   icon?: React.ReactNode;
+  screenSize: ResponsiveScreenSize;
 }
 
-function TimeDisplay({ label, value, variant = 'default', icon }: TimeDisplayProps) {
+function TimeDisplay({ label, value, variant = 'default', icon, screenSize }: TimeDisplayProps) {
   return (
     <div className="text-center">
       {icon && variant !== 'minimal' && (
-        <ResponsiveIcon 
+        <ResponsiveIcon
+          screenSize={screenSize}
           size={{ mobile: 'xs', tablet: 'sm', desktop: 'sm', wide: 'md' }}
           className="text-gray-400 mx-auto mb-1"
         >
           {icon}
         </ResponsiveIcon>
       )}
-      
-      <ResponsiveText 
+
+      <ResponsiveText
+        screenSize={screenSize}
         size={{ mobile: 'xs', tablet: 'xs', desktop: 'xs', wide: 'sm' }}
         color="muted"
         className="block mb-1"
       >
         {variant === 'minimal' ? label.slice(0, 3) : label}
       </ResponsiveText>
-      
-      <ResponsiveText 
+
+      <ResponsiveText
+        screenSize={screenSize}
         size={{ mobile: 'xs', tablet: 'sm', desktop: 'sm', wide: 'sm' }}
         weight="semibold"
         className="tabular-nums"
@@ -59,13 +71,15 @@ interface TimeControlsProps {
   onResume?: () => void;
   onAdvanceCycle?: () => void;
   variant?: 'default' | 'compact' | 'minimal';
+  screenSize: ResponsiveScreenSize;
 }
 
-function TimeControls({ isPaused, onPause, onResume, onAdvanceCycle, variant = 'default' }: TimeControlsProps) {
+function TimeControls({ isPaused, onPause, onResume, onAdvanceCycle, variant = 'default', screenSize }: TimeControlsProps) {
   if (variant === 'minimal') {
     return (
       <div className="flex items-center gap-1 justify-center">
         <ResponsiveButton
+          screenSize={screenSize}
           onClick={isPaused ? onResume : onPause}
           variant={isPaused ? 'success' : 'secondary'}
           size={{ mobile: 'xs', tablet: 'xs', desktop: 'sm', wide: 'sm' }}
@@ -73,6 +87,7 @@ function TimeControls({ isPaused, onPause, onResume, onAdvanceCycle, variant = '
           {isPaused ? '▶' : '⏸'}
         </ResponsiveButton>
         <ResponsiveButton
+          screenSize={screenSize}
           onClick={onAdvanceCycle}
           variant="primary"
           size={{ mobile: 'xs', tablet: 'xs', desktop: 'sm', wide: 'sm' }}
@@ -86,6 +101,7 @@ function TimeControls({ isPaused, onPause, onResume, onAdvanceCycle, variant = '
   return (
     <div className="flex items-center gap-2 justify-center">
       <ResponsiveButton
+        screenSize={screenSize}
         onClick={isPaused ? onResume : onPause}
         variant={isPaused ? 'success' : 'secondary'}
         size={{ mobile: 'xs', tablet: 'sm', desktop: 'sm', wide: 'md' }}
@@ -93,6 +109,7 @@ function TimeControls({ isPaused, onPause, onResume, onAdvanceCycle, variant = '
         {isPaused ? 'Resume' : 'Pause'}
       </ResponsiveButton>
       <ResponsiveButton
+        screenSize={screenSize}
         onClick={onAdvanceCycle}
         variant="primary"
         size={{ mobile: 'xs', tablet: 'sm', desktop: 'sm', wide: 'md' }}
@@ -122,18 +139,19 @@ const timeIcons = {
   )
 };
 
-export function ModularTimePanel({ 
-  time, 
-  isPaused, 
-  onPause, 
-  onResume, 
-  onAdvanceCycle, 
+export function ModularTimePanel({
+  time,
+  isPaused,
+  onPause,
+  onResume,
+  onAdvanceCycle,
   intervalMs,
   onChangeIntervalMs,
   variant = 'default',
-  collapsible = true 
+  collapsible = true
 }: ModularTimePanelProps) {
   const [isCollapsed, setIsCollapsed] = useState(false);
+  const { screenSize } = useHUDLayout();
   
   // Register this panel with the HUD system
   useHUDPanel({
@@ -174,6 +192,7 @@ export function ModularTimePanel({
 
   return (
     <ResponsivePanel
+      screenSize={screenSize}
       title={variant === 'minimal' ? 'Time' : 'Time Controls'}
       icon={titleIcon}
       variant={variant}
@@ -183,43 +202,48 @@ export function ModularTimePanel({
       priority="high"
       className="min-w-0"
     >
-      <ResponsiveGrid 
-        columns={{ 
-          mobile: variant === 'minimal' ? 3 : 2, 
-          tablet: 3, 
-          desktop: 3, 
-          wide: 3 
+      <ResponsiveGrid
+        screenSize={screenSize}
+        columns={{
+          mobile: variant === 'minimal' ? 3 : 2,
+          tablet: 3,
+          desktop: 3,
+          wide: 3
         }}
         gap={variant === 'minimal' ? 'sm' : 'md'}
         className="mb-3"
       >
-        <TimeDisplay 
-          label="Cycle" 
-          value={time.cycle} 
+        <TimeDisplay
+          label="Cycle"
+          value={time.cycle}
           variant={variant}
           icon={timeIcons.cycle}
+          screenSize={screenSize}
         />
-        <TimeDisplay 
-          label="Season" 
-          value={time.season} 
+        <TimeDisplay
+          label="Season"
+          value={time.season}
           variant={variant}
           icon={timeIcons.season}
+          screenSize={screenSize}
         />
-        <TimeDisplay 
-          label={variant === 'minimal' ? 'Next' : 'Next in'} 
-          value={formatTimeRemaining(time.timeRemaining)} 
+        <TimeDisplay
+          label={variant === 'minimal' ? 'Next' : 'Next in'}
+          value={formatTimeRemaining(time.timeRemaining)}
           variant={variant}
           icon={timeIcons.timer}
+          screenSize={screenSize}
         />
       </ResponsiveGrid>
       
       <div className="pt-2 border-t border-gray-700">
-        <TimeControls 
+        <TimeControls
           isPaused={isPaused}
           onPause={onPause}
           onResume={onResume}
           onAdvanceCycle={onAdvanceCycle}
           variant={variant}
+          screenSize={screenSize}
         />
       </div>
 

--- a/src/components/game/hud/panels/ModularWorkerPanel.tsx
+++ b/src/components/game/hud/panels/ModularWorkerPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState, useEffect } from 'react';
-import { ResponsivePanel, ResponsiveText } from '../ResponsiveHUDPanels';
+import { ResponsivePanel, ResponsiveText } from '@arcane/ui/responsive';
 import { useHUDPanel } from '../HUDPanelRegistry';
+import { useHUDLayout } from '../HUDLayoutSystem';
 import { SIM_BUILDINGS } from '@/components/game/simCatalog';
 import type { SimResources } from '@/components/game/resourceUtils';
 
@@ -29,6 +30,7 @@ export default function ModularWorkerPanel({ buildings, idleWorkers, onAssign, o
   const prevIdleRef = useRef(idleWorkers);
   const collapseTimerRef = useRef<number | null>(null);
   const panelRef = useRef<HTMLDivElement | null>(null);
+  const { screenSize } = useHUDLayout();
 
   // Auto-expand when new idle workers become available
   useEffect(() => {
@@ -113,6 +115,7 @@ export default function ModularWorkerPanel({ buildings, idleWorkers, onAssign, o
 
   return (
     <ResponsivePanel
+      screenSize={screenSize}
       title={variant !== 'minimal' ? 'Workforce' : 'W'}
       icon={titleIcon}
       variant={variant}
@@ -150,7 +153,13 @@ export default function ModularWorkerPanel({ buildings, idleWorkers, onAssign, o
       <div className="text-[10px] text-gray-400 mb-2">Upkeep ~{Math.round((totalWorkers || 0) * 0.2)} grain / cycle</div>
       <div className="space-y-2">
         {buildings.length === 0 && (
-          <ResponsiveText size={{ mobile: 'xs', tablet: 'xs', desktop: 'sm', wide: 'sm' }} color="muted">No buildings</ResponsiveText>
+          <ResponsiveText
+            screenSize={screenSize}
+            size={{ mobile: 'xs', tablet: 'xs', desktop: 'sm', wide: 'sm' }}
+            color="muted"
+          >
+            No buildings
+          </ResponsiveText>
         )}
         {buildings.map(b => {
           const def = SIM_BUILDINGS[b.typeId];


### PR DESCRIPTION
## Summary
- extract responsive HUD primitives into `packages/ui/src/responsive` with explicit `screenSize` props and re-export them from the UI package index
- add a HUD adapter that injects `useHUDLayout` screen size context and update HUD panels to import the shared primitives while threading `screenSize` into helper components
- add `responsiveAtoms` vitest coverage to verify the responsive class name calculations for the shared atoms

## Testing
- `npm run lint` *(passes with existing warnings in unrelated modules)*
- `npx vitest run packages/ui/src/responsive/__tests__/responsiveAtoms.test.tsx`
- `npm run test` *(fails in existing `useCityManagement` suite and glob resolution for `src/hooks/**/*.test.{ts,tsx}`)*
- `npm run build` *(fails due to pre-existing duplicate `getCitizenState` implementation in `packages/engine/src/simulation/citizenAI.ts`)*

------
https://chatgpt.com/codex/tasks/task_e_68cac6d5ec688325a471035958502e11