### PR TITLE
Refactor HUD preset management into dedicated hook and data module

### DIFF
--- a/src/components/game/hud/HUDLayoutPresets.tsx
+++ b/src/components/game/hud/HUDLayoutPresets.tsx
@@ -1,38 +1,40 @@
-import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
-import { HUDZone, HUDLayoutConfig, ResponsiveBreakpoints } from './HUDLayoutSystem';
-import { HUDPanelConfig } from './HUDPanelRegistry';
+import React, { createContext, useContext, type ReactNode } from 'react';
+import { useHudPresetManager, type HudPresetManagerOptions, type HudPresetManager } from './hooks/useHudPresetManager';
+import { defaultHudPresets } from './presets/defaultPresets';
+import type { HUDLayoutPresetId } from './presets/types';
 
-// Layout preset interface
-export interface HUDLayoutPreset {
-  id: string;
-  name: string;
-  description: string;
-  icon?: React.ReactNode;
-  layout: HUDLayoutConfig;
-  panelConfigs: Record<string, Partial<HUDPanelConfig>>;
-  panelVariants: Record<string, 'default' | 'compact' | 'minimal'>;
-  features: {
-    autoHide?: boolean;
-    smartCollapse?: boolean;
-    contextualPanels?: boolean;
-    adaptiveLayout?: boolean;
-  };
+export type HUDLayoutPresetContextValue = HudPresetManager;
+
+interface HUDLayoutPresetProviderProps {
+  children: ReactNode;
+  defaultPreset?: HUDLayoutPresetId;
+  storage?: HudPresetManagerOptions['storage'];
+  storageKeys?: HudPresetManagerOptions['storageKeys'];
 }
 
-// Preset context
-interface HUDLayoutPresetContextType {
-  currentPreset: HUDLayoutPreset;
-  availablePresets: HUDLayoutPreset[];
-  setPreset: (presetId: string) => void;
-  customizePreset: (presetId: string, customizations: Partial<HUDLayoutPreset>) => void;
-  resetPreset: (presetId: string) => void;
-  createCustomPreset: (preset: HUDLayoutPreset) => void;
-  deleteCustomPreset: (presetId: string) => void;
+const HUDLayoutPresetContext = createContext<HUDLayoutPresetContextValue | null>(null);
+
+export function HUDLayoutPresetProvider({
+  children,
+  defaultPreset = 'default',
+  storage,
+  storageKeys,
+}: HUDLayoutPresetProviderProps) {
+  const manager = useHudPresetManager({
+    basePresets: defaultHudPresets,
+    defaultPresetId: defaultPreset,
+    storage,
+    storageKeys,
+  });
+
+  return (
+    <HUDLayoutPresetContext.Provider value={manager}>
+      {children}
+    </HUDLayoutPresetContext.Provider>
+  );
 }
 
-const HUDLayoutPresetContext = createContext<HUDLayoutPresetContextType | null>(null);
-
-export function useHUDLayoutPresets() {
+export function useHUDLayoutPresets(): HUDLayoutPresetContextValue {
   const context = useContext(HUDLayoutPresetContext);
   if (!context) {
     throw new Error('useHUDLayoutPresets must be used within a HUDLayoutPresetProvider');
@@ -40,307 +42,8 @@ export function useHUDLayoutPresets() {
   return context;
 }
 
-// Default presets
-const DEFAULT_PRESETS: HUDLayoutPreset[] = [
-  {
-    id: 'default',
-    name: 'Default Layout',
-    description: 'Balanced layout with all panels visible and accessible',
-    icon: (
-      <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z" />
-      </svg>
-    ),
-    layout: {
-      zones: {
-        'top-left': { enabled: true, className: 'absolute top-4 left-4 z-40', maxPanels: 2, priority: 8 },
-        'top-center': { enabled: true, className: 'absolute top-4 left-1/2 -translate-x-1/2 z-40', maxPanels: 1, priority: 10 },
-        'top-right': { enabled: false, className: '' },
-        'middle-left': { enabled: true, className: 'absolute left-4 top-1/2 -translate-y-1/2 z-40', maxPanels: 2, priority: 7 },
-        'middle-center': { enabled: false, className: '' },
-        'middle-right': { enabled: false, className: '' },
-        'bottom-left': { enabled: true, className: 'absolute bottom-4 left-4 z-40', maxPanels: 2, priority: 5 },
-        'bottom-center': { enabled: true, className: 'absolute bottom-4 left-1/2 -translate-x-1/2 z-40', maxPanels: 1, priority: 4 },
-        'bottom-right': { enabled: true, className: 'absolute bottom-4 right-4 z-40', maxPanels: 2, priority: 3 },
-        'sidebar-left': { enabled: false, className: '' },
-        'sidebar-right': { enabled: true, className: 'absolute top-0 right-0 h-full w-[300px] md:w-[340px] lg:w-[360px] flex flex-col gap-2 md:gap-3 p-3 md:p-4 overflow-y-auto z-40 bg-gray-900/30 backdrop-blur-md border-l border-gray-800', maxPanels: 12, priority: 2 },
-        'overlay': { enabled: true, className: 'absolute inset-0 z-50 pointer-events-none', priority: 11 }
-      },
-      responsive: {
-        mobile: ['sidebar-right', 'overlay'],
-        tablet: ['top-center', 'bottom-center', 'sidebar-right', 'overlay'],
-        desktop: ['top-left', 'top-center', 'middle-left', 'bottom-center', 'sidebar-right', 'overlay'],
-        wide: ['top-left', 'top-center', 'bottom-left', 'bottom-center', 'bottom-right', 'sidebar-right', 'overlay']
-      }
-    },
-    panelConfigs: {
-      'resources': { priority: 10, persistent: true },
-      'time-panel': { priority: 9, persistent: true },
-      'action-panel': { priority: 8 },
-      'status-bar': { priority: 7 },
-      'top-bar': { priority: 11, persistent: true }
-    },
-    panelVariants: {
-      'resources': 'default',
-      'time-panel': 'compact',
-      'action-panel': 'compact',
-      'status-bar': 'default',
-      'top-bar': 'default'
-    },
-    features: {
-      autoHide: false,
-      smartCollapse: true,
-      contextualPanels: false,
-      adaptiveLayout: true
-    }
-  },
-  {
-    id: 'compact',
-    name: 'Compact Layout',
-    description: 'Space-efficient layout with smaller panels and smart collapsing',
-    icon: (
-      <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 10h16M4 14h16M4 18h16" />
-      </svg>
-    ),
-    layout: {
-      zones: {
-        'top-left': { enabled: false, className: '' },
-        'top-center': { enabled: true, className: 'absolute top-4 left-1/2 -translate-x-1/2 z-40', maxPanels: 1, priority: 10 },
-        'top-right': { enabled: false, className: '' },
-        'middle-left': { enabled: false, className: '' },
-        'middle-center': { enabled: false, className: '' },
-        'middle-right': { enabled: false, className: '' },
-        'bottom-left': { enabled: false, className: '' },
-        'bottom-center': { enabled: true, className: 'absolute bottom-4 left-1/2 -translate-x-1/2 z-40', maxPanels: 1, priority: 7 },
-        'bottom-right': { enabled: false, className: '' },
-        'sidebar-left': { enabled: false, className: '' },
-        'sidebar-right': { enabled: true, className: 'absolute top-0 right-0 h-full w-[300px] md:w-[340px] lg:w-[360px] flex flex-col gap-2 md:gap-3 p-3 md:p-4 overflow-y-auto z-40 bg-gray-900/30 backdrop-blur-md border-l border-gray-800', maxPanels: 12, priority: 6 },
-        'overlay': { enabled: true, className: 'absolute inset-0 z-50 pointer-events-none', priority: 11 }
-      },
-      responsive: {
-        mobile: ['sidebar-right', 'overlay'],
-        tablet: ['top-center', 'sidebar-right', 'overlay'],
-        desktop: ['top-center', 'sidebar-right', 'overlay'],
-        wide: ['top-center', 'bottom-center', 'sidebar-right', 'overlay']
-      }
-    },
-    panelConfigs: {
-      'resources': { priority: 10, persistent: true },
-      'time-panel': { priority: 9, persistent: true, responsive: { collapseOnMobile: true } },
-      'action-panel': { priority: 8, responsive: { hideOnMobile: true } }
-    },
-    panelVariants: {
-      'resources': 'compact',
-      'time-panel': 'compact',
-      'action-panel': 'compact'
-    },
-    features: {
-      autoHide: true,
-      smartCollapse: true,
-      contextualPanels: true,
-      adaptiveLayout: true
-    }
-  },
-  {
-    id: 'minimal',
-    name: 'Minimal Layout',
-    description: 'Clean, distraction-free layout with only essential information',
-    icon: (
-      <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 12H4" />
-      </svg>
-    ),
-    layout: {
-      zones: {
-        'top-left': { enabled: false, className: '' },
-        'top-center': { enabled: false, className: '' },
-        'top-right': { enabled: false, className: '' },
-        'middle-left': { enabled: false, className: '' },
-        'middle-center': { enabled: false, className: '' },
-        'middle-right': { enabled: false, className: '' },
-        'bottom-left': { enabled: false, className: '' },
-        'bottom-center': { enabled: false, className: '' },
-        'bottom-right': { enabled: false, className: '' },
-        'sidebar-left': { enabled: false, className: '' },
-        'sidebar-right': { enabled: true, className: 'absolute top-0 right-0 h-full w-[280px] md:w-[300px] lg:w-[320px] flex flex-col gap-2 md:gap-3 p-3 overflow-y-auto z-40 bg-gray-900/30 backdrop-blur-md border-l border-gray-800', maxPanels: 8, priority: 6 },
-        'overlay': { enabled: true, className: 'absolute inset-0 z-50 pointer-events-none', priority: 11 }
-      },
-      responsive: {
-        mobile: ['sidebar-right', 'overlay'],
-        tablet: ['sidebar-right', 'overlay'],
-        desktop: ['sidebar-right', 'overlay'],
-        wide: ['sidebar-right', 'overlay']
-      }
-    },
-    panelConfigs: {
-      'resources': { priority: 10, persistent: true },
-      'time-panel': { priority: 9, persistent: true },
-      'action-panel': { priority: 8 }
-    },
-    panelVariants: {
-      'resources': 'minimal',
-      'time-panel': 'minimal',
-      'action-panel': 'minimal'
-    },
-    features: {
-      autoHide: true,
-      smartCollapse: false,
-      contextualPanels: false,
-      adaptiveLayout: true
-    }
-  },
-  {
-    id: 'immersive',
-    name: 'Immersive Layout',
-    description: 'Maximum screen space for gameplay with auto-hiding panels',
-    icon: (
-      <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
-      </svg>
-    ),
-    layout: {
-      zones: {
-        'top-left': { enabled: false, className: '' },
-        'top-center': { enabled: false, className: '' },
-        'top-right': { enabled: false, className: '' },
-        'middle-left': { enabled: false, className: '' },
-        'middle-center': { enabled: false, className: '' },
-        'middle-right': { enabled: false, className: '' },
-        'bottom-left': { enabled: false, className: '' },
-        'bottom-center': { enabled: false, className: '' },
-        'bottom-right': { enabled: false, className: '' },
-        'sidebar-left': { enabled: false, className: '' },
-        'sidebar-right': { enabled: true, className: 'absolute top-0 right-0 h-full w-[280px] md:w-[300px] lg:w-[320px] flex flex-col gap-2 md:gap-3 p-3 overflow-y-auto z-40 bg-gray-900/30 backdrop-blur-md border-l border-gray-800', maxPanels: 6, priority: 6 },
-        'overlay': { enabled: true, className: 'absolute inset-0 z-50 pointer-events-none', priority: 11 }
-      },
-      responsive: {
-        mobile: ['overlay'],
-        tablet: ['sidebar-right', 'overlay'],
-        desktop: ['sidebar-right', 'overlay'],
-        wide: ['sidebar-right', 'overlay']
-      }
-    },
-    panelConfigs: {
-      'resources': { priority: 10, persistent: false },
-      'time-panel': { priority: 9, persistent: true }
-    },
-    panelVariants: {
-      'resources': 'minimal',
-      'time-panel': 'minimal'
-    },
-    features: {
-      autoHide: true,
-      smartCollapse: false,
-      contextualPanels: true,
-      adaptiveLayout: true
-    }
-  }
-];
-
-interface HUDLayoutPresetProviderProps {
-  children: ReactNode;
-  defaultPreset?: string;
-}
-
-export function HUDLayoutPresetProvider({ children, defaultPreset = 'default' }: HUDLayoutPresetProviderProps) {
-  const [presets, setPresets] = useState<HUDLayoutPreset[]>(DEFAULT_PRESETS);
-  const [currentPresetId, setCurrentPresetId] = useState(defaultPreset);
-  const [customPresets, setCustomPresets] = useState<HUDLayoutPreset[]>([]);
-
-  // Load custom presets from localStorage on mount
-  useEffect(() => {
-    const savedPresets = localStorage.getItem('hud-custom-presets');
-    if (savedPresets) {
-      try {
-        const parsed = JSON.parse(savedPresets);
-        setCustomPresets(parsed);
-      } catch (error) {
-        console.warn('Failed to load custom HUD presets:', error);
-      }
-    }
-
-    const savedCurrentPreset = localStorage.getItem('hud-current-preset');
-    if (savedCurrentPreset) {
-      setCurrentPresetId(savedCurrentPreset);
-    }
-  }, []);
-
-  // Save custom presets to localStorage
-  useEffect(() => {
-    localStorage.setItem('hud-custom-presets', JSON.stringify(customPresets));
-  }, [customPresets]);
-
-  // Save current preset to localStorage
-  useEffect(() => {
-    localStorage.setItem('hud-current-preset', currentPresetId);
-  }, [currentPresetId]);
-
-  const allPresets = [...presets, ...customPresets];
-  const currentPreset = allPresets.find(p => p.id === currentPresetId) || presets[0];
-
-  const setPreset = (presetId: string) => {
-    const preset = allPresets.find(p => p.id === presetId);
-    if (preset) {
-      setCurrentPresetId(presetId);
-    }
-  };
-
-  const customizePreset = (presetId: string, customizations: Partial<HUDLayoutPreset>) => {
-    const preset = allPresets.find(p => p.id === presetId);
-    if (preset) {
-      const customizedPreset = { ...preset, ...customizations };
-      
-      if (presets.find(p => p.id === presetId)) {
-        // If it's a default preset, create a new custom preset
-        const newPreset = {
-          ...customizedPreset,
-          id: `${presetId}-custom-${Date.now()}`,
-          name: `${preset.name} (Custom)`
-        };
-        setCustomPresets(prev => [...prev, newPreset]);
-        setCurrentPresetId(newPreset.id);
-      } else {
-        // If it's already a custom preset, update it
-        setCustomPresets(prev => prev.map(p => p.id === presetId ? customizedPreset : p));
-      }
-    }
-  };
-
-  const resetPreset = (presetId: string) => {
-    const originalPreset = DEFAULT_PRESETS.find(p => p.id === presetId);
-    if (originalPreset) {
-      setCustomPresets(prev => prev.filter(p => !p.id.startsWith(`${presetId}-custom`)));
-      setCurrentPresetId(presetId);
-    }
-  };
-
-  const createCustomPreset = (preset: HUDLayoutPreset) => {
-    setCustomPresets(prev => [...prev, preset]);
-  };
-
-  const deleteCustomPreset = (presetId: string) => {
-    setCustomPresets(prev => prev.filter(p => p.id !== presetId));
-    if (currentPresetId === presetId) {
-      setCurrentPresetId('default');
-    }
-  };
-
-  const contextValue: HUDLayoutPresetContextType = {
-    currentPreset,
-    availablePresets: allPresets,
-    setPreset,
-    customizePreset,
-    resetPreset,
-    createCustomPreset,
-    deleteCustomPreset
-  };
-
-  return (
-    <HUDLayoutPresetContext.Provider value={contextValue}>
-      {children}
-    </HUDLayoutPresetContext.Provider>
-  );
-}
+export { defaultHudPresets } from './presets/defaultPresets';
+export type { HUDLayoutPreset, HUDLayoutPresetIconData, HUDLayoutPresetId } from './presets/types';
+export type { HudPresetManager } from './hooks/useHudPresetManager';
 
 export default HUDLayoutPresetProvider;

--- a/src/components/game/hud/HUDSettingsPanel.tsx
+++ b/src/components/game/hud/HUDSettingsPanel.tsx
@@ -1,9 +1,26 @@
 import React from 'react';
-import { useHUDLayoutPresets } from './HUDLayoutPresets';
+import { useHUDLayoutPresets, type HUDLayoutPresetIconData } from './HUDLayoutPresets';
 
 interface HUDSettingsPanelProps {
   isOpen: boolean;
   onClose: () => void;
+}
+
+function HUDPresetIcon({ icon }: { icon: HUDLayoutPresetIconData }) {
+  const { viewBox = '0 0 24 24', paths } = icon;
+  return (
+    <svg fill="none" stroke="currentColor" viewBox={viewBox} aria-hidden="true">
+      {paths.map(({ d, strokeLinecap = 'round', strokeLinejoin = 'round', strokeWidth = 2 }) => (
+        <path
+          key={d}
+          d={d}
+          strokeLinecap={strokeLinecap}
+          strokeLinejoin={strokeLinejoin}
+          strokeWidth={strokeWidth}
+        />
+      ))}
+    </svg>
+  );
 }
 
 export function HUDSettingsPanel({ isOpen, onClose }: HUDSettingsPanelProps) {
@@ -46,7 +63,7 @@ export function HUDSettingsPanel({ isOpen, onClose }: HUDSettingsPanelProps) {
                   <div className="flex items-center space-x-2">
                     {preset.icon && (
                       <div className="w-4 h-4 text-gray-300">
-                        {preset.icon}
+                        <HUDPresetIcon icon={preset.icon} />
                       </div>
                     )}
                     <div>

--- a/src/components/game/hud/__tests__/useHudPresetManager.test.ts
+++ b/src/components/game/hud/__tests__/useHudPresetManager.test.ts
@@ -1,0 +1,101 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { defaultHudPresets } from '../presets/defaultPresets';
+import {
+  createInMemoryPresetStorage,
+  useHudPresetManager,
+} from '../hooks/useHudPresetManager';
+
+describe('useHudPresetManager', () => {
+  it('creates and retrieves custom presets without mutating base presets', () => {
+    const storage = createInMemoryPresetStorage();
+    const { result } = renderHook(() =>
+      useHudPresetManager({ basePresets: defaultHudPresets, storage })
+    );
+
+    const customPreset = {
+      ...defaultHudPresets[0],
+      id: 'custom-one',
+      name: 'Custom One',
+    };
+
+    act(() => {
+      result.current.createCustomPreset(customPreset);
+    });
+
+    expect(result.current.customPresets).toHaveLength(1);
+    expect(result.current.getPresetById('custom-one')).toEqual(customPreset);
+    expect(result.current.isCustomPreset('custom-one')).toBe(true);
+    expect(result.current.availablePresets).toContainEqual(customPreset);
+    expect(result.current.basePresets[0].id).toBe(defaultHudPresets[0].id);
+  });
+
+  it('customizes presets by cloning defaults and updating custom entries', () => {
+    const storage = createInMemoryPresetStorage();
+    const { result } = renderHook(() =>
+      useHudPresetManager({ basePresets: defaultHudPresets, storage })
+    );
+
+    let customId: string | null = null;
+    act(() => {
+      customId = result.current.customizePreset('default', { name: 'Tailored Layout' });
+    });
+
+    expect(customId).toBeTruthy();
+    expect(result.current.customPresets).toHaveLength(1);
+    expect(result.current.currentPreset.id).toBe(customId);
+    expect(result.current.currentPreset.name).toBe('Tailored Layout');
+
+    act(() => {
+      result.current.customizePreset(customId!, { description: 'Updated description' });
+    });
+
+    expect(result.current.customPresets).toHaveLength(1);
+    expect(result.current.currentPreset.id).toBe(customId);
+    expect(result.current.currentPreset.description).toBe('Updated description');
+  });
+
+  it('resets and deletes custom presets, restoring defaults safely', () => {
+    const storage = createInMemoryPresetStorage();
+    const { result } = renderHook(() =>
+      useHudPresetManager({ basePresets: defaultHudPresets, storage })
+    );
+
+    let customId: string | null = null;
+    act(() => {
+      customId = result.current.customizePreset('default', { name: 'Temporary Layout' });
+    });
+
+    expect(result.current.currentPreset.id).toBe(customId);
+
+    act(() => {
+      result.current.resetPreset('default');
+    });
+
+    expect(result.current.customPresets).toHaveLength(0);
+    expect(result.current.currentPreset.id).toBe('default');
+
+    const removablePreset = {
+      ...defaultHudPresets[1],
+      id: 'custom-delete',
+      name: 'Delete Me',
+    };
+
+    act(() => {
+      result.current.createCustomPreset(removablePreset);
+    });
+
+    act(() => {
+      result.current.setPreset('custom-delete');
+    });
+
+    expect(result.current.currentPreset.id).toBe('custom-delete');
+
+    act(() => {
+      result.current.deleteCustomPreset('custom-delete');
+    });
+
+    expect(result.current.isCustomPreset('custom-delete')).toBe(false);
+    expect(result.current.currentPreset.id).toBe('default');
+  });
+});

--- a/src/components/game/hud/hooks/useHudPresetManager.ts
+++ b/src/components/game/hud/hooks/useHudPresetManager.ts
@@ -1,0 +1,301 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type {
+  HUDLayoutPreset,
+  HUDLayoutPresetId,
+} from '../presets/types';
+
+const DEFAULT_STORAGE_KEYS = {
+  customPresets: 'hud-custom-presets',
+  currentPreset: 'hud-current-preset',
+};
+
+type StorageLike = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+
+const memoryStorage = (() => {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => (store.has(key) ? store.get(key) ?? null : null),
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+  } satisfies StorageLike;
+})();
+
+function resolveStorage(storage?: StorageLike): StorageLike {
+  if (storage) {
+    return storage;
+  }
+
+  if (typeof window !== 'undefined' && typeof window.localStorage !== 'undefined') {
+    return window.localStorage;
+  }
+
+  return memoryStorage;
+}
+
+function parseStoredPresets(raw: string | null): HUDLayoutPreset[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed as HUDLayoutPreset[];
+  } catch {
+    return [];
+  }
+}
+
+function createCustomPresetId(baseId: HUDLayoutPresetId) {
+  return `${baseId}-custom-${Date.now().toString(36)}`;
+}
+
+function mergePreset(base: HUDLayoutPreset, updates: Partial<HUDLayoutPreset>): HUDLayoutPreset {
+  return {
+    ...base,
+    ...updates,
+  };
+}
+
+export interface HudPresetManagerOptions {
+  basePresets: HUDLayoutPreset[];
+  defaultPresetId?: HUDLayoutPresetId;
+  storage?: StorageLike;
+  storageKeys?: Partial<typeof DEFAULT_STORAGE_KEYS>;
+}
+
+export interface HudPresetManager {
+  basePresets: HUDLayoutPreset[];
+  customPresets: HUDLayoutPreset[];
+  availablePresets: HUDLayoutPreset[];
+  currentPreset: HUDLayoutPreset;
+  currentPresetId: HUDLayoutPresetId;
+  setPreset: (presetId: HUDLayoutPresetId) => void;
+  customizePreset: (presetId: HUDLayoutPresetId, updates: Partial<HUDLayoutPreset>) => HUDLayoutPresetId | null;
+  resetPreset: (presetId: HUDLayoutPresetId) => void;
+  createCustomPreset: (preset: HUDLayoutPreset) => void;
+  deleteCustomPreset: (presetId: HUDLayoutPresetId) => void;
+  getPresetById: (presetId: HUDLayoutPresetId) => HUDLayoutPreset | undefined;
+  isCustomPreset: (presetId: HUDLayoutPresetId) => boolean;
+}
+
+export function useHudPresetManager({
+  basePresets,
+  defaultPresetId,
+  storage,
+  storageKeys,
+}: HudPresetManagerOptions): HudPresetManager {
+  const resolvedStorage = useMemo(() => resolveStorage(storage), [storage]);
+  const keys = useMemo(() => ({
+    customPresets: storageKeys?.customPresets ?? DEFAULT_STORAGE_KEYS.customPresets,
+    currentPreset: storageKeys?.currentPreset ?? DEFAULT_STORAGE_KEYS.currentPreset,
+  }), [storageKeys?.customPresets, storageKeys?.currentPreset]);
+
+  const [customPresets, setCustomPresets] = useState<HUDLayoutPreset[]>(() =>
+    parseStoredPresets(resolvedStorage.getItem(keys.customPresets))
+  );
+
+  const initialPresetId = useMemo(() => {
+    const storedId = resolvedStorage.getItem(keys.currentPreset);
+    if (storedId) {
+      return storedId as HUDLayoutPresetId;
+    }
+    if (defaultPresetId) {
+      return defaultPresetId;
+    }
+    return basePresets[0]?.id ?? 'default';
+  }, [basePresets, defaultPresetId, keys.currentPreset, resolvedStorage]);
+
+  const [currentPresetId, setCurrentPresetId] = useState<HUDLayoutPresetId>(initialPresetId);
+
+  useEffect(() => {
+    const availableIds = new Set([
+      ...basePresets.map(preset => preset.id),
+      ...customPresets.map(preset => preset.id),
+    ]);
+
+    if (!availableIds.has(currentPresetId)) {
+      const fallbackId =
+        (defaultPresetId && availableIds.has(defaultPresetId) && defaultPresetId) ||
+        basePresets[0]?.id ||
+        customPresets[0]?.id;
+
+      if (fallbackId && fallbackId !== currentPresetId) {
+        setCurrentPresetId(fallbackId);
+      }
+    }
+  }, [basePresets, customPresets, currentPresetId, defaultPresetId]);
+
+  useEffect(() => {
+    try {
+      resolvedStorage.setItem(keys.customPresets, JSON.stringify(customPresets));
+    } catch (error) {
+      console.warn('Failed to persist HUD custom presets', error);
+    }
+  }, [customPresets, keys.customPresets, resolvedStorage]);
+
+  useEffect(() => {
+    try {
+      resolvedStorage.setItem(keys.currentPreset, currentPresetId);
+    } catch (error) {
+      console.warn('Failed to persist HUD current preset', error);
+    }
+  }, [currentPresetId, keys.currentPreset, resolvedStorage]);
+
+  const basePresetMap = useMemo(() => new Map(basePresets.map(preset => [preset.id, preset])), [basePresets]);
+  const customPresetMap = useMemo(
+    () => new Map(customPresets.map(preset => [preset.id, preset])),
+    [customPresets]
+  );
+
+  const availablePresets = useMemo(
+    () => [...basePresets, ...customPresets],
+    [basePresets, customPresets]
+  );
+
+  const availablePresetMap = useMemo(
+    () => new Map(availablePresets.map(preset => [preset.id, preset])),
+    [availablePresets]
+  );
+
+  const currentPreset = useMemo(() => {
+    return (
+      availablePresetMap.get(currentPresetId) ||
+      availablePresets[0] ||
+      basePresets[0]
+    );
+  }, [availablePresetMap, availablePresets, basePresets, currentPresetId]);
+
+  const setPreset = useCallback(
+    (presetId: HUDLayoutPresetId) => {
+      if (!availablePresetMap.has(presetId)) {
+        return;
+      }
+      setCurrentPresetId(presetId);
+    },
+    [availablePresetMap]
+  );
+
+  const customizePreset = useCallback(
+    (presetId: HUDLayoutPresetId, updates: Partial<HUDLayoutPreset>) => {
+      const targetPreset = availablePresetMap.get(presetId);
+      if (!targetPreset) {
+        return null;
+      }
+
+      const mergedPreset = mergePreset(targetPreset, updates);
+
+      if (basePresetMap.has(presetId)) {
+        const id = createCustomPresetId(presetId);
+        const customPreset: HUDLayoutPreset = {
+          ...mergedPreset,
+          id,
+          name: updates.name ?? `${targetPreset.name} (Custom)`,
+        };
+
+        setCustomPresets(prev => [...prev, customPreset]);
+        setCurrentPresetId(id);
+        return id;
+      }
+
+      setCustomPresets(prev =>
+        prev.map(preset => (preset.id === presetId ? { ...preset, ...mergedPreset } : preset))
+      );
+      return presetId;
+    },
+    [availablePresetMap, basePresetMap]
+  );
+
+  const resetPreset = useCallback(
+    (presetId: HUDLayoutPresetId) => {
+      if (!basePresetMap.has(presetId)) {
+        return;
+      }
+
+      setCustomPresets(prev => prev.filter(preset => !preset.id.startsWith(`${presetId}-custom`)));
+      setCurrentPresetId(presetId);
+    },
+    [basePresetMap]
+  );
+
+  const createCustomPreset = useCallback((preset: HUDLayoutPreset) => {
+    setCustomPresets(prev => {
+      const existingIndex = prev.findIndex(item => item.id === preset.id);
+      if (existingIndex === -1) {
+        return [...prev, preset];
+      }
+
+      const next = [...prev];
+      next[existingIndex] = preset;
+      return next;
+    });
+  }, []);
+
+  const deleteCustomPreset = useCallback(
+    (presetId: HUDLayoutPresetId) => {
+      setCustomPresets(prev => prev.filter(preset => preset.id !== presetId));
+      if (currentPresetId === presetId) {
+        const fallbackId = basePresets[0]?.id ?? defaultPresetId ?? availablePresets[0]?.id;
+        if (fallbackId) {
+          setCurrentPresetId(fallbackId);
+        }
+      }
+    },
+    [availablePresets, basePresets, currentPresetId, defaultPresetId]
+  );
+
+  const getPresetById = useCallback(
+    (presetId: HUDLayoutPresetId) => availablePresetMap.get(presetId),
+    [availablePresetMap]
+  );
+
+  const isCustomPreset = useCallback(
+    (presetId: HUDLayoutPresetId) => customPresetMap.has(presetId),
+    [customPresetMap]
+  );
+
+  return useMemo(
+    () => ({
+      basePresets,
+      customPresets,
+      availablePresets,
+      currentPreset,
+      currentPresetId,
+      setPreset,
+      customizePreset,
+      resetPreset,
+      createCustomPreset,
+      deleteCustomPreset,
+      getPresetById,
+      isCustomPreset,
+    }),
+    [
+      availablePresets,
+      basePresets,
+      createCustomPreset,
+      currentPreset,
+      currentPresetId,
+      customizePreset,
+      deleteCustomPreset,
+      getPresetById,
+      isCustomPreset,
+      resetPreset,
+      setPreset,
+      customPresets,
+    ]
+  );
+}
+
+export function createInMemoryPresetStorage(initial: Record<string, string> = {}): StorageLike {
+  const store = new Map<string, string>(Object.entries(initial));
+  return {
+    getItem: (key: string) => (store.has(key) ? store.get(key) ?? null : null),
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+  };
+}

--- a/src/components/game/hud/presets/defaultPresets.ts
+++ b/src/components/game/hud/presets/defaultPresets.ts
@@ -1,0 +1,248 @@
+import type { HUDLayoutPreset } from './types';
+
+const strokeDefaults = {
+  strokeLinecap: 'round' as const,
+  strokeLinejoin: 'round' as const,
+  strokeWidth: 2,
+};
+
+const viewBox = '0 0 24 24';
+
+export const defaultHudPresets: HUDLayoutPreset[] = [
+  {
+    id: 'default',
+    name: 'Default Layout',
+    description: 'Balanced layout with all panels visible and accessible',
+    icon: {
+      viewBox,
+      paths: [
+        {
+          d: 'M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z',
+          ...strokeDefaults,
+        },
+      ],
+    },
+    layout: {
+      zones: {
+        'top-left': { enabled: true, className: 'absolute top-4 left-4 z-40', maxPanels: 2, priority: 8 },
+        'top-center': { enabled: true, className: 'absolute top-4 left-1/2 -translate-x-1/2 z-40', maxPanels: 1, priority: 10 },
+        'top-right': { enabled: false, className: '' },
+        'middle-left': { enabled: true, className: 'absolute left-4 top-1/2 -translate-y-1/2 z-40', maxPanels: 2, priority: 7 },
+        'middle-center': { enabled: false, className: '' },
+        'middle-right': { enabled: false, className: '' },
+        'bottom-left': { enabled: true, className: 'absolute bottom-4 left-4 z-40', maxPanels: 2, priority: 5 },
+        'bottom-center': { enabled: true, className: 'absolute bottom-4 left-1/2 -translate-x-1/2 z-40', maxPanels: 1, priority: 4 },
+        'bottom-right': { enabled: true, className: 'absolute bottom-4 right-4 z-40', maxPanels: 2, priority: 3 },
+        'sidebar-left': { enabled: false, className: '' },
+        'sidebar-right': {
+          enabled: true,
+          className:
+            'absolute top-0 right-0 h-full w-[300px] md:w-[340px] lg:w-[360px] flex flex-col gap-2 md:gap-3 p-3 md:p-4 overflow-y-auto z-40 bg-gray-900/30 backdrop-blur-md border-l border-gray-800',
+          maxPanels: 12,
+          priority: 2,
+        },
+        overlay: { enabled: true, className: 'absolute inset-0 z-50 pointer-events-none', priority: 11 },
+      },
+      responsive: {
+        mobile: ['sidebar-right', 'overlay'],
+        tablet: ['top-center', 'bottom-center', 'sidebar-right', 'overlay'],
+        desktop: ['top-left', 'top-center', 'middle-left', 'bottom-center', 'sidebar-right', 'overlay'],
+        wide: ['top-left', 'top-center', 'bottom-left', 'bottom-center', 'bottom-right', 'sidebar-right', 'overlay'],
+      },
+    },
+    panelConfigs: {
+      resources: { priority: 10, persistent: true },
+      'time-panel': { priority: 9, persistent: true },
+      'action-panel': { priority: 8 },
+      'status-bar': { priority: 7 },
+      'top-bar': { priority: 11, persistent: true },
+    },
+    panelVariants: {
+      resources: 'default',
+      'time-panel': 'compact',
+      'action-panel': 'compact',
+      'status-bar': 'default',
+      'top-bar': 'default',
+    },
+    features: {
+      autoHide: false,
+      smartCollapse: true,
+      contextualPanels: false,
+      adaptiveLayout: true,
+    },
+  },
+  {
+    id: 'compact',
+    name: 'Compact Layout',
+    description: 'Space-efficient layout with smaller panels and smart collapsing',
+    icon: {
+      viewBox,
+      paths: [
+        {
+          d: 'M4 6h16M4 10h16M4 14h16M4 18h16',
+          ...strokeDefaults,
+        },
+      ],
+    },
+    layout: {
+      zones: {
+        'top-left': { enabled: false, className: '' },
+        'top-center': { enabled: true, className: 'absolute top-4 left-1/2 -translate-x-1/2 z-40', maxPanels: 1, priority: 10 },
+        'top-right': { enabled: false, className: '' },
+        'middle-left': { enabled: false, className: '' },
+        'middle-center': { enabled: false, className: '' },
+        'middle-right': { enabled: false, className: '' },
+        'bottom-left': { enabled: false, className: '' },
+        'bottom-center': { enabled: true, className: 'absolute bottom-4 left-1/2 -translate-x-1/2 z-40', maxPanels: 1, priority: 7 },
+        'bottom-right': { enabled: false, className: '' },
+        'sidebar-left': { enabled: false, className: '' },
+        'sidebar-right': {
+          enabled: true,
+          className:
+            'absolute top-0 right-0 h-full w-[300px] md:w-[340px] lg:w-[360px] flex flex-col gap-2 md:gap-3 p-3 md:p-4 overflow-y-auto z-40 bg-gray-900/30 backdrop-blur-md border-l border-gray-800',
+          maxPanels: 12,
+          priority: 6,
+        },
+        overlay: { enabled: true, className: 'absolute inset-0 z-50 pointer-events-none', priority: 11 },
+      },
+      responsive: {
+        mobile: ['sidebar-right', 'overlay'],
+        tablet: ['top-center', 'sidebar-right', 'overlay'],
+        desktop: ['top-center', 'sidebar-right', 'overlay'],
+        wide: ['top-center', 'bottom-center', 'sidebar-right', 'overlay'],
+      },
+    },
+    panelConfigs: {
+      resources: { priority: 10, persistent: true },
+      'time-panel': { priority: 9, persistent: true, responsive: { collapseOnMobile: true } },
+      'action-panel': { priority: 8, responsive: { hideOnMobile: true } },
+    },
+    panelVariants: {
+      resources: 'compact',
+      'time-panel': 'compact',
+      'action-panel': 'compact',
+    },
+    features: {
+      autoHide: true,
+      smartCollapse: true,
+      contextualPanels: true,
+      adaptiveLayout: true,
+    },
+  },
+  {
+    id: 'minimal',
+    name: 'Minimal Layout',
+    description: 'Clean, distraction-free layout with only essential information',
+    icon: {
+      viewBox,
+      paths: [
+        {
+          d: 'M20 12H4',
+          ...strokeDefaults,
+        },
+      ],
+    },
+    layout: {
+      zones: {
+        'top-left': { enabled: false, className: '' },
+        'top-center': { enabled: false, className: '' },
+        'top-right': { enabled: false, className: '' },
+        'middle-left': { enabled: false, className: '' },
+        'middle-center': { enabled: false, className: '' },
+        'middle-right': { enabled: false, className: '' },
+        'bottom-left': { enabled: false, className: '' },
+        'bottom-center': { enabled: false, className: '' },
+        'bottom-right': { enabled: false, className: '' },
+        'sidebar-left': { enabled: false, className: '' },
+        'sidebar-right': {
+          enabled: true,
+          className:
+            'absolute top-0 right-0 h-full w-[280px] md:w-[300px] lg:w-[320px] flex flex-col gap-2 md:gap-3 p-3 overflow-y-auto z-40 bg-gray-900/30 backdrop-blur-md border-l border-gray-800',
+          maxPanels: 8,
+          priority: 6,
+        },
+        overlay: { enabled: true, className: 'absolute inset-0 z-50 pointer-events-none', priority: 11 },
+      },
+      responsive: {
+        mobile: ['sidebar-right', 'overlay'],
+        tablet: ['sidebar-right', 'overlay'],
+        desktop: ['sidebar-right', 'overlay'],
+        wide: ['sidebar-right', 'overlay'],
+      },
+    },
+    panelConfigs: {
+      resources: { priority: 10, persistent: true },
+      'time-panel': { priority: 9, persistent: true },
+      'action-panel': { priority: 8 },
+    },
+    panelVariants: {
+      resources: 'minimal',
+      'time-panel': 'minimal',
+      'action-panel': 'minimal',
+    },
+    features: {
+      autoHide: true,
+      smartCollapse: false,
+      contextualPanels: false,
+      adaptiveLayout: true,
+    },
+  },
+  {
+    id: 'immersive',
+    name: 'Immersive Layout',
+    description: 'Maximum screen space for gameplay with auto-hiding panels',
+    icon: {
+      viewBox,
+      paths: [
+        {
+          d: 'M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z',
+          ...strokeDefaults,
+        },
+      ],
+    },
+    layout: {
+      zones: {
+        'top-left': { enabled: false, className: '' },
+        'top-center': { enabled: false, className: '' },
+        'top-right': { enabled: false, className: '' },
+        'middle-left': { enabled: false, className: '' },
+        'middle-center': { enabled: false, className: '' },
+        'middle-right': { enabled: false, className: '' },
+        'bottom-left': { enabled: false, className: '' },
+        'bottom-center': { enabled: false, className: '' },
+        'bottom-right': { enabled: false, className: '' },
+        'sidebar-left': { enabled: false, className: '' },
+        'sidebar-right': {
+          enabled: true,
+          className:
+            'absolute top-0 right-0 h-full w-[280px] md:w-[300px] lg:w-[320px] flex flex-col gap-2 md:gap-3 p-3 overflow-y-auto z-40 bg-gray-900/30 backdrop-blur-md border-l border-gray-800',
+          maxPanels: 6,
+          priority: 6,
+        },
+        overlay: { enabled: true, className: 'absolute inset-0 z-50 pointer-events-none', priority: 11 },
+      },
+      responsive: {
+        mobile: ['overlay'],
+        tablet: ['sidebar-right', 'overlay'],
+        desktop: ['sidebar-right', 'overlay'],
+        wide: ['sidebar-right', 'overlay'],
+      },
+    },
+    panelConfigs: {
+      resources: { priority: 10, persistent: false },
+      'time-panel': { priority: 9, persistent: true },
+    },
+    panelVariants: {
+      resources: 'minimal',
+      'time-panel': 'minimal',
+    },
+    features: {
+      autoHide: true,
+      smartCollapse: false,
+      contextualPanels: true,
+      adaptiveLayout: true,
+    },
+  },
+];
+
+export default defaultHudPresets;

--- a/src/components/game/hud/presets/types.ts
+++ b/src/components/game/hud/presets/types.ts
@@ -1,0 +1,32 @@
+import type { HUDLayoutConfig } from '../HUDLayoutSystem';
+import type { HUDPanelConfig } from '../panelRegistryStore';
+
+export interface HUDLayoutPresetIconPath {
+  d: string;
+  strokeLinecap?: 'butt' | 'round' | 'square';
+  strokeLinejoin?: 'arcs' | 'bevel' | 'miter' | 'miter-clip' | 'round';
+  strokeWidth?: number;
+}
+
+export interface HUDLayoutPresetIconData {
+  viewBox?: string;
+  paths: HUDLayoutPresetIconPath[];
+}
+
+export interface HUDLayoutPreset {
+  id: string;
+  name: string;
+  description: string;
+  icon?: HUDLayoutPresetIconData;
+  layout: HUDLayoutConfig;
+  panelConfigs: Record<string, Partial<HUDPanelConfig>>;
+  panelVariants: Record<string, 'default' | 'compact' | 'minimal'>;
+  features: {
+    autoHide?: boolean;
+    smartCollapse?: boolean;
+    contextualPanels?: boolean;
+    adaptiveLayout?: boolean;
+  };
+}
+
+export type HUDLayoutPresetId = HUDLayoutPreset['id'];

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,6 +22,9 @@ export default defineConfig({
       ],
       [
         'src/components/**/*.test.{ts,tsx}',
+        'jsdom',
+      ],
+      [
         'src/hooks/**/*.test.{ts,tsx}',
         'jsdom',
       ],


### PR DESCRIPTION
## Summary
- move HUD preset data into `presets/defaultPresets.ts` with structured icon descriptors and shared types
- add a `useHudPresetManager` hook that owns preset state, persistence, and memoized helpers used by the provider and panels
- update HUD layout context, settings UI, and vitest configuration plus add targeted unit tests for custom preset CRUD

## Testing
- npm run lint *(passes with pre-existing warnings in unrelated files)*
- npm run test
- npm run build *(fails: packages/engine/src/simulation/citizenAI.ts duplicate function implementation, existing issue)*

------
https://chatgpt.com/codex/tasks/task_e_68cac6d667a08325b65b095d8baf54c3