### PR TITLE
Refactor edicts panel layout

### DIFF
--- a/src/components/game/hud/panels/edicts/CategorySection.tsx
+++ b/src/components/game/hud/panels/edicts/CategorySection.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { CategoryIcon, type CategoryType } from '@arcane/ui';
+
+import { EdictControl } from './EdictControl';
+import type { EdictWithState } from './useEdictsPanel';
+
+interface CategorySectionProps {
+  category: CategoryType;
+  title: string;
+  edicts: EdictWithState[];
+  onChange: (edictId: string, value: number) => void;
+}
+
+export const CategorySection: React.FC<CategorySectionProps> = ({
+  category,
+  title,
+  edicts,
+  onChange,
+}) => {
+  if (edicts.length === 0) return null;
+
+  return (
+    <section className="space-y-4" aria-labelledby={`category-${category}`}>
+      <h2 id={`category-${category}`} className="text-lg font-semibold text-white flex items-center gap-2">
+        <CategoryIcon category={category} />
+        {title}
+      </h2>
+      <div className="grid gap-4">
+        {edicts.map(({ edict, pendingValue, hasChanged, cost, isLocked }) => (
+          <EdictControl
+            key={edict.id}
+            edict={edict}
+            pendingValue={pendingValue}
+            hasChanged={hasChanged}
+            cost={cost}
+            isLocked={isLocked}
+            onChange={(value) => onChange(edict.id, value)}
+          />
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default CategorySection;

--- a/src/components/game/hud/panels/edicts/EdictControl.tsx
+++ b/src/components/game/hud/panels/edicts/EdictControl.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import * as Slider from '@radix-ui/react-slider';
+import * as Toggle from '@radix-ui/react-toggle';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCrown, faLock } from '@/lib/icons';
+import { CategoryIcon } from '@arcane/ui';
+
+import type { EdictSetting } from './types';
+
+export interface EdictControlProps {
+  edict: EdictSetting;
+  pendingValue: number;
+  hasChanged: boolean;
+  cost: number;
+  isLocked: boolean;
+  onChange: (value: number) => void;
+}
+
+export const EdictControl: React.FC<EdictControlProps> = ({
+  edict,
+  pendingValue,
+  hasChanged,
+  cost,
+  isLocked,
+  onChange,
+}) => {
+  return (
+    <div
+      className={`bg-gray-900/50 rounded-lg p-4 border ${
+        hasChanged ? 'border-yellow-500/60' : 'border-gray-700'
+      } shadow-sm text-gray-200 ${isLocked ? 'opacity-50' : ''}`}
+    >
+      {/* Header */}
+      <div className="flex items-start justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <CategoryIcon category={edict.category} />
+          <div>
+            <h3 className="text-gray-100 font-medium">{edict.name}</h3>
+            <p className="text-gray-400 text-sm">{edict.description}</p>
+          </div>
+        </div>
+        {cost > 0 && (
+          <div className="text-xs bg-yellow-900/30 text-yellow-300 border border-yellow-700/60 px-2 py-1 rounded flex items-center gap-1">
+            <FontAwesomeIcon icon={faCrown} /> {cost}
+          </div>
+        )}
+      </div>
+
+      {/* Control */}
+      <div className="mb-3">
+        {edict.type === 'slider' ? (
+          <div className="space-y-2">
+            <div className="flex justify-between text-sm">
+              <span className="text-gray-400">Value:</span>
+              <span
+                className={`font-mono ${hasChanged ? 'text-amber-300' : 'text-gray-200'}`}
+              >
+                {pendingValue}%
+              </span>
+            </div>
+            <Slider.Root
+              value={[pendingValue]}
+              onValueChange={([value]) => !isLocked && onChange(value)}
+              max={100}
+              step={5}
+              className="relative flex items-center select-none touch-none w-full h-5"
+              disabled={isLocked}
+            >
+              <Slider.Track className="bg-gray-700 relative grow rounded-full h-2">
+                <Slider.Range className="absolute bg-blue-500 rounded-full h-full" />
+              </Slider.Track>
+              <Slider.Thumb
+                className="block w-4 h-4 bg-gray-200 rounded-full shadow-lg hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+                aria-label="Value"
+              />
+            </Slider.Root>
+          </div>
+        ) : (
+          <div className="flex items-center justify-between">
+            <span className="text-gray-400 text-sm">Status:</span>
+            <Toggle.Root
+              pressed={pendingValue === 1}
+              onPressedChange={(pressed) => !isLocked && onChange(pressed ? 1 : 0)}
+              className={`px-3 py-1 rounded text-sm font-medium transition-colors ${
+                pendingValue === 1
+                  ? 'bg-green-600 text-white'
+                  : 'bg-gray-700 text-gray-200'
+              } ${isLocked ? 'cursor-not-allowed' : 'hover:opacity-80'}`}
+              disabled={isLocked}
+            >
+              {pendingValue === 1 ? 'Enabled' : 'Disabled'}
+            </Toggle.Root>
+          </div>
+        )}
+      </div>
+
+      {/* Effects */}
+      <div className="space-y-1">
+        <div className="text-xs text-gray-400">Effects:</div>
+        {edict.effects.map((effect, index) => (
+          <div key={index} className="text-xs text-gray-300 flex items-center gap-2">
+            <span className="text-blue-400">{effect.resource}:</span>
+            <span>{effect.impact}</span>
+          </div>
+        ))}
+      </div>
+
+      {/* Requirements */}
+      {edict.requirements && edict.requirements.length > 0 && (
+        <div className="mt-2 pt-2 border-t border-gray-700">
+          <div className="text-xs text-gray-400 mb-1">Requirements:</div>
+          {edict.requirements.map((req, index) => (
+            <div key={index} className="text-xs text-gray-300">
+              • {req}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Lock Status */}
+      {isLocked && (
+        <div className="mt-2 pt-2 border-t border-gray-700">
+          <div className="text-xs text-red-400 flex items-center gap-1">
+            <FontAwesomeIcon icon={faLock} /> Locked - Requirements not met
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default EdictControl;

--- a/src/components/game/hud/panels/edicts/types.ts
+++ b/src/components/game/hud/panels/edicts/types.ts
@@ -1,0 +1,20 @@
+import type { CategoryType } from '@arcane/ui';
+
+export interface EdictEffect {
+  resource: string;
+  impact: string;
+}
+
+export interface EdictSetting {
+  id: string;
+  name: string;
+  description: string;
+  type: 'slider' | 'toggle';
+  category: CategoryType;
+  currentValue: number;
+  defaultValue: number;
+  cost?: number;
+  effects: EdictEffect[];
+  requirements?: string[];
+  isLocked?: boolean;
+}

--- a/src/components/game/hud/panels/edicts/useEdictsPanel.test.tsx
+++ b/src/components/game/hud/panels/edicts/useEdictsPanel.test.tsx
@@ -1,0 +1,109 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { useEdictsPanel } from './useEdictsPanel';
+import type { EdictSetting } from './types';
+
+const createEdicts = (): EdictSetting[] => [
+  {
+    id: 'grain_tithe',
+    name: 'Grain Tithe',
+    description: 'Adjust tithe to bolster the granaries.',
+    type: 'slider',
+    category: 'economic',
+    currentValue: 40,
+    defaultValue: 40,
+    cost: 3,
+    effects: [],
+  },
+  {
+    id: 'night_watch',
+    name: 'Night Watch',
+    description: 'Post wardens along the streets after dusk.',
+    type: 'toggle',
+    category: 'military',
+    currentValue: 0,
+    defaultValue: 0,
+    cost: 2,
+    effects: [],
+  },
+  {
+    id: 'festival',
+    name: 'Festival Dockets',
+    description: 'Authorize seasonal celebrations to calm unrest.',
+    type: 'toggle',
+    category: 'social',
+    currentValue: 1,
+    defaultValue: 1,
+    cost: 5,
+    effects: [],
+  },
+  {
+    id: 'road_upkeep',
+    name: 'Road Upkeep',
+    description: 'Divert crews to smooth the cobbles.',
+    type: 'slider',
+    category: 'infrastructure',
+    currentValue: 50,
+    defaultValue: 50,
+    effects: [],
+  },
+];
+
+describe('useEdictsPanel', () => {
+  it('reports zero total cost when no edicts have pending changes', () => {
+    const edicts = createEdicts();
+    const { result } = renderHook(() =>
+      useEdictsPanel({ edicts, pendingChanges: {}, currentFavor: 10 }),
+    );
+
+    expect(result.current.totalCost).toBe(0);
+    expect(result.current.hasChanges).toBe(false);
+    expect(result.current.changesToApply).toEqual({});
+    expect(result.current.canAfford).toBe(true);
+  });
+
+  it('sums favor cost for each modified edict and checks affordability', () => {
+    const edicts = createEdicts();
+    const { result } = renderHook(() =>
+      useEdictsPanel({
+        edicts,
+        pendingChanges: {
+          grain_tithe: 60,
+          night_watch: 0,
+          festival: 0,
+        },
+        currentFavor: 7,
+      }),
+    );
+
+    expect(result.current.totalCost).toBe(8);
+    expect(result.current.hasChanges).toBe(true);
+    expect(result.current.canAfford).toBe(false);
+    expect(result.current.changesToApply).toEqual({
+      grain_tithe: 60,
+      festival: 0,
+    });
+  });
+
+  it('ignores unchanged entries and treats missing costs as zero', () => {
+    const edicts = createEdicts();
+    const { result } = renderHook(() =>
+      useEdictsPanel({
+        edicts,
+        pendingChanges: {
+          grain_tithe: 40,
+          road_upkeep: 75,
+        },
+        currentFavor: 2,
+      }),
+    );
+
+    expect(result.current.totalCost).toBe(0);
+    expect(result.current.hasChanges).toBe(true);
+    expect(result.current.canAfford).toBe(true);
+    expect(result.current.changesToApply).toEqual({
+      road_upkeep: 75,
+    });
+  });
+});

--- a/src/components/game/hud/panels/edicts/useEdictsPanel.ts
+++ b/src/components/game/hud/panels/edicts/useEdictsPanel.ts
@@ -1,0 +1,114 @@
+import { useMemo } from 'react';
+import { CATEGORY_TYPES, type CategoryType } from '@arcane/ui';
+
+import type { EdictSetting } from './types';
+
+export interface UseEdictsPanelOptions {
+  edicts: EdictSetting[];
+  pendingChanges: Record<string, number>;
+  currentFavor: number;
+}
+
+export interface EdictWithState {
+  edict: EdictSetting;
+  pendingValue: number;
+  hasChanged: boolean;
+  cost: number;
+  isLocked: boolean;
+}
+
+export interface CategoryGroup {
+  category: CategoryType;
+  title: string;
+  edicts: EdictWithState[];
+}
+
+export interface UseEdictsPanelResult {
+  categoryGroups: CategoryGroup[];
+  hasChanges: boolean;
+  totalCost: number;
+  canAfford: boolean;
+  changesToApply: Record<string, number>;
+  pendingSelection: Record<string, number>;
+}
+
+const CATEGORY_TITLES: Record<CategoryType, string> = {
+  economic: 'Economic Policy',
+  military: 'Military Doctrine',
+  social: 'Social Order',
+  mystical: 'Mystical Arts',
+  diplomatic: 'Diplomacy',
+  infrastructure: 'Infrastructure',
+};
+
+export const useEdictsPanel = ({
+  edicts,
+  pendingChanges,
+  currentFavor,
+}: UseEdictsPanelOptions): UseEdictsPanelResult => {
+  const edictStates = useMemo<EdictWithState[]>(() => {
+    return edicts.map(edict => {
+      const pendingValue = pendingChanges.hasOwnProperty(edict.id)
+        ? pendingChanges[edict.id]
+        : edict.currentValue;
+      const hasChanged = pendingValue !== edict.currentValue;
+      const cost = hasChanged ? edict.cost ?? 0 : 0;
+
+      return {
+        edict,
+        pendingValue,
+        hasChanged,
+        cost,
+        isLocked: edict.isLocked ?? false,
+      } satisfies EdictWithState;
+    });
+  }, [edicts, pendingChanges]);
+
+  const categoryGroups = useMemo<CategoryGroup[]>(() => {
+    return CATEGORY_TYPES.map(category => {
+      const edictsForCategory = edictStates.filter(entry => entry.edict.category === category);
+      if (edictsForCategory.length === 0) {
+        return null;
+      }
+
+      return {
+        category,
+        title: CATEGORY_TITLES[category],
+        edicts: edictsForCategory,
+      } satisfies CategoryGroup;
+    }).filter((group): group is CategoryGroup => group !== null);
+  }, [edictStates]);
+
+  const totalCost = useMemo(
+    () => edictStates.reduce((sum, entry) => sum + entry.cost, 0),
+    [edictStates],
+  );
+
+  const changesToApply = useMemo(() => {
+    return edictStates.reduce<Record<string, number>>((acc, entry) => {
+      if (entry.hasChanged) {
+        acc[entry.edict.id] = entry.pendingValue;
+      }
+      return acc;
+    }, {});
+  }, [edictStates]);
+
+  const pendingSelection = useMemo(() => {
+    return edictStates.reduce<Record<string, number>>((acc, entry) => {
+      acc[entry.edict.id] = entry.pendingValue;
+      return acc;
+    }, {});
+  }, [edictStates]);
+
+  const hasChanges = Object.keys(changesToApply).length > 0;
+  const canAfford = currentFavor >= totalCost;
+
+  return {
+    categoryGroups,
+    hasChanges,
+    totalCost,
+    canAfford,
+    changesToApply,
+    pendingSelection,
+  };
+};


### PR DESCRIPTION
## Summary
- extract the edict card and category grid into dedicated components under panels/edicts
- add a useEdictsPanel hook that derives pending selections, grouped categories, and favor costs for the dialog
- update EdictsPanel and PlayPage to consume the hook and new payload shape, and add unit coverage for the hook’s cost math

## Testing
- `npm run lint`
- `npm run test` *(fails: existing useCityManagement suite and vitest glob resolution errors)*
- `npm run build` *(fails: existing duplicate function implementation in packages/engine/src/simulation/citizenAI.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68cac6d7532083258a54dc2b9ca84938