### PR TITLE
Refactor council panel view logic and add coverage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -498,8 +498,6 @@
       ],
       "dev": true,
       "license": "MIT",
-      
-      
       "optional": true,
       "os": [
         "freebsd"

--- a/src/components/game/hud/CouncilPanel.tsx
+++ b/src/components/game/hud/CouncilPanel.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import { GameResources } from './types';
-import { ResourceIcon, CategoryIcon, type ResourceType, type CategoryType } from '@arcane/ui';
-import { getResourceIcon, getResourceColor } from '../resourceUtils';
+import { ProposalCard } from './panels/council/ProposalCard';
+import { useCouncilPanel } from './panels/council/useCouncilPanel';
+import type { CategoryType } from '@arcane/ui';
 
 export interface ProposalDelta {
   grain?: number;
@@ -43,178 +44,6 @@ export interface CouncilPanelProps {
   canGenerateProposals: boolean;
 }
 
-const ResourceDelta: React.FC<{ delta: ProposalDelta; type: 'cost' | 'benefit' }> = ({ delta, type: _type }) => {
-  const entries = Object.entries(delta).filter(([_, value]) => value !== 0 && value !== undefined);
-
-  if (entries.length === 0) return null;
-
-  return (
-    <div className="flex flex-wrap gap-2">
-      {entries.map(([resource, value]) => (
-        <ResourceIcon
-          key={resource}
-          type={resource as ResourceType}
-          value={value as number}
-          delta={value as number}
-          className="text-xs"
-        />
-      ))}
-    </div>
-  );
-};
-
-const ProposalCard: React.FC<{
-  proposal: CouncilProposal;
-  currentResources: GameResources;
-  onAccept: () => void;
-  onReject: () => void;
-  onScry: () => void;
-}> = ({ proposal, currentResources, onAccept, onReject, onScry }) => {
-  const getTypeColor = (type: CategoryType) => {
-    switch (type) {
-      case 'economic': return 'bg-yellow-900/30 text-yellow-300 border border-yellow-700/60';
-      case 'military': return 'bg-red-900/30 text-red-300 border border-red-700/60';
-      case 'diplomatic': return 'bg-blue-900/30 text-blue-300 border border-blue-700/60';
-      case 'mystical': return 'bg-purple-900/30 text-purple-300 border border-purple-700/60';
-      case 'infrastructure': return 'bg-green-900/30 text-green-300 border border-green-700/60';
-      case 'social': return 'bg-pink-900/30 text-pink-300 border border-pink-700/60';
-      default: return 'bg-gray-900/30 text-gray-300 border border-gray-700/60';
-    }
-  };
-
-  const canAfford = () => {
-    return Object.entries(proposal.cost).every(([resource, cost]) => {
-      if (cost === undefined || cost === 0) return true;
-      const current = currentResources[resource as keyof GameResources];
-      return current >= cost;
-    });
-  };
-
-  const meetsRequirements = () => {
-    // Simplified - in real game this would check actual requirements
-    return !proposal.requirements || proposal.requirements.length === 0;
-  };
-
-  const isActionable = canAfford() && meetsRequirements() && (proposal.status ?? 'pending') === 'pending';
-
-  return (
-    <div className="bg-gray-900/50 text-gray-200 rounded-lg p-4 border border-gray-700 shadow-sm">
-      {/* Header */}
-      <div className="flex items-start justify-between mb-3">
-        <div className="flex items-center gap-2">
-          <span className={`px-2 py-1 rounded text-xs font-medium ${getTypeColor(proposal.type)}`}>
-            <CategoryIcon category={proposal.type} className="text-xs" /> {proposal.type.toUpperCase()}
-          </span>
-          <div className="flex items-center gap-1">
-            <span className="text-xs text-gray-400">Risk:</span>
-            <span className={`text-xs font-medium ${
-              proposal.risk < 30 ? 'text-success' :
-              proposal.risk < 70 ? 'text-warning' : 'text-danger'
-            }`}>
-              {proposal.risk}%
-            </span>
-          </div>
-        </div>
-        <div className="text-xs text-gray-400 flex items-center gap-2">
-          {proposal.duration} cycle{proposal.duration !== 1 ? 's' : ''}
-          {proposal.status && (
-            <span className={`px-2 py-0.5 rounded text-[10px] font-medium border ${
-              proposal.status === 'accepted' ? 'bg-emerald-900/30 text-emerald-300 border-emerald-700/60' :
-              proposal.status === 'rejected' ? 'bg-rose-900/30 text-rose-300 border-rose-700/60' :
-              proposal.status === 'applied' ? 'bg-gray-800 text-gray-400 border-gray-700' :
-              'bg-amber-900/30 text-amber-300 border-amber-700/60'
-            }`}>
-              {proposal.status.toUpperCase()}
-            </span>
-          )}
-        </div>
-      </div>
-
-      {/* Title and Description */}
-      <h3 className="text-gray-100 font-medium mb-2">{proposal.title}</h3>
-      <p className="text-gray-300 text-sm mb-3">{proposal.description}</p>
-
-      {/* Requirements */}
-      {proposal.requirements && proposal.requirements.length > 0 && (
-        <div className="mb-3">
-          <div className="text-xs text-gray-400 mb-1">Requirements:</div>
-          <ul className="text-xs text-gray-400 list-disc list-inside">
-            {proposal.requirements.map((req, index) => (
-              <li key={index}>{req}</li>
-            ))}
-          </ul>
-        </div>
-      )}
-
-      {/* Cost and Benefits */}
-      <div className="grid grid-cols-2 gap-4 mb-4">
-        <div>
-          <div className="text-xs text-gray-400 mb-1">Cost:</div>
-          <ResourceDelta delta={proposal.cost} type="cost" />
-        </div>
-        <div>
-          <div className="text-xs text-gray-400 mb-1">Benefit:</div>
-          <ResourceDelta delta={proposal.benefit} type="benefit" />
-        </div>
-      </div>
-
-      {/* Scry Results */}
-      {proposal.scryResult && (
-        <div className="bg-blue-900/40 border border-blue-700 rounded p-2 mb-3">
-          <div className="text-xs text-blue-200 mb-1">🔮 Scry Results:</div>
-          <div className="text-xs text-blue-200 mb-1">
-            Success Chance: {proposal.scryResult.successChance}%
-          </div>
-          {proposal.scryResult.hiddenEffects && (
-            <div className="text-xs text-blue-200">
-              Hidden Effects: {proposal.scryResult.hiddenEffects.join(', ')}
-            </div>
-          )}
-        </div>
-      )}
-
-      {/* Actions */}
-      <div className="flex gap-2">
-        {proposal.canScry && !proposal.scryResult && (proposal.status ?? 'pending') === 'pending' && (
-          <button
-            onClick={onScry}
-            className="px-3 py-1 bg-blue-600 hover:bg-blue-700 text-white text-xs rounded transition-colors"
-          >
-            🔮 Scry
-          </button>
-        )}
-        <button
-          onClick={onAccept}
-          disabled={!isActionable}
-          className={`px-3 py-1 text-xs rounded transition-colors ${
-            isActionable
-              ? 'bg-emerald-600 hover:bg-emerald-700 text-white'
-              : 'bg-gray-700 text-gray-400 cursor-not-allowed'
-          }`}
-        >
-          ✓ Accept
-        </button>
-        <button
-          onClick={onReject}
-          disabled={(proposal.status ?? 'pending') !== 'pending'}
-          className={`px-3 py-1 text-xs rounded transition-colors ${
-            (proposal.status ?? 'pending') === 'pending' ? 'bg-rose-600 hover:bg-rose-700 text-white' : 'bg-gray-700 text-gray-400 cursor-not-allowed'
-          }`}
-        >
-          ✗ Reject
-        </button>
-      </div>
-
-      {/* Affordability Warning */}
-      {!canAfford() && (
-        <div className="mt-2 text-xs text-rose-400">
-          ⚠️ Insufficient resources
-        </div>
-      )}
-    </div>
-  );
-};
-
 export const CouncilPanel: React.FC<CouncilPanelProps> = ({
   isOpen,
   onClose,
@@ -226,6 +55,8 @@ export const CouncilPanel: React.FC<CouncilPanelProps> = ({
   onGenerateProposals,
   canGenerateProposals
 }) => {
+  const { viewModels } = useCouncilPanel({ proposals, currentResources });
+
   return (
     <Dialog.Root open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>
       <Dialog.Portal>
@@ -271,7 +102,7 @@ export const CouncilPanel: React.FC<CouncilPanelProps> = ({
 
           {/* Content */}
           <div className="p-6 overflow-y-auto max-h-[calc(90vh-120px)] bg-gray-800">
-            {proposals.length === 0 ? (
+            {viewModels.length === 0 ? (
               <div className="text-center py-12">
                 <div className="text-6xl mb-4">📜</div>
                 <h3 className="text-xl font-medium text-gray-100 mb-2">No Active Proposals</h3>
@@ -292,14 +123,20 @@ export const CouncilPanel: React.FC<CouncilPanelProps> = ({
               </div>
             ) : (
               <div className="grid gap-4">
-                {proposals.map((proposal) => (
+                {viewModels.map((viewModel) => (
                   <ProposalCard
-                    key={proposal.id}
-                    proposal={proposal}
-                    currentResources={currentResources}
-                    onAccept={() => onAcceptProposal(proposal.id)}
-                    onReject={() => onRejectProposal(proposal.id)}
-                    onScry={() => onScryProposal(proposal.id)}
+                    key={viewModel.proposal.id}
+                    proposal={viewModel.proposal}
+                    typeClassName={viewModel.typeClassName}
+                    canAfford={viewModel.canAfford}
+                    meetsRequirements={viewModel.meetsRequirements}
+                    isActionable={viewModel.isActionable}
+                    isPending={viewModel.isPending}
+                    showScryButton={viewModel.showScryButton}
+                    disableReasons={viewModel.disableReasons}
+                    onAccept={() => onAcceptProposal(viewModel.proposal.id)}
+                    onReject={() => onRejectProposal(viewModel.proposal.id)}
+                    onScry={() => onScryProposal(viewModel.proposal.id)}
                   />
                 ))}
               </div>

--- a/src/components/game/hud/panels/council/ProposalCard.tsx
+++ b/src/components/game/hud/panels/council/ProposalCard.tsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import { CategoryIcon, ResourceIcon, type ResourceType } from '@arcane/ui';
+import type { CouncilProposal, ProposalDelta } from '../../CouncilPanel';
+import type { ProposalDisableReasons } from './useCouncilPanel';
+
+const ResourceDelta: React.FC<{ delta: ProposalDelta }> = ({ delta }) => {
+  const entries = Object.entries(delta).filter(([, value]) => value !== 0 && value !== undefined);
+
+  if (entries.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {entries.map(([resource, value]) => (
+        <ResourceIcon
+          key={resource}
+          type={resource as ResourceType}
+          value={value as number}
+          delta={value as number}
+          className="text-xs"
+        />
+      ))}
+    </div>
+  );
+};
+
+export interface ProposalCardProps {
+  proposal: CouncilProposal;
+  onAccept: () => void;
+  onReject: () => void;
+  onScry: () => void;
+  typeClassName: string;
+  canAfford: boolean;
+  meetsRequirements: boolean;
+  isActionable: boolean;
+  isPending: boolean;
+  showScryButton: boolean;
+  disableReasons: ProposalDisableReasons;
+}
+
+export const ProposalCard: React.FC<ProposalCardProps> = ({
+  proposal,
+  onAccept,
+  onReject,
+  onScry,
+  typeClassName,
+  canAfford,
+  meetsRequirements,
+  isActionable,
+  isPending,
+  showScryButton,
+  disableReasons,
+}) => {
+  const riskClassName =
+    proposal.risk < 30 ? 'text-success' : proposal.risk < 70 ? 'text-warning' : 'text-danger';
+
+  const shouldShowRequirements = proposal.requirements && proposal.requirements.length > 0;
+
+  const disableMessage = !isActionable ? disableReasons.accept : undefined;
+  const disableMessageClass = !canAfford
+    ? 'text-rose-400'
+    : !meetsRequirements
+      ? 'text-amber-300'
+      : 'text-rose-400';
+
+  return (
+    <div className="bg-gray-900/50 text-gray-200 rounded-lg p-4 border border-gray-700 shadow-sm">
+      <div className="flex items-start justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <span className={`px-2 py-1 rounded text-xs font-medium ${typeClassName}`}>
+            <CategoryIcon category={proposal.type} className="text-xs" /> {proposal.type.toUpperCase()}
+          </span>
+          <div className="flex items-center gap-1">
+            <span className="text-xs text-gray-400">Risk:</span>
+            <span className={`text-xs font-medium ${riskClassName}`}>{proposal.risk}%</span>
+          </div>
+        </div>
+        <div className="text-xs text-gray-400 flex items-center gap-2">
+          {proposal.duration} cycle{proposal.duration !== 1 ? 's' : ''}
+          {proposal.status && (
+            <span
+              className={`px-2 py-0.5 rounded text-[10px] font-medium border ${
+                proposal.status === 'accepted'
+                  ? 'bg-emerald-900/30 text-emerald-300 border-emerald-700/60'
+                  : proposal.status === 'rejected'
+                    ? 'bg-rose-900/30 text-rose-300 border-rose-700/60'
+                    : proposal.status === 'applied'
+                      ? 'bg-gray-800 text-gray-400 border-gray-700'
+                      : 'bg-amber-900/30 text-amber-300 border-amber-700/60'
+              }`}
+            >
+              {proposal.status.toUpperCase()}
+            </span>
+          )}
+        </div>
+      </div>
+
+      <h3 className="text-gray-100 font-medium mb-2">{proposal.title}</h3>
+      <p className="text-gray-300 text-sm mb-3">{proposal.description}</p>
+
+      {shouldShowRequirements && (
+        <div className="mb-3">
+          <div className="text-xs text-gray-400 mb-1">Requirements:</div>
+          <ul className="text-xs text-gray-400 list-disc list-inside">
+            {proposal.requirements!.map((req, index) => (
+              <li key={index}>{req}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className="grid grid-cols-2 gap-4 mb-4">
+        <div>
+          <div className="text-xs text-gray-400 mb-1">Cost:</div>
+          <ResourceDelta delta={proposal.cost} />
+        </div>
+        <div>
+          <div className="text-xs text-gray-400 mb-1">Benefit:</div>
+          <ResourceDelta delta={proposal.benefit} />
+        </div>
+      </div>
+
+      {proposal.scryResult && (
+        <div className="bg-blue-900/40 border border-blue-700 rounded p-2 mb-3">
+          <div className="text-xs text-blue-200 mb-1">🔮 Scry Results:</div>
+          <div className="text-xs text-blue-200 mb-1">Success Chance: {proposal.scryResult.successChance}%</div>
+          {proposal.scryResult.hiddenEffects && (
+            <div className="text-xs text-blue-200">
+              Hidden Effects: {proposal.scryResult.hiddenEffects.join(', ')}
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="flex gap-2">
+        {showScryButton && (
+          <button
+            onClick={onScry}
+            className="px-3 py-1 bg-blue-600 hover:bg-blue-700 text-white text-xs rounded transition-colors"
+          >
+            🔮 Scry
+          </button>
+        )}
+        <button
+          onClick={onAccept}
+          disabled={!isActionable}
+          className={`px-3 py-1 text-xs rounded transition-colors ${
+            isActionable ? 'bg-emerald-600 hover:bg-emerald-700 text-white' : 'bg-gray-700 text-gray-400 cursor-not-allowed'
+          }`}
+        >
+          ✓ Accept
+        </button>
+        <button
+          onClick={onReject}
+          disabled={!isPending}
+          className={`px-3 py-1 text-xs rounded transition-colors ${
+            isPending ? 'bg-rose-600 hover:bg-rose-700 text-white' : 'bg-gray-700 text-gray-400 cursor-not-allowed'
+          }`}
+        >
+          ✗ Reject
+        </button>
+      </div>
+
+      {disableMessage && (
+        <div className={`mt-2 text-xs ${disableMessageClass}`}>⚠️ {disableMessage}</div>
+      )}
+    </div>
+  );
+};
+
+export default ProposalCard;

--- a/src/components/game/hud/panels/council/__tests__/CouncilPanel.test.tsx
+++ b/src/components/game/hud/panels/council/__tests__/CouncilPanel.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { CouncilPanel, type CouncilProposal } from '../../../CouncilPanel';
+import type { GameResources } from '../../../types';
+
+describe('CouncilPanel', () => {
+  const resources: GameResources = {
+    grain: 50,
+    coin: 20,
+    mana: 15,
+    favor: 5,
+    wood: 30,
+    planks: 10,
+    unrest: 1,
+    threat: 1,
+  };
+
+  const buildProposal = (overrides: Partial<CouncilProposal>): CouncilProposal => ({
+    id: 'default',
+    title: 'Default',
+    description: 'Default description',
+    type: 'economic',
+    cost: {},
+    benefit: {},
+    risk: 20,
+    duration: 1,
+    requirements: [],
+    canScry: false,
+    ...overrides,
+  });
+
+  it('invokes callbacks only for actionable proposals', async () => {
+    const actionable = buildProposal({
+      id: 'actionable',
+      title: 'Approve Workshop',
+      cost: { grain: 10 },
+      benefit: { coin: 5 },
+    });
+
+    const unaffordable = buildProposal({
+      id: 'unaffordable',
+      title: 'Lavish Festival',
+      cost: { grain: 80 },
+      benefit: { favor: 10 },
+    });
+
+    const onAccept = vi.fn();
+    const onReject = vi.fn();
+    const onScry = vi.fn();
+    const onGenerate = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <CouncilPanel
+        isOpen
+        onClose={onClose}
+        proposals={[actionable, unaffordable]}
+        currentResources={resources}
+        onAcceptProposal={onAccept}
+        onRejectProposal={onReject}
+        onScryProposal={onScry}
+        onGenerateProposals={onGenerate}
+        canGenerateProposals
+      />,
+    );
+
+    const acceptButtons = await screen.findAllByRole('button', { name: /Accept/ });
+
+    fireEvent.click(acceptButtons[0]);
+    expect(onAccept).toHaveBeenCalledWith('actionable');
+
+    fireEvent.click(acceptButtons[1]);
+    expect(onAccept).toHaveBeenCalledTimes(1);
+    expect(acceptButtons[1].getAttribute('disabled')).not.toBeNull();
+  });
+});

--- a/src/components/game/hud/panels/council/__tests__/useCouncilPanel.test.tsx
+++ b/src/components/game/hud/panels/council/__tests__/useCouncilPanel.test.tsx
@@ -1,0 +1,63 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useCouncilPanel } from '../useCouncilPanel';
+import type { CouncilProposal } from '../../../CouncilPanel';
+import type { GameResources } from '../../../types';
+
+describe('useCouncilPanel', () => {
+  const resources: GameResources = {
+    grain: 50,
+    coin: 20,
+    mana: 15,
+    favor: 5,
+    wood: 30,
+    planks: 10,
+    unrest: 1,
+    threat: 1,
+  };
+
+  const baseProposal: Omit<CouncilProposal, 'id' | 'title' | 'description' | 'cost' | 'benefit'> = {
+    type: 'economic',
+    risk: 35,
+    duration: 2,
+    requirements: [],
+    canScry: false,
+  };
+
+  it('flags proposals that cannot be afforded and exposes disable reasons', () => {
+    const proposals: CouncilProposal[] = [
+      {
+        ...baseProposal,
+        id: 'expensive',
+        title: 'Grand Project',
+        description: 'Requires substantial grain reserves.',
+        cost: { grain: 60 },
+        benefit: { favor: 5 },
+      },
+      {
+        ...baseProposal,
+        id: 'modest',
+        title: 'Modest Works',
+        description: 'Within current means.',
+        cost: { grain: 10 },
+        benefit: { favor: 2 },
+      },
+    ];
+
+    const { result } = renderHook(() => useCouncilPanel({ proposals, currentResources: resources }));
+
+    const expensive = result.current.viewModels.find((vm) => vm.proposal.id === 'expensive');
+    const modest = result.current.viewModels.find((vm) => vm.proposal.id === 'modest');
+
+    expect(expensive).toBeDefined();
+    expect(expensive?.canAfford).toBe(false);
+    expect(expensive?.disableReasons.accept).toBe('Insufficient resources');
+
+    expect(modest).toBeDefined();
+    expect(modest?.canAfford).toBe(true);
+    expect(modest?.disableReasons.accept).toBeUndefined();
+
+    expect(result.current.pendingStates.expensive).toBe(true);
+    expect(result.current.pendingStates.modest).toBe(true);
+  });
+});

--- a/src/components/game/hud/panels/council/useCouncilPanel.ts
+++ b/src/components/game/hud/panels/council/useCouncilPanel.ts
@@ -1,0 +1,127 @@
+import { useMemo } from 'react';
+import type { CategoryType } from '@arcane/ui';
+import type { CouncilProposal } from '../../CouncilPanel';
+import type { GameResources } from '../../types';
+
+export interface ProposalDisableReasons {
+  accept?: string;
+  reject?: string;
+  scry?: string;
+}
+
+export interface ProposalViewModel {
+  proposal: CouncilProposal;
+  typeClassName: string;
+  canAfford: boolean;
+  meetsRequirements: boolean;
+  isPending: boolean;
+  isActionable: boolean;
+  showScryButton: boolean;
+  disableReasons: ProposalDisableReasons;
+}
+
+const typeClassNames: Partial<Record<CategoryType, string>> = {
+  economic: 'bg-yellow-900/30 text-yellow-300 border border-yellow-700/60',
+  military: 'bg-red-900/30 text-red-300 border border-red-700/60',
+  diplomatic: 'bg-blue-900/30 text-blue-300 border border-blue-700/60',
+  mystical: 'bg-purple-900/30 text-purple-300 border border-purple-700/60',
+  infrastructure: 'bg-green-900/30 text-green-300 border border-green-700/60',
+  social: 'bg-pink-900/30 text-pink-300 border border-pink-700/60',
+};
+
+const fallbackTypeClassName = 'bg-gray-900/30 text-gray-300 border border-gray-700/60';
+
+const getTypeClassName = (type: CategoryType): string => typeClassNames[type] ?? fallbackTypeClassName;
+
+const calculateAffordability = (proposal: CouncilProposal, currentResources: GameResources): boolean => {
+  return Object.entries(proposal.cost).every(([resource, cost]) => {
+    if (cost === undefined || cost === 0) return true;
+
+    const current = currentResources[resource as keyof GameResources];
+    return current !== undefined && current >= cost;
+  });
+};
+
+const meetsRequirements = (proposal: CouncilProposal): boolean => {
+  return !proposal.requirements || proposal.requirements.length === 0;
+};
+
+const deriveDisableReasons = (
+  {
+    isPending,
+    canAfford,
+    meetsRequirements: requirementsMet,
+    proposal,
+  }: {
+    isPending: boolean;
+    canAfford: boolean;
+    meetsRequirements: boolean;
+    proposal: CouncilProposal;
+  },
+): ProposalDisableReasons => {
+  const reasons: ProposalDisableReasons = {};
+
+  if (!isPending) {
+    reasons.accept = 'Proposal already resolved';
+    reasons.reject = 'Proposal already resolved';
+  } else {
+    if (!canAfford) {
+      reasons.accept = 'Insufficient resources';
+    } else if (!requirementsMet) {
+      reasons.accept = 'Requirements not met';
+    }
+  }
+
+  if (!proposal.canScry) {
+    reasons.scry = 'Scrying unavailable';
+  } else if (!isPending) {
+    reasons.scry = 'Proposal already resolved';
+  } else if (proposal.scryResult) {
+    reasons.scry = 'Already scryed';
+  }
+
+  return reasons;
+};
+
+interface UseCouncilPanelOptions {
+  proposals: CouncilProposal[];
+  currentResources: GameResources;
+}
+
+export const useCouncilPanel = ({ proposals, currentResources }: UseCouncilPanelOptions) => {
+  const viewModels = useMemo<ProposalViewModel[]>(() => {
+    return proposals.map((proposal) => {
+      const isPending = (proposal.status ?? 'pending') === 'pending';
+      const canAfford = calculateAffordability(proposal, currentResources);
+      const requirementsMet = meetsRequirements(proposal);
+      const disableReasons = deriveDisableReasons({
+        isPending,
+        canAfford,
+        meetsRequirements: requirementsMet,
+        proposal,
+      });
+
+      return {
+        proposal,
+        typeClassName: getTypeClassName(proposal.type),
+        canAfford,
+        meetsRequirements: requirementsMet,
+        isPending,
+        isActionable: isPending && canAfford && requirementsMet,
+        showScryButton: proposal.canScry && !proposal.scryResult && isPending,
+        disableReasons,
+      } satisfies ProposalViewModel;
+    });
+  }, [proposals, currentResources]);
+
+  const pendingStates = useMemo(() => {
+    return viewModels.reduce<Record<string, boolean>>((acc, viewModel) => {
+      acc[viewModel.proposal.id] = viewModel.isPending;
+      return acc;
+    }, {});
+  }, [viewModels]);
+
+  return { viewModels, pendingStates };
+};
+
+export default useCouncilPanel;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,6 +22,9 @@ export default defineConfig({
       ],
       [
         'src/components/**/*.test.{ts,tsx}',
+        'jsdom',
+      ],
+      [
         'src/hooks/**/*.test.{ts,tsx}',
         'jsdom',
       ],


### PR DESCRIPTION
## Summary
- move the council proposal card into a dedicated component that accepts computed props and surfaces disable messaging
- add a `useCouncilPanel` hook to derive affordability, requirements, pending states, and button disable reasons
- wire the council panel to the new hook/card, fix Vitest environment config, and add unit tests covering affordability and action gating

## Testing
- npm run lint
- npm run test
- npm run build *(fails: Duplicate function implementation in packages/engine/src/simulation/citizenAI.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68cac6d7e1f08325ad707ea6c9c121da