### PR TITLE
Refactor event system state handling and generation

### DIFF
--- a/packages/engine/src/simulation/events/__tests__/eventGeneration.test.ts
+++ b/packages/engine/src/simulation/events/__tests__/eventGeneration.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import {
+  adjustEventProbability,
+  generateEventCandidates
+} from '../eventGeneration';
+import type { SystemState, EventDefinition, EventType, ActiveEvent } from '../types';
+
+const baseSystemState: SystemState = {
+  population: 60,
+  happiness: 25,
+  economicHealth: 80,
+  infrastructure: 35,
+  resources: 70,
+  stability: 20
+};
+
+function createEventDefinition(
+  type: EventType,
+  overrides: Partial<EventDefinition> = {}
+): EventDefinition {
+  const { impact: overrideImpact, ...rest } = overrides;
+
+  const baseImpact: EventDefinition['impact'] = {
+    resources: { coin: 0 },
+    citizenMood: { happiness: 0, stress: 0, motivation: 0 },
+    buildingEffects: { conditionChange: 0, efficiencyMultiplier: 1, maintenanceCostMultiplier: 1 },
+    economicEffects: { wageMultiplier: 1, tradeMultiplier: 1, growthRate: 0 },
+    duration: 2,
+    probability: 0.2
+  };
+
+  return {
+    type,
+    severity: rest.severity ?? 'moderate',
+    title: rest.title ?? `Event: ${type}`,
+    description: rest.description ?? `Description for ${type}`,
+    impact: {
+      ...baseImpact,
+      ...overrideImpact,
+      resources: {
+        ...baseImpact.resources,
+        ...(overrideImpact?.resources ?? {})
+      },
+      citizenMood: {
+        ...baseImpact.citizenMood,
+        ...(overrideImpact?.citizenMood ?? {})
+      },
+      buildingEffects: {
+        ...baseImpact.buildingEffects,
+        ...(overrideImpact?.buildingEffects ?? {})
+      },
+      economicEffects: {
+        ...baseImpact.economicEffects,
+        ...(overrideImpact?.economicEffects ?? {})
+      }
+    },
+    iconType: rest.iconType ?? 'warning',
+    color: rest.color ?? '#abcdef',
+    animationType: rest.animationType ?? 'pulse',
+    responses: rest.responses,
+    triggers: rest.triggers
+  };
+}
+
+describe('eventGeneration utilities', () => {
+  it('adjusts probabilities based on system pressure', () => {
+    const unrestProbability = adjustEventProbability('social_unrest', 0.1, baseSystemState);
+    const plagueProbability = adjustEventProbability('plague_outbreak', 0.05, baseSystemState);
+    const breakthroughProbability = adjustEventProbability(
+      'technological_breakthrough',
+      0.2,
+      baseSystemState
+    );
+
+    expect(unrestProbability).toBeCloseTo(0.3, 5);
+    expect(plagueProbability).toBeCloseTo(0.078, 5);
+    expect(breakthroughProbability).toBeCloseTo(0.24, 5);
+  });
+
+  it('generates candidates in detection order with indicator sequencing', () => {
+    const socialUnrest = createEventDefinition('social_unrest', {
+      impact: {
+        probability: 0.4,
+        citizenMood: { happiness: -5, stress: 4, motivation: -2 }
+      },
+      color: '#ff0000'
+    });
+
+    const economicBoom = createEventDefinition('economic_boom', {
+      impact: {
+        probability: 0.35,
+        resources: { coin: 20 },
+        economicEffects: { wageMultiplier: 1.1, tradeMultiplier: 1.2, growthRate: 0.05 }
+      },
+      color: '#00ff99',
+      severity: 'major'
+    });
+
+    const eventDefinitions: Record<EventType, EventDefinition> = {
+      social_unrest: socialUnrest,
+      economic_boom: economicBoom
+    };
+
+    const activeEvent: ActiveEvent = {
+      id: 'active-1',
+      ...socialUnrest,
+      startCycle: 0,
+      endCycle: 2,
+      isActive: true,
+      triggers: [
+        {
+          condition: 'high_trade',
+          eventType: 'economic_boom',
+          probability: 0.9
+        }
+      ]
+    };
+
+    const randomValues = [0.05, 0.99, 0.1];
+    let callCount = 0;
+    const deterministicRandom = () => randomValues[callCount++] ?? 1;
+
+    const candidates = generateEventCandidates({
+      systemState: baseSystemState,
+      activeEvents: [activeEvent],
+      eventDefinitions,
+      random: deterministicRandom
+    });
+
+    expect(candidates).toHaveLength(2);
+    expect(candidates[0].type).toBe('social_unrest');
+    expect(candidates[0].reason).toBe('probability');
+    expect(candidates[0].indicator.change).toBe(1);
+
+    expect(candidates[1].type).toBe('economic_boom');
+    expect(candidates[1].reason).toBe('trigger');
+    expect(candidates[1].indicator.change).toBe(2);
+
+    expect(candidates.map(candidate => candidate.indicator.icon)).toEqual([
+      'social_unrest',
+      'economic_boom'
+    ]);
+  });
+});

--- a/packages/engine/src/simulation/events/eventGeneration.ts
+++ b/packages/engine/src/simulation/events/eventGeneration.ts
@@ -1,0 +1,156 @@
+import type {
+  ActiveEvent,
+  EventDefinition,
+  EventImpact,
+  EventType,
+  SystemState,
+  VisualIndicator
+} from './types';
+
+export type RandomFn = () => number;
+
+export type EventGenerationReason = 'probability' | 'trigger' | 'manual';
+
+export interface EventCandidate {
+  type: EventType;
+  definition: EventDefinition;
+  indicator: IndicatorPayload;
+  reason: EventGenerationReason;
+}
+
+export type IndicatorPayload = Omit<VisualIndicator, 'id'>;
+
+export function adjustEventProbability(
+  eventType: EventType,
+  baseProbability: number,
+  state: SystemState
+): number {
+  let probability = baseProbability;
+
+  switch (eventType) {
+    case 'social_unrest':
+      if (state.happiness < 40) probability *= 2;
+      if (state.stability < 30) probability *= 1.5;
+      break;
+    case 'plague_outbreak':
+      if (state.population > 50) probability *= 1.3;
+      if (state.infrastructure < 40) probability *= 1.2;
+      break;
+    case 'economic_boom':
+      if (state.economicHealth > 70) probability *= 1.5;
+      break;
+    case 'technological_breakthrough':
+      if (state.resources > 60) probability *= 1.2;
+      break;
+    default:
+      break;
+  }
+
+  return Math.min(probability, 1);
+}
+
+export function shouldActivateTrigger(condition: string, state: SystemState): boolean {
+  switch (condition) {
+    case 'low_infrastructure':
+      return state.infrastructure < 40;
+    case 'high_trade':
+      return state.economicHealth > 70;
+    case 'high_population_density':
+      return state.population > 40;
+    default:
+      return false;
+  }
+}
+
+export function computeEventImpactScore(impact: EventImpact): number {
+  const resourceImpact = Object.values(impact.resources).reduce(
+    (sum, value) => sum + Math.abs(value || 0),
+    0
+  );
+  const moodImpact =
+    Math.abs(impact.citizenMood.happiness) +
+    Math.abs(impact.citizenMood.stress) +
+    Math.abs(impact.citizenMood.motivation);
+  const economicImpact = Math.abs((impact.economicEffects.growthRate || 0) * 2);
+
+  return Math.min(100, resourceImpact / 10 + moodImpact + economicImpact);
+}
+
+export function buildEventIndicator(
+  definition: EventDefinition,
+  reason: EventGenerationReason
+): IndicatorPayload {
+  const priority =
+    definition.severity === 'critical'
+      ? 'critical'
+      : definition.severity === 'major'
+        ? 'high'
+        : 'medium';
+
+  return {
+    type: 'event_impact',
+    position: { x: 0, y: 0 },
+    value: computeEventImpactScore(definition.impact),
+    change: reason === 'trigger' ? 2 : 1,
+    color: definition.color,
+    icon: definition.type,
+    animation: definition.animationType,
+    duration: 5,
+    priority
+  };
+}
+
+export function generateEventCandidates({
+  systemState,
+  activeEvents,
+  eventDefinitions,
+  random = Math.random
+}: {
+  systemState: SystemState;
+  activeEvents: Iterable<ActiveEvent>;
+  eventDefinitions: Record<EventType, EventDefinition>;
+  random?: RandomFn;
+}): EventCandidate[] {
+  const candidates: EventCandidate[] = [];
+
+  for (const [eventType, definition] of Object.entries(eventDefinitions) as Array<[
+    EventType,
+    EventDefinition
+  ]>) {
+    const adjustedProbability = adjustEventProbability(
+      eventType,
+      definition.impact.probability,
+      systemState
+    );
+
+    if (random() < adjustedProbability) {
+      candidates.push({
+        type: eventType,
+        definition,
+        reason: 'probability',
+        indicator: buildEventIndicator(definition, 'probability')
+      });
+    }
+  }
+
+  for (const event of activeEvents) {
+    if (!event.triggers) continue;
+
+    for (const trigger of event.triggers) {
+      if (!shouldActivateTrigger(trigger.condition, systemState)) continue;
+      if (random() >= trigger.probability) continue;
+
+      const definition = eventDefinitions[trigger.eventType];
+      if (!definition) continue;
+
+      candidates.push({
+        type: trigger.eventType,
+        definition,
+        reason: 'trigger',
+        indicator: buildEventIndicator(definition, 'trigger')
+      });
+    }
+  }
+
+  return candidates;
+}

--- a/packages/engine/src/simulation/events/index.ts
+++ b/packages/engine/src/simulation/events/index.ts
@@ -1,3 +1,5 @@
 export * from './types';
 export { EventManager } from './EventManager';
 export { EVENT_DEFINITIONS } from './definitions';
+export * from './systemState';
+export * from './eventGeneration';

--- a/packages/engine/src/simulation/events/systemState.ts
+++ b/packages/engine/src/simulation/events/systemState.ts
@@ -1,0 +1,105 @@
+import type { SimResources } from '../../index';
+import type { SimulatedBuilding } from '../buildingSimulation';
+import type { Citizen } from '../citizens/citizen';
+import type { WorkerProfile } from '../workers/types';
+import type { SystemState } from './types';
+
+export interface SimulationSnapshot {
+  buildings: SimulatedBuilding[];
+  citizens: Citizen[];
+  workers: WorkerProfile[];
+  resources: SimResources;
+}
+
+export const DEFAULT_SYSTEM_STATE: SystemState = {
+  population: 0,
+  happiness: 50,
+  economicHealth: 50,
+  infrastructure: 50,
+  resources: 50,
+  stability: 50
+};
+
+export function scorePopulation(citizens: Citizen[]): number {
+  return citizens.length;
+}
+
+export function scoreHappiness(citizens: Citizen[]): number {
+  if (citizens.length === 0) {
+    return DEFAULT_SYSTEM_STATE.happiness;
+  }
+
+  const totalHappiness = citizens.reduce((sum, citizen) => sum + citizen.mood.happiness, 0);
+  return totalHappiness / citizens.length;
+}
+
+export function scoreEconomicHealth(
+  resources: SimResources,
+  workers: WorkerProfile[]
+): number {
+  const resourceScore = Math.min(100, (resources.coin || 0) / 2);
+
+  if (workers.length === 0) {
+    return (resourceScore + DEFAULT_SYSTEM_STATE.economicHealth) / 2;
+  }
+
+  const workerSatisfaction =
+    workers.reduce((sum, worker) => sum + worker.jobSatisfaction, 0) / workers.length;
+
+  return (resourceScore + workerSatisfaction) / 2;
+}
+
+const BUILDING_CONDITION_SCORES: Record<string, number> = {
+  excellent: 100,
+  good: 80,
+  fair: 60,
+  poor: 40,
+  critical: 20
+};
+
+const NO_CITIZEN_BASELINE_STRESS = 30;
+
+export function scoreInfrastructure(buildings: SimulatedBuilding[]): number {
+  if (buildings.length === 0) {
+    return DEFAULT_SYSTEM_STATE.infrastructure;
+  }
+
+  const totalConditionScore = buildings.reduce((sum, building) => {
+    const conditionScore = BUILDING_CONDITION_SCORES[building.condition] ?? DEFAULT_SYSTEM_STATE.infrastructure;
+    return sum + conditionScore;
+  }, 0);
+
+  return totalConditionScore / buildings.length;
+}
+
+export function scoreResources(resources: SimResources): number {
+  const totalResources =
+    (resources.coin || 0) +
+    (resources.grain || 0) +
+    (resources.planks || 0) +
+    (resources.mana || 0);
+
+  return Math.min(100, totalResources / 5);
+}
+
+export function scoreStability(citizens: Citizen[]): number {
+  if (citizens.length === 0) {
+    return Math.max(0, 100 - NO_CITIZEN_BASELINE_STRESS);
+  }
+
+  const totalStress = citizens.reduce((sum, citizen) => sum + citizen.mood.stress, 0);
+  const averageStress = totalStress / citizens.length;
+
+  return Math.max(0, 100 - averageStress);
+}
+
+export function computeSystemState(snapshot: SimulationSnapshot): SystemState {
+  return {
+    population: scorePopulation(snapshot.citizens),
+    happiness: scoreHappiness(snapshot.citizens),
+    economicHealth: scoreEconomicHealth(snapshot.resources, snapshot.workers),
+    infrastructure: scoreInfrastructure(snapshot.buildings),
+    resources: scoreResources(snapshot.resources),
+    stability: scoreStability(snapshot.citizens)
+  };
+}


### PR DESCRIPTION
## Summary
- extract system state scoring into reusable simulation/events/systemState utilities
- move probability adjustments and trigger handling into simulation/events/eventGeneration and keep EventManager focused on orchestration
- add targeted eventGeneration tests that cover probability tuning and indicator sequencing

## Testing
- npm run lint *(warnings only; existing lint warnings outside the touched files)*
- npm run test *(fails: vitest attempts to import src/hooks/**/*.test.{ts,tsx} from environmentMatchGlobs and reports missing file)*
- npm run build *(fails: pre-existing duplicate function implementation error in packages/engine/src/simulation/citizenAI.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68cac6d9f6808325b7b9b6204f770f38