### PR TITLE
Refactor city management state and actions

### DIFF
--- a/packages/engine/src/simulation/__tests__/cityManagementInterface.test.ts
+++ b/packages/engine/src/simulation/__tests__/cityManagementInterface.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { createGameTime } from '../../types/gameTime';
+import { CityManagementInterface } from '../cityManagementInterface';
+import { createZoneAction } from '../cityManagement/cityActions';
+
+const baseConfig = {
+  gridWidth: 20,
+  gridHeight: 20,
+  initialBudget: 10000,
+  difficulty: 'normal' as const
+};
+
+describe('CityManagementInterface integration', () => {
+  it('applies income and expenses when updating the simulation', async () => {
+    const management = new CityManagementInterface(baseConfig);
+    await management.initialize();
+    management.startSimulation();
+
+    expect(management.zoneArea(0, 0, 0, 0)).toBe(true);
+    expect(management.buildService(2, 2)).toBe(true);
+
+    management.update(1, createGameTime(0));
+
+    const stats = management.getStats();
+    expect(stats.population).toBe(10);
+    expect(stats.income).toBe(50);
+    expect(stats.expenses).toBe(5110);
+    expect(stats.budget).toBe(4940);
+  });
+
+  it('deducts budget and records expenses when executing an action immediately', async () => {
+    const management = new CityManagementInterface({ ...baseConfig, initialBudget: 1000 });
+    await management.initialize();
+
+    const action = createZoneAction({
+      startX: 5,
+      startY: 5,
+      endX: 5,
+      endY: 5,
+      zoneType: 'residential'
+    });
+
+    await expect(management.executeAction(action)).resolves.toBe(true);
+
+    const stats = management.getStats();
+    expect(stats.budget).toBe(900);
+    expect(stats.expenses).toBe(action.cost);
+    expect(management.getZoningSystem().getZonesByType('residential').length).toBeGreaterThan(0);
+  });
+});

--- a/packages/engine/src/simulation/cityManagement/CityManagementState.ts
+++ b/packages/engine/src/simulation/cityManagement/CityManagementState.ts
@@ -1,0 +1,81 @@
+export interface CityStats {
+  population: number;
+  happiness: number;
+  traffic: number;
+  pollution: number;
+  crime: number;
+  education: number;
+  healthcare: number;
+  employment: number;
+  budget: number;
+  income: number;
+  expenses: number;
+}
+
+const DEFAULT_STATS: Omit<CityStats, 'budget'> = {
+  population: 0,
+  happiness: 50,
+  traffic: 0,
+  pollution: 0,
+  crime: 10,
+  education: 30,
+  healthcare: 30,
+  employment: 70,
+  income: 0,
+  expenses: 0
+};
+
+type MutableMetrics = Omit<CityStats, 'budget' | 'income' | 'expenses' | 'population'>;
+
+export class CityManagementState {
+  private stats: CityStats;
+
+  constructor(initialBudget: number) {
+    this.stats = {
+      ...DEFAULT_STATS,
+      budget: initialBudget
+    };
+  }
+
+  resetFlow(): void {
+    this.stats.income = 0;
+    this.stats.expenses = 0;
+  }
+
+  applyIncome(amount: number): void {
+    if (amount <= 0) return;
+
+    this.stats.income += amount;
+    this.stats.budget += amount;
+  }
+
+  applyExpense(amount: number): void {
+    if (amount <= 0) return;
+
+    this.stats.expenses += amount;
+    this.stats.budget -= amount;
+  }
+
+  updatePopulation(population: number): void {
+    this.stats.population = Math.max(0, Math.floor(population));
+  }
+
+  updateMetrics(metrics: Partial<MutableMetrics>): void {
+    this.stats = {
+      ...this.stats,
+      ...metrics
+    };
+  }
+
+  canAfford(cost: number): boolean {
+    return this.stats.budget >= cost;
+  }
+
+  getBudget(): number {
+    return this.stats.budget;
+  }
+
+  getStats(): CityStats {
+    return { ...this.stats };
+  }
+}

--- a/packages/engine/src/simulation/cityManagement/cityActions.ts
+++ b/packages/engine/src/simulation/cityManagement/cityActions.ts
@@ -1,0 +1,178 @@
+import type { CityManagementState } from './CityManagementState';
+import { ServiceType, type CityServicesSystem } from '../cityServices';
+import type { RoadNetworkSystem } from '../roadNetwork';
+import type { ZoningSystem, ZoneType } from '../zoning';
+
+export interface CityActionContext {
+  zoningSystem: ZoningSystem;
+  roadNetwork: RoadNetworkSystem;
+  cityServices: CityServicesSystem;
+}
+
+export interface ManagementAction {
+  type: 'zone' | 'build_road' | 'build_service' | 'demolish' | 'upgrade';
+  position: { x: number; y: number };
+  data: Record<string, unknown>;
+  cost: number;
+}
+
+export interface ZoneActionOptions {
+  startX: number;
+  startY: number;
+  endX: number;
+  endY: number;
+  zoneType: ZoneType;
+}
+
+export interface RoadActionOptions {
+  startX: number;
+  startY: number;
+  endX: number;
+  endY: number;
+  roadType: string;
+}
+
+export interface ServiceActionOptions {
+  x: number;
+  y: number;
+  serviceType: ServiceType;
+}
+
+export function calculateZoneCost({ startX, startY, endX, endY }: ZoneActionOptions): number {
+  const width = Math.abs(endX - startX) + 1;
+  const height = Math.abs(endY - startY) + 1;
+  return width * height * 100;
+}
+
+export function calculateRoadCost({ startX, startY, endX, endY, roadType }: RoadActionOptions): number {
+  const distance = Math.abs(endX - startX) + Math.abs(endY - startY);
+  const baseCost = roadType === 'highway' ? 500 : roadType === 'commercial' ? 300 : 200;
+  return distance * baseCost;
+}
+
+export function calculateServiceCost(serviceType: ServiceType): number {
+  switch (serviceType) {
+    case ServiceType.POLICE:
+      return 5000;
+    case ServiceType.FIRE:
+      return 7000;
+    case ServiceType.HEALTHCARE:
+      return 10000;
+    case ServiceType.EDUCATION:
+      return 8000;
+    case ServiceType.POWER:
+      return 15000;
+    case ServiceType.WATER:
+      return 12000;
+    case ServiceType.WASTE:
+      return 6000;
+    default:
+      return 5000;
+  }
+}
+
+export function createZoneAction(options: ZoneActionOptions): ManagementAction {
+  return {
+    type: 'zone',
+    position: { x: options.startX, y: options.startY },
+    data: {
+      endX: options.endX,
+      endY: options.endY,
+      zoneType: options.zoneType
+    },
+    cost: calculateZoneCost(options)
+  };
+}
+
+export function createRoadAction(options: RoadActionOptions): ManagementAction {
+  return {
+    type: 'build_road',
+    position: { x: options.startX, y: options.startY },
+    data: {
+      endPosition: { x: options.endX, y: options.endY },
+      roadType: options.roadType
+    },
+    cost: calculateRoadCost(options)
+  };
+}
+
+export function createServiceAction(options: ServiceActionOptions): ManagementAction {
+  return {
+    type: 'build_service',
+    position: { x: options.x, y: options.y },
+    data: { serviceType: options.serviceType },
+    cost: calculateServiceCost(options.serviceType)
+  };
+}
+
+export function applyCityAction(action: ManagementAction, context: CityActionContext): void {
+  switch (action.type) {
+    case 'zone': {
+      const { endX, endY, zoneType } = action.data as {
+        endX: number;
+        endY: number;
+        zoneType: ZoneType;
+      };
+      context.zoningSystem.zoneArea(action.position.x, action.position.y, endX, endY, zoneType);
+      break;
+    }
+    case 'build_road': {
+      const { endPosition, roadType } = action.data as {
+        endPosition: { x: number; y: number };
+        roadType: string;
+      };
+      context.roadNetwork.planRoad(roadType as any, action.position, endPosition);
+      break;
+    }
+    case 'build_service': {
+      const { serviceType } = action.data as { serviceType: ServiceType };
+      context.cityServices.addServiceBuilding({
+        id: `service_${Date.now()}`,
+        typeId: serviceType,
+        position: action.position,
+        x: action.position.x,
+        y: action.position.y,
+        serviceType,
+        capacity: 100,
+        currentLoad: 0,
+        efficiency: 1.0,
+        maintenanceCost: 100,
+        coverage: 10,
+        staffing: 5,
+        maxStaffing: 10
+      });
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+export function processCityActions(
+  actions: ManagementAction[],
+  context: CityActionContext,
+  state: CityManagementState
+): void {
+  for (const action of actions) {
+    if (!state.canAfford(action.cost)) {
+      continue;
+    }
+
+    applyCityAction(action, context);
+    state.applyExpense(action.cost);
+  }
+}
+
+export function executeCityAction(
+  action: ManagementAction,
+  context: CityActionContext,
+  state: CityManagementState
+): boolean {
+  if (!state.canAfford(action.cost)) {
+    return false;
+  }
+
+  applyCityAction(action, context);
+  state.applyExpense(action.cost);
+  return true;
+}

--- a/packages/engine/src/simulation/cityManagementInterface.ts
+++ b/packages/engine/src/simulation/cityManagementInterface.ts
@@ -5,6 +5,16 @@ import { TrafficSimulationSystem } from './trafficSimulation';
 import { ZoningSystem, ZoneType } from './zoning';
 import { CityServicesSystem, ServiceType } from './cityServices';
 import { PublicTransportSystem } from './transport/transportSystem';
+import { CityManagementState } from './cityManagement/CityManagementState';
+import {
+  type CityActionContext,
+  type ManagementAction,
+  createRoadAction,
+  createServiceAction,
+  createZoneAction,
+  executeCityAction,
+  processCityActions
+} from './cityManagement/cityActions';
 
 export interface CityManagementConfig {
   gridWidth: number;
@@ -13,32 +23,11 @@ export interface CityManagementConfig {
   difficulty: 'easy' | 'normal' | 'hard';
 }
 
-export interface CityStats {
-  population: number;
-  happiness: number;
-  traffic: number;
-  pollution: number;
-  crime: number;
-  education: number;
-  healthcare: number;
-  employment: number;
-  budget: number;
-  income: number;
-  expenses: number;
-}
-
-export interface ManagementAction {
-  type: 'zone' | 'build_road' | 'build_service' | 'demolish' | 'upgrade';
-  position: { x: number; y: number };
-  data: any;
-  cost: number;
-}
-
 export class CityManagementInterface {
   private config: CityManagementConfig;
-  private stats: CityStats;
+  private state: CityManagementState;
   private actions: ManagementAction[] = [];
-  
+
   // Core systems
   private pathfinding: AdvancedPathfinding;
   private roadNetwork: RoadNetworkSystem;
@@ -46,34 +35,17 @@ export class CityManagementInterface {
   private zoningSystem: ZoningSystem;
   private cityServices: CityServicesSystem;
   private publicTransport: PublicTransportSystem;
-  
+
   // Management state
   private selectedTool: string = 'select';
   private selectedZoneType: ZoneType = 'residential';
   private selectedServiceType: ServiceType = ServiceType.POLICE;
-  private budget: number;
   private isSimulationRunning: boolean = false;
-  
+
   constructor(config: CityManagementConfig) {
     this.config = config;
-    this.budget = config.initialBudget;
-    
-    // Initialize stats
-    this.stats = {
-      population: 0,
-      happiness: 50,
-      traffic: 0,
-      pollution: 0,
-      crime: 10,
-      education: 30,
-      healthcare: 30,
-      employment: 70,
-      budget: this.budget,
-      income: 0,
-      expenses: 0
-    };
-    
-    // Initialize systems
+    this.state = new CityManagementState(config.initialBudget);
+
     this.pathfinding = new AdvancedPathfinding(config.gridWidth, config.gridHeight);
     this.roadNetwork = new RoadNetworkSystem(config.gridWidth, config.gridHeight);
     this.trafficSimulation = new TrafficSimulationSystem(config.gridWidth, config.gridHeight);
@@ -83,135 +55,101 @@ export class CityManagementInterface {
   }
 
   async initialize(): Promise<void> {
-    this.updateStats();
+    this.syncPopulationAndMetrics();
   }
-  
+
   // Simulation control
   startSimulation(): void {
     this.isSimulationRunning = true;
   }
-  
+
   pauseSimulation(): void {
     this.isSimulationRunning = false;
   }
-  
+
   update(deltaTime: number, gameTime: GameTime): void {
     if (!this.isSimulationRunning) return;
-    
-    // Update all systems
+
     this.trafficSimulation.update(deltaTime);
     this.zoningSystem.update(gameTime, []);
     this.cityServices.update(deltaTime);
     this.publicTransport.update(deltaTime);
-    
-    // Update stats
-    this.updateStats();
-    
-    // Process pending actions
-    this.processActions();
+
+    this.state.resetFlow();
+    processCityActions(this.actions, this.getActionContext(), this.state);
+    this.actions = [];
+
+    this.syncPopulationAndMetrics();
+
+    const population = this.state.getStats().population;
+    const income = this.calculateIncome(population);
+    if (income > 0) {
+      this.state.applyIncome(income);
+    }
+
+    const serviceExpenses = this.calculateServiceExpense();
+    if (serviceExpenses > 0) {
+      this.state.applyExpense(serviceExpenses);
+    }
   }
 
-  private updateStats(): void {
-    // Update population from zoning
-    const residentialZones = this.zoningSystem.getZonesByType('residential');
-    this.stats.population = residentialZones.length * 10; // Rough estimate
-    
-    // Update budget
-    this.stats.budget = this.budget;
-    
-    // Calculate income from taxes
-    this.stats.income = this.stats.population * 5; // $5 per citizen per update
-    
-    // Calculate expenses from services
-    const serviceBuildings = this.cityServices.getServiceBuildings();
-    this.stats.expenses = serviceBuildings.length * 10; // $10 per service building
-    
-    // Update budget
-    this.budget += this.stats.income - this.stats.expenses;
-    this.stats.budget = this.budget;
-    
-    // Update other metrics
-    this.stats.happiness = this.calculateHappiness();
-    this.stats.traffic = this.calculateTrafficLevel();
-    this.stats.pollution = this.calculatePollutionLevel();
+  private getActionContext(): CityActionContext {
+    return {
+      zoningSystem: this.zoningSystem,
+      roadNetwork: this.roadNetwork,
+      cityServices: this.cityServices
+    };
   }
-  
+
+  private syncPopulationAndMetrics(): void {
+    const population = this.calculatePopulation();
+    this.state.updatePopulation(population);
+    this.state.updateMetrics({
+      happiness: this.calculateHappiness(),
+      traffic: this.calculateTrafficLevel(),
+      pollution: this.calculatePollutionLevel()
+    });
+  }
+
+  private calculatePopulation(): number {
+    const residentialZones = this.zoningSystem.getZonesByType('residential');
+    return residentialZones.length * 10;
+  }
+
+  private calculateIncome(population: number): number {
+    return population * 5;
+  }
+
+  private calculateServiceExpense(): number {
+    const serviceBuildings = this.cityServices.getServiceBuildings();
+    return serviceBuildings.length * 10;
+  }
+
   private calculateHappiness(): number {
     const zones = this.zoningSystem.getAllZones();
     if (zones.length === 0) return 50;
-    
+
     const totalHappiness = zones.reduce((sum, zone) => sum + zone.happiness, 0);
     return totalHappiness / zones.length;
   }
-  
+
   private calculateTrafficLevel(): number {
-    // Simple traffic calculation based on vehicle count
     const vehicles = this.trafficSimulation.getAllVehicles();
     return Math.min(100, vehicles.length * 2);
   }
-  
+
   private calculatePollutionLevel(): number {
     const industrialZones = this.zoningSystem.getZonesByType('industrial');
     return Math.min(100, industrialZones.length * 5);
   }
-  
-  private processActions(): void {
-    for (const action of this.actions) {
-      if (this.budget >= action.cost) {
-        this.applyAction(action);
-        this.budget -= action.cost;
-      }
-    }
-    this.actions = [];
-  }
-
-  private applyAction(action: ManagementAction): void {
-    switch (action.type) {
-      case 'zone':
-        this.zoningSystem.zoneArea(
-          action.position.x, action.position.y,
-          action.position.x, action.position.y,
-          action.data.zoneType
-        );
-        break;
-        
-      case 'build_road':
-        this.roadNetwork.planRoad(
-          action.data.roadType as any,
-          action.position,
-          action.data.endPosition
-        );
-        break;
-        
-      case 'build_service':
-        this.cityServices.addServiceBuilding({
-          id: `service_${Date.now()}`,
-          typeId: action.data.serviceType,
-          position: action.position,
-          x: action.position.x,
-          y: action.position.y,
-          serviceType: action.data.serviceType,
-          capacity: 100,
-          currentLoad: 0,
-          efficiency: 1.0,
-          maintenanceCost: 100,
-          coverage: 10,
-          staffing: 5,
-          maxStaffing: 10
-        });
-        break;
-    }
-  }
 
   async executeAction(action: ManagementAction): Promise<boolean> {
-    if (this.budget < action.cost) {
+    const executed = executeCityAction(action, this.getActionContext(), this.state);
+    if (!executed) {
       return false;
     }
 
-    this.applyAction(action);
-    this.budget -= action.cost;
-    this.stats = { ...this.stats, budget: this.budget };
-
+    this.syncPopulationAndMetrics();
     return true;
   }
 
@@ -219,154 +157,117 @@ export class CityManagementInterface {
     this.pauseSimulation();
     this.actions = [];
   }
-  
+
   // Public interface methods
   setSelectedTool(tool: string): void {
     this.selectedTool = tool;
   }
-  
+
   setSelectedZoneType(zoneType: ZoneType): void {
     this.selectedZoneType = zoneType;
   }
-  
+
   setSelectedServiceType(serviceType: ServiceType): void {
     this.selectedServiceType = serviceType;
   }
-  
+
   // Zone management
   zoneArea(startX: number, startY: number, endX: number, endY: number): boolean {
-    const cost = this.calculateZoneCost(startX, startY, endX, endY);
-    
-    if (this.budget < cost) return false;
-    
-    this.actions.push({
-      type: 'zone',
-      position: { x: startX, y: startY },
-      data: { 
-        endX, endY, 
-        zoneType: this.selectedZoneType 
-      },
-      cost
+    const action = createZoneAction({
+      startX,
+      startY,
+      endX,
+      endY,
+      zoneType: this.selectedZoneType
     });
-    
+
+    if (!this.state.canAfford(action.cost)) return false;
+
+    this.actions.push(action);
     return true;
   }
-  
+
   // Road management
-  buildRoad(startX: number, startY: number, endX: number, endY: number, roadType: string = 'residential'): boolean {
-    const cost = this.calculateRoadCost(startX, startY, endX, endY, roadType);
-    
-    if (this.budget < cost) return false;
-    
-    this.actions.push({
-      type: 'build_road',
-      position: { x: startX, y: startY },
-      data: { 
-        endPosition: { x: endX, y: endY },
-        roadType 
-      },
-      cost
-    });
-    
+  buildRoad(
+    startX: number,
+    startY: number,
+    endX: number,
+    endY: number,
+    roadType: string = 'residential'
+  ): boolean {
+    const action = createRoadAction({ startX, startY, endX, endY, roadType });
+
+    if (!this.state.canAfford(action.cost)) return false;
+
+    this.actions.push(action);
     return true;
   }
-  
+
   // Service management
   buildService(x: number, y: number): boolean {
-    const cost = this.calculateServiceCost(this.selectedServiceType);
-    
-    if (this.budget < cost) return false;
-    
-    this.actions.push({
-      type: 'build_service',
-      position: { x, y },
-      data: { serviceType: this.selectedServiceType },
-      cost
-    });
-    
+    const action = createServiceAction({ x, y, serviceType: this.selectedServiceType });
+
+    if (!this.state.canAfford(action.cost)) return false;
+
+    this.actions.push(action);
     return true;
   }
-  
-  // Cost calculations
-  private calculateZoneCost(startX: number, startY: number, endX: number, endY: number): number {
-    const area = Math.abs(endX - startX + 1) * Math.abs(endY - startY + 1);
-    return area * 100; // $100 per cell
-  }
-  
-  private calculateRoadCost(startX: number, startY: number, endX: number, endY: number, roadType: string): number {
-    const distance = Math.abs(endX - startX) + Math.abs(endY - startY);
-    const baseCost = roadType === 'highway' ? 500 : roadType === 'commercial' ? 300 : 200;
-    return distance * baseCost;
-  }
-  
-  private calculateServiceCost(serviceType: ServiceType): number {
-    switch (serviceType) {
-      case ServiceType.POLICE: return 5000;
-      case ServiceType.FIRE: return 7000;
-      case ServiceType.HEALTHCARE: return 10000;
-      case ServiceType.EDUCATION: return 8000;
-      case ServiceType.POWER: return 15000;
-      case ServiceType.WATER: return 12000;
-      case ServiceType.WASTE: return 6000;
-      default: return 5000;
-    }
-  }
-  
+
   // Getters
   getStats(): CityStats {
-    return { ...this.stats };
+    return this.state.getStats();
   }
-  
+
   getBudget(): number {
-    return this.budget;
+    return this.state.getBudget();
   }
-  
+
   getSelectedTool(): string {
     return this.selectedTool;
   }
-  
+
   getSelectedZoneType(): ZoneType {
     return this.selectedZoneType;
   }
-  
+
   getSelectedServiceType(): ServiceType {
     return this.selectedServiceType;
   }
-  
+
   // System access
   getPathfinding(): AdvancedPathfinding {
     return this.pathfinding;
   }
-  
+
   getRoadNetwork(): RoadNetworkSystem {
     return this.roadNetwork;
   }
-  
+
   getTrafficSimulation(): TrafficSimulationSystem {
     return this.trafficSimulation;
   }
-  
+
   getZoningSystem(): ZoningSystem {
     return this.zoningSystem;
   }
-  
+
   getCityServices(): CityServicesSystem {
     return this.cityServices;
   }
-  
+
   getPublicTransport(): PublicTransportSystem {
     return this.publicTransport;
   }
-  
+
   // Simulation queries
   getZoneAt(x: number, y: number) {
     return this.zoningSystem.getZoneAt(x, y);
   }
-  
+
   getRoadAt(x: number, y: number) {
     return this.roadNetwork.getRoadAt(x, y);
   }
-  
+
   getServiceBuildingsInRange(x: number, y: number, range: number) {
     return this.cityServices.getServiceBuildings().filter(building => {
       const distance = Math.sqrt(
@@ -375,18 +276,20 @@ export class CityManagementInterface {
       return distance <= range;
     });
   }
-  
+
   // Spawn entities for testing
   spawnVehicle(start: { x: number; y: number }, destination: { x: number; y: number }): string {
     return this.trafficSimulation.spawnVehicle('car', start, destination);
   }
-  
+
   spawnPedestrian(start: { x: number; y: number }, destination: { x: number; y: number }): string {
     return this.trafficSimulation.spawnPedestrian(start, destination);
   }
 }
 
-// Export singleton instance for easy use
+export type { CityStats } from './cityManagement/CityManagementState';
+export type { ManagementAction } from './cityManagement/cityActions';
+
 export const cityManagement = new CityManagementInterface({
   gridWidth: 200,
   gridHeight: 200,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,15 +16,9 @@ export default defineConfig({
   test: {
     environment: 'node',
     environmentMatchGlobs: [
-      [
-        'src/state/**/*.test.{ts,tsx}',
-        'jsdom',
-      ],
-      [
-        'src/components/**/*.test.{ts,tsx}',
-        'src/hooks/**/*.test.{ts,tsx}',
-        'jsdom',
-      ],
+      ['src/state/**/*.test.{ts,tsx}', 'jsdom'],
+      ['src/components/**/*.test.{ts,tsx}', 'jsdom'],
+      ['src/hooks/**/*.test.{ts,tsx}', 'jsdom'],
     ],
   },
 });


### PR DESCRIPTION
## Summary
- add a dedicated `CityManagementState` service to own budget and stat mutations
- move zoning, road, and service action creation/processing into a reusable `cityActions` module and compose both services inside `CityManagementInterface`
- fix Vitest environment globs and add integration coverage for budget and action cost bookkeeping

## Testing
- `npm run lint`
- `npm run test` *(fails: suite still missing @testing-library/react for skill hook tests)*
- `npx vitest run packages/engine/src/simulation/__tests__/cityManagementInterface.test.ts`
- `CI=1 npm run build` *(fails: existing duplicate implementation error in packages/engine/src/simulation/citizenAI.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68cac6e8b318832593f943f7ac976a7f