### PR TITLE
Modularize settings config into typed category builders

### DIFF
--- a/packages/ui/src/settings/__tests__/createSettingsConfig.test.ts
+++ b/packages/ui/src/settings/__tests__/createSettingsConfig.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSettingsConfig } from '../config';
+import type { LayoutPreset } from '../config';
+
+const layoutPresets: LayoutPreset[] = [
+  {
+    id: 'default',
+    name: 'Default',
+    description: 'Default layout',
+  },
+];
+
+describe('createSettingsConfig', () => {
+  it('wraps world handlers with onAnyChange callbacks', () => {
+    const onAnyChange = vi.fn();
+    const onToggleRoads = vi.fn();
+    const onChangeCitizensCount = vi.fn();
+
+    const categories = createSettingsConfig({
+      onAnyChange,
+      display: {
+        layoutPresets,
+        currentPreset: 'default',
+        onPresetChange: vi.fn(),
+      },
+      world: {
+        showRoads: {
+          value: true,
+          onChange: onToggleRoads,
+        },
+        citizensCount: {
+          value: 8,
+          onChange: onChangeCitizensCount,
+        },
+      },
+    });
+
+    const worldCategory = categories.find((category) => category.id === 'world');
+    expect(worldCategory).toBeDefined();
+
+    const showRoadsSetting = worldCategory?.settings.find(
+      (setting) => setting.id === 'show-roads',
+    );
+    expect(showRoadsSetting).toBeDefined();
+    showRoadsSetting?.onChange(false);
+
+    expect(onToggleRoads).toHaveBeenCalledWith(false);
+
+    const citizensCountSetting = worldCategory?.settings.find(
+      (setting) => setting.id === 'citizens-count',
+    );
+    expect(citizensCountSetting).toBeDefined();
+    citizensCountSetting?.onChange(12);
+
+    expect(onChangeCitizensCount).toHaveBeenCalledWith(12);
+    expect(onAnyChange).toHaveBeenCalledTimes(2);
+  });
+
+  it('applies default display values', () => {
+    const categories = createSettingsConfig({
+      onAnyChange: vi.fn(),
+      display: {
+        layoutPresets,
+        currentPreset: 'default',
+        onPresetChange: vi.fn(),
+      },
+    });
+
+    const displayCategory = categories.find((category) => category.id === 'display');
+    expect(displayCategory).toBeDefined();
+
+    const qualitySetting = displayCategory?.settings.find(
+      (setting) => setting.id === 'quality',
+    );
+    expect(qualitySetting?.value).toBe('high');
+
+    const fpsLimitSetting = displayCategory?.settings.find(
+      (setting) => setting.id === 'fps-limit',
+    );
+    expect(fpsLimitSetting?.value).toBe(60);
+
+    const vsyncSetting = displayCategory?.settings.find(
+      (setting) => setting.id === 'vsync',
+    );
+    expect(vsyncSetting?.value).toBe(true);
+  });
+
+  it('omits the world category when no world options are provided', () => {
+    const categories = createSettingsConfig({
+      onAnyChange: vi.fn(),
+      display: {
+        layoutPresets,
+        currentPreset: 'default',
+        onPresetChange: vi.fn(),
+      },
+    });
+
+    expect(categories.some((category) => category.id === 'world')).toBe(false);
+  });
+});

--- a/packages/ui/src/settings/categories/accessibilityCategory.ts
+++ b/packages/ui/src/settings/categories/accessibilityCategory.ts
@@ -1,0 +1,59 @@
+import { faUniversalAccess } from '@fortawesome/free-solid-svg-icons';
+import type { CategoryBuilderContext, SettingCategory } from '../types';
+
+export const buildAccessibilityCategory = (
+  context: CategoryBuilderContext,
+): SettingCategory => ({
+  id: 'accessibility',
+  name: 'Accessibility',
+  icon: faUniversalAccess,
+  description: 'Options to improve game accessibility',
+  settings: [
+    {
+      id: 'high-contrast',
+      name: 'High Contrast Mode',
+      description: 'Increase visual contrast for better visibility',
+      type: 'toggle',
+      value: false,
+      onChange: () => context.onAnyChange(),
+    },
+    {
+      id: 'large-text',
+      name: 'Large Text',
+      description: 'Increase text size throughout the interface',
+      type: 'toggle',
+      value: false,
+      onChange: () => context.onAnyChange(),
+    },
+    {
+      id: 'reduced-motion',
+      name: 'Reduce Motion',
+      description: 'Minimize animations and transitions',
+      type: 'toggle',
+      value: false,
+      onChange: () => context.onAnyChange(),
+    },
+    {
+      id: 'screen-reader',
+      name: 'Screen Reader Support',
+      description: 'Enhanced support for screen readers',
+      type: 'toggle',
+      value: false,
+      onChange: () => context.onAnyChange(),
+    },
+    {
+      id: 'colorblind-support',
+      name: 'Colorblind Support',
+      description: 'Alternative color schemes for colorblind users',
+      type: 'select',
+      value: 'none',
+      options: [
+        { value: 'none', label: 'None' },
+        { value: 'protanopia', label: 'Protanopia' },
+        { value: 'deuteranopia', label: 'Deuteranopia' },
+        { value: 'tritanopia', label: 'Tritanopia' },
+      ],
+      onChange: () => context.onAnyChange(),
+    },
+  ],
+});

--- a/packages/ui/src/settings/categories/audioCategory.ts
+++ b/packages/ui/src/settings/categories/audioCategory.ts
@@ -1,0 +1,54 @@
+import { faVolumeUp } from '@fortawesome/free-solid-svg-icons';
+import type { CategoryBuilderContext, SettingCategory } from '../types';
+
+export const buildAudioCategory = (
+  context: CategoryBuilderContext,
+): SettingCategory => ({
+  id: 'audio',
+  name: 'Audio',
+  icon: faVolumeUp,
+  description: 'Sound and music settings',
+  settings: [
+    {
+      id: 'master-volume',
+      name: 'Master Volume',
+      description: 'Overall audio level',
+      type: 'range',
+      value: 80,
+      min: 0,
+      max: 100,
+      step: 5,
+      onChange: () => context.onAnyChange(),
+    },
+    {
+      id: 'music-volume',
+      name: 'Music Volume',
+      description: 'Background music level',
+      type: 'range',
+      value: 60,
+      min: 0,
+      max: 100,
+      step: 5,
+      onChange: () => context.onAnyChange(),
+    },
+    {
+      id: 'sfx-volume',
+      name: 'Sound Effects',
+      description: 'Game sound effects level',
+      type: 'range',
+      value: 80,
+      min: 0,
+      max: 100,
+      step: 5,
+      onChange: () => context.onAnyChange(),
+    },
+    {
+      id: 'mute-background',
+      name: 'Mute When Inactive',
+      description: 'Mute audio when game is not focused',
+      type: 'toggle',
+      value: true,
+      onChange: () => context.onAnyChange(),
+    },
+  ],
+});

--- a/packages/ui/src/settings/categories/displayCategory.ts
+++ b/packages/ui/src/settings/categories/displayCategory.ts
@@ -1,0 +1,80 @@
+import { faDesktop } from '@fortawesome/free-solid-svg-icons';
+import type {
+  CategoryBuilderContext,
+  LayoutPreset,
+  SettingCategory,
+} from '../types';
+
+export interface DisplayCategoryOptions {
+  layoutPresets: LayoutPreset[];
+  currentPreset: string;
+  onPresetChange: (presetId: string) => void;
+}
+
+export const buildDisplayCategory = (
+  options: DisplayCategoryOptions,
+  context: CategoryBuilderContext,
+): SettingCategory => ({
+  id: 'display',
+  name: 'Display & Graphics',
+  icon: faDesktop,
+  description: 'Visual settings and performance options',
+  settings: [
+    {
+      id: 'layout-preset',
+      name: 'Layout Preset',
+      description: 'Choose your preferred HUD layout',
+      type: 'preset',
+      value: options.currentPreset,
+      options: options.layoutPresets.map((preset) => ({
+        value: preset.id,
+        label: preset.name,
+      })),
+      onChange: (presetId) => {
+        options.onPresetChange(presetId);
+        context.onAnyChange();
+      },
+    },
+    {
+      id: 'quality',
+      name: 'Graphics Quality',
+      description: 'Adjust visual quality for performance',
+      type: 'select',
+      value: 'high',
+      options: [
+        { value: 'low', label: 'Low' },
+        { value: 'medium', label: 'Medium' },
+        { value: 'high', label: 'High' },
+        { value: 'ultra', label: 'Ultra' },
+      ],
+      onChange: () => context.onAnyChange(),
+    },
+    {
+      id: 'fps-limit',
+      name: 'FPS Limit',
+      description: 'Maximum frames per second',
+      type: 'range',
+      value: 60,
+      min: 30,
+      max: 120,
+      step: 10,
+      onChange: () => context.onAnyChange(),
+    },
+    {
+      id: 'vsync',
+      name: 'V-Sync',
+      description: 'Synchronize with monitor refresh rate',
+      type: 'toggle',
+      value: true,
+      onChange: () => context.onAnyChange(),
+    },
+    {
+      id: 'fullscreen',
+      name: 'Fullscreen Mode',
+      description: 'Run game in fullscreen',
+      type: 'toggle',
+      value: false,
+      onChange: () => context.onAnyChange(),
+    },
+  ],
+});

--- a/packages/ui/src/settings/categories/gameplayCategory.ts
+++ b/packages/ui/src/settings/categories/gameplayCategory.ts
@@ -1,0 +1,43 @@
+import { faGamepad } from '@fortawesome/free-solid-svg-icons';
+import type { CategoryBuilderContext, SettingCategory } from '../types';
+
+export const buildGameplayCategory = (
+  context: CategoryBuilderContext,
+): SettingCategory => ({
+  id: 'gameplay',
+  name: 'Gameplay',
+  icon: faGamepad,
+  description: 'Game mechanics and difficulty settings',
+  settings: [
+    {
+      id: 'auto-pause',
+      name: 'Auto-Pause Events',
+      description: 'Automatically pause on important events',
+      type: 'toggle',
+      value: true,
+      onChange: () => context.onAnyChange(),
+    },
+    {
+      id: 'tutorial-hints',
+      name: 'Tutorial Hints',
+      description: 'Show helpful tips and guidance',
+      type: 'toggle',
+      value: true,
+      onChange: () => context.onAnyChange(),
+    },
+    {
+      id: 'difficulty',
+      name: 'Difficulty Level',
+      description: 'Adjust game challenge',
+      type: 'select',
+      value: 'normal',
+      options: [
+        { value: 'easy', label: 'Easy' },
+        { value: 'normal', label: 'Normal' },
+        { value: 'hard', label: 'Hard' },
+        { value: 'expert', label: 'Expert' },
+      ],
+      onChange: () => context.onAnyChange(),
+    },
+  ],
+});

--- a/packages/ui/src/settings/categories/inboxCategory.ts
+++ b/packages/ui/src/settings/categories/inboxCategory.ts
@@ -1,0 +1,10 @@
+import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
+import type { SettingCategory } from '../types';
+
+export const buildInboxCategory = (): SettingCategory => ({
+  id: 'inbox',
+  name: 'Inbox',
+  icon: faInfoCircle,
+  description: 'Notifications & history',
+  settings: [],
+});

--- a/packages/ui/src/settings/categories/worldCategory.ts
+++ b/packages/ui/src/settings/categories/worldCategory.ts
@@ -1,0 +1,165 @@
+import { faGamepad } from '@fortawesome/free-solid-svg-icons';
+import type {
+  CategoryBuilderContext,
+  NumericSettingConfig,
+  SettingCategory,
+  SettingItem,
+  ToggleSettingConfig,
+} from '../types';
+import { createNumericHandler, createToggleHandler } from '../utils';
+
+export interface WorldCategoryOptions {
+  showRoads?: ToggleSettingConfig;
+  showCitizens?: ToggleSettingConfig;
+  autoAssignWorkers?: ToggleSettingConfig;
+  edgeScrollEnabled?: ToggleSettingConfig;
+  requireRoadConfirm?: ToggleSettingConfig;
+  citizensCount?: NumericSettingConfig;
+  citizensSeed?: NumericSettingConfig;
+}
+
+const pushToggleSetting = (
+  settings: SettingItem[],
+  context: CategoryBuilderContext,
+  id: string,
+  name: string,
+  description: string,
+  config?: ToggleSettingConfig,
+) => {
+  if (!config) return;
+
+  settings.push({
+    id,
+    name,
+    description,
+    type: 'toggle',
+    value: Boolean(config.value),
+    onChange: createToggleHandler(config.onChange, context.onAnyChange),
+  });
+};
+
+const pushNumericSetting = (
+  settings: SettingItem[],
+  context: CategoryBuilderContext,
+  id: string,
+  name: string,
+  description: string,
+  config?: NumericSettingConfig,
+  extra?: { min: number; max: number; step?: number },
+) => {
+  if (!config) return;
+
+  const value = Number.isFinite(config.value) ? config.value : extra?.min ?? 0;
+  const onChange = createNumericHandler(config.onChange, context.onAnyChange);
+
+  if (extra) {
+    settings.push({
+      id,
+      name,
+      description,
+      type: 'range',
+      value,
+      min: extra.min,
+      max: extra.max,
+      step: extra.step,
+      onChange,
+    });
+    return;
+  }
+
+  settings.push({
+    id,
+    name,
+    description,
+    type: 'number',
+    value,
+    onChange,
+  });
+};
+
+export const buildWorldCategory = (
+  options: WorldCategoryOptions | undefined,
+  context: CategoryBuilderContext,
+): SettingCategory | null => {
+  if (!options) {
+    return null;
+  }
+
+  const settings: SettingItem[] = [];
+
+  pushToggleSetting(
+    settings,
+    context,
+    'show-roads',
+    'Show Roads',
+    'Toggle road overlays on the map',
+    options.showRoads,
+  );
+
+  pushToggleSetting(
+    settings,
+    context,
+    'show-citizens',
+    'Show Citizens',
+    'Toggle citizen activity markers',
+    options.showCitizens,
+  );
+
+  pushToggleSetting(
+    settings,
+    context,
+    'auto-assign-workers',
+    'Auto-Assign Workers',
+    'Automatically assign idle workers to best available jobs',
+    options.autoAssignWorkers,
+  );
+
+  pushToggleSetting(
+    settings,
+    context,
+    'edge-scroll',
+    'Edge Scroll Panning',
+    'Pan camera when cursor nears screen edge',
+    options.edgeScrollEnabled,
+  );
+
+  pushToggleSetting(
+    settings,
+    context,
+    'confirm-roads',
+    'Confirm Roads Before Building',
+    'Ask for approval when citizens propose roads',
+    options.requireRoadConfirm,
+  );
+
+  pushNumericSetting(
+    settings,
+    context,
+    'citizens-count',
+    'Citizens Count',
+    'Number of active citizens (applies immediately)',
+    options.citizensCount,
+    { min: 2, max: 20, step: 1 },
+  );
+
+  pushNumericSetting(
+    settings,
+    context,
+    'citizens-seed',
+    'Citizens Seed',
+    'Randomization seed for citizens (movement variance)',
+    options.citizensSeed,
+  );
+
+  if (settings.length === 0) {
+    return null;
+  }
+
+  return {
+    id: 'world',
+    name: 'World',
+    icon: faGamepad,
+    description: 'Map, citizens, and building preferences',
+    settings,
+  };
+};

--- a/packages/ui/src/settings/config.ts
+++ b/packages/ui/src/settings/config.ts
@@ -1,365 +1,92 @@
-import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
-import {
-  faGamepad,
-  faDesktop,
-  faVolumeUp,
-  faUniversalAccess,
-  faInfoCircle,
-} from '@fortawesome/free-solid-svg-icons';
+import type { SettingCategory } from './types';
+export type {
+  CategoryBuilderContext,
+  LayoutPreset,
+  NumericSettingConfig,
+  NumericChangeHandler,
+  PresetSettingItem,
+  RangeSettingItem,
+  SelectChangeHandler,
+  SelectOption,
+  SelectSettingItem,
+  SettingItem,
+  SettingType,
+  SettingValue,
+  ToggleChangeHandler,
+  ToggleSettingConfig,
+  ToggleSettingItem,
+  NumberSettingItem,
+} from './types';
+export {
+  isNumberSetting,
+  isPresetSetting,
+  isRangeSetting,
+  isSelectSetting,
+  isToggleSetting,
+} from './types';
 
-export interface LayoutPreset {
-  id: string;
-  name: string;
-  description: string;
-  icon?: IconDefinition;
-}
+import { buildAccessibilityCategory } from './categories/accessibilityCategory';
+import { buildAudioCategory } from './categories/audioCategory';
+import { buildDisplayCategory } from './categories/displayCategory';
+import type { DisplayCategoryOptions } from './categories/displayCategory';
+import { buildGameplayCategory } from './categories/gameplayCategory';
+import { buildInboxCategory } from './categories/inboxCategory';
+import { buildWorldCategory } from './categories/worldCategory';
+import type { WorldCategoryOptions } from './categories/worldCategory';
+import type { CategoryBuilderContext } from './types';
 
-export type SettingValue = string | number | boolean;
+export type { DisplayCategoryOptions, WorldCategoryOptions };
 
-export interface SettingItem {
-  id: string;
-  name: string;
-  description: string;
-  type: 'toggle' | 'select' | 'range' | 'preset' | 'number';
-  value: SettingValue;
-  options?: { value: SettingValue; label: string }[];
-  min?: number;
-  max?: number;
-  step?: number;
-  onChange: (value: SettingValue) => void;
-}
-
-export interface SettingCategory {
-  id: string;
-  name: string;
-  icon: IconDefinition;
-  description: string;
-  settings: SettingItem[];
-}
-
-export interface SettingsConfigOptions {
-  layoutPresets: LayoutPreset[];
-  currentPreset: string;
-  onPresetChange: (presetId: string) => void;
+export interface SettingsComposerOptions {
   onAnyChange: () => void;
-  showRoads?: boolean;
-  onToggleRoads?: (value: boolean) => void;
-  showCitizens?: boolean;
-  onToggleCitizens?: (value: boolean) => void;
-  requireRoadConfirm?: boolean;
-  onToggleRoadConfirm?: (value: boolean) => void;
-  edgeScrollEnabled?: boolean;
-  onToggleEdgeScroll?: (value: boolean) => void;
-  citizensCount?: number;
-  onChangeCitizensCount?: (value: number) => void;
-  citizensSeed?: number;
-  onChangeCitizensSeed?: (value: number) => void;
-  autoAssignWorkers?: boolean;
-  onToggleAutoAssignWorkers?: (value: boolean) => void;
+  display?: DisplayCategoryOptions;
+  world?: WorldCategoryOptions;
+  includeInbox?: boolean;
+  includeGameplay?: boolean;
+  includeAudio?: boolean;
+  includeAccessibility?: boolean;
 }
 
-export const createSettingsConfig = (
-  opts: SettingsConfigOptions,
-): SettingCategory[] => [
-  {
-    id: 'inbox',
-    name: 'Inbox',
-    icon: faInfoCircle,
-    description: 'Notifications & history',
-    settings: [],
-  },
-  {
-    id: 'world',
-    name: 'World',
-    icon: faGamepad,
-    description: 'Map, citizens, and building preferences',
-    settings: [
-      {
-        id: 'show-roads',
-        name: 'Show Roads',
-        description: 'Toggle road overlays on the map',
-        type: 'toggle',
-        value: Boolean(opts.showRoads),
-        onChange: (v: SettingValue) => {
-          opts.onToggleRoads?.(Boolean(v));
-          opts.onAnyChange();
-        },
-      },
-      {
-        id: 'show-citizens',
-        name: 'Show Citizens',
-        description: 'Toggle citizen activity markers',
-        type: 'toggle',
-        value: Boolean(opts.showCitizens),
-        onChange: (v: SettingValue) => {
-          opts.onToggleCitizens?.(Boolean(v));
-          opts.onAnyChange();
-        },
-      },
-      {
-        id: 'auto-assign-workers',
-        name: 'Auto-Assign Workers',
-        description: 'Automatically assign idle workers to best available jobs',
-        type: 'toggle',
-        value: Boolean(opts.autoAssignWorkers),
-        onChange: (v: SettingValue) => {
-          opts.onToggleAutoAssignWorkers?.(Boolean(v));
-          opts.onAnyChange();
-        },
-      },
-      {
-        id: 'edge-scroll',
-        name: 'Edge Scroll Panning',
-        description: 'Pan camera when cursor nears screen edge',
-        type: 'toggle',
-        value: Boolean(opts.edgeScrollEnabled),
-        onChange: (v: SettingValue) => {
-          opts.onToggleEdgeScroll?.(Boolean(v));
-          opts.onAnyChange();
-        },
-      },
-      {
-        id: 'confirm-roads',
-        name: 'Confirm Roads Before Building',
-        description: 'Ask for approval when citizens propose roads',
-        type: 'toggle',
-        value: Boolean(opts.requireRoadConfirm),
-        onChange: (v: SettingValue) => {
-          opts.onToggleRoadConfirm?.(Boolean(v));
-          opts.onAnyChange();
-        },
-      },
-      {
-        id: 'citizens-count',
-        name: 'Citizens Count',
-        description: 'Number of active citizens (applies immediately)',
-        type: 'range',
-        value: Number(opts.citizensCount ?? 8),
-        min: 2,
-        max: 20,
-        step: 1,
-        onChange: (v: SettingValue) => {
-          opts.onChangeCitizensCount?.(Number(v));
-          opts.onAnyChange();
-        },
-      },
-      {
-        id: 'citizens-seed',
-        name: 'Citizens Seed',
-        description: 'Randomization seed for citizens (movement variance)',
-        type: 'number',
-        value: Number(opts.citizensSeed ?? 0),
-        onChange: (v: SettingValue) => {
-          opts.onChangeCitizensSeed?.(Number(v));
-          opts.onAnyChange();
-        },
-      },
-    ],
-  },
-  {
-    id: 'display',
-    name: 'Display & Graphics',
-    icon: faDesktop,
-    description: 'Visual settings and performance options',
-    settings: [
-      {
-        id: 'layout-preset',
-        name: 'Layout Preset',
-        description: 'Choose your preferred HUD layout',
-        type: 'preset',
-        value: opts.currentPreset,
-        options: opts.layoutPresets.map(preset => ({
-          value: preset.id,
-          label: preset.name,
-        })),
-        onChange: (value: SettingValue) => {
-          opts.onPresetChange(value as string);
-          opts.onAnyChange();
-        },
-      },
-      {
-        id: 'quality',
-        name: 'Graphics Quality',
-        description: 'Adjust visual quality for performance',
-        type: 'select',
-        value: 'high',
-        options: [
-          { value: 'low', label: 'Low' },
-          { value: 'medium', label: 'Medium' },
-          { value: 'high', label: 'High' },
-          { value: 'ultra', label: 'Ultra' },
-        ],
-        onChange: () => opts.onAnyChange(),
-      },
-      {
-        id: 'fps-limit',
-        name: 'FPS Limit',
-        description: 'Maximum frames per second',
-        type: 'range',
-        value: 60,
-        min: 30,
-        max: 120,
-        step: 10,
-        onChange: () => opts.onAnyChange(),
-      },
-      {
-        id: 'vsync',
-        name: 'V-Sync',
-        description: 'Synchronize with monitor refresh rate',
-        type: 'toggle',
-        value: true,
-        onChange: () => opts.onAnyChange(),
-      },
-      {
-        id: 'fullscreen',
-        name: 'Fullscreen Mode',
-        description: 'Run game in fullscreen',
-        type: 'toggle',
-        value: false,
-        onChange: () => opts.onAnyChange(),
-      },
-    ],
-  },
-  {
-    id: 'gameplay',
-    name: 'Gameplay',
-    icon: faGamepad,
-    description: 'Game mechanics and difficulty settings',
-    settings: [
-      {
-        id: 'auto-pause',
-        name: 'Auto-Pause Events',
-        description: 'Automatically pause on important events',
-        type: 'toggle',
-        value: true,
-        onChange: () => opts.onAnyChange(),
-      },
-      {
-        id: 'tutorial-hints',
-        name: 'Tutorial Hints',
-        description: 'Show helpful tips and guidance',
-        type: 'toggle',
-        value: true,
-        onChange: () => opts.onAnyChange(),
-      },
-      {
-        id: 'difficulty',
-        name: 'Difficulty Level',
-        description: 'Adjust game challenge',
-        type: 'select',
-        value: 'normal',
-        options: [
-          { value: 'easy', label: 'Easy' },
-          { value: 'normal', label: 'Normal' },
-          { value: 'hard', label: 'Hard' },
-          { value: 'expert', label: 'Expert' },
-        ],
-        onChange: () => opts.onAnyChange(),
-      },
-    ],
-  },
-  {
-    id: 'audio',
-    name: 'Audio',
-    icon: faVolumeUp,
-    description: 'Sound and music settings',
-    settings: [
-      {
-        id: 'master-volume',
-        name: 'Master Volume',
-        description: 'Overall audio level',
-        type: 'range',
-        value: 80,
-        min: 0,
-        max: 100,
-        step: 5,
-        onChange: () => opts.onAnyChange(),
-      },
-      {
-        id: 'music-volume',
-        name: 'Music Volume',
-        description: 'Background music level',
-        type: 'range',
-        value: 60,
-        min: 0,
-        max: 100,
-        step: 5,
-        onChange: () => opts.onAnyChange(),
-      },
-      {
-        id: 'sfx-volume',
-        name: 'Sound Effects',
-        description: 'Game sound effects level',
-        type: 'range',
-        value: 80,
-        min: 0,
-        max: 100,
-        step: 5,
-        onChange: () => opts.onAnyChange(),
-      },
-      {
-        id: 'mute-background',
-        name: 'Mute When Inactive',
-        description: 'Mute audio when game is not focused',
-        type: 'toggle',
-        value: true,
-        onChange: () => opts.onAnyChange(),
-      },
-    ],
-  },
-  {
-    id: 'accessibility',
-    name: 'Accessibility',
-    icon: faUniversalAccess,
-    description: 'Options to improve game accessibility',
-    settings: [
-      {
-        id: 'high-contrast',
-        name: 'High Contrast Mode',
-        description: 'Increase visual contrast for better visibility',
-        type: 'toggle',
-        value: false,
-        onChange: () => opts.onAnyChange(),
-      },
-      {
-        id: 'large-text',
-        name: 'Large Text',
-        description: 'Increase text size throughout the interface',
-        type: 'toggle',
-        value: false,
-        onChange: () => opts.onAnyChange(),
-      },
-      {
-        id: 'reduced-motion',
-        name: 'Reduce Motion',
-        description: 'Minimize animations and transitions',
-        type: 'toggle',
-        value: false,
-        onChange: () => opts.onAnyChange(),
-      },
-      {
-        id: 'screen-reader',
-        name: 'Screen Reader Support',
-        description: 'Enhanced support for screen readers',
-        type: 'toggle',
-        value: false,
-        onChange: () => opts.onAnyChange(),
-      },
-      {
-        id: 'colorblind-support',
-        name: 'Colorblind Support',
-        description: 'Alternative color schemes for colorblind users',
-        type: 'select',
-        value: 'none',
-        options: [
-          { value: 'none', label: 'None' },
-          { value: 'protanopia', label: 'Protanopia' },
-          { value: 'deuteranopia', label: 'Deuteranopia' },
-          { value: 'tritanopia', label: 'Tritanopia' },
-        ],
-        onChange: () => opts.onAnyChange(),
-      },
-    ],
-  },
-];
+const createContext = (onAnyChange: () => void): CategoryBuilderContext => ({
+  onAnyChange,
+});
 
+export const createSettingsConfig = ({
+  onAnyChange,
+  display,
+  world,
+  includeInbox = true,
+  includeGameplay = true,
+  includeAudio = true,
+  includeAccessibility = true,
+}: SettingsComposerOptions): SettingCategory[] => {
+  const categories: SettingCategory[] = [];
+  const context = createContext(onAnyChange);
+
+  if (includeInbox) {
+    categories.push(buildInboxCategory());
+  }
+
+  const worldCategory = buildWorldCategory(world, context);
+  if (worldCategory) {
+    categories.push(worldCategory);
+  }
+
+  if (display) {
+    categories.push(buildDisplayCategory(display, context));
+  }
+
+  if (includeGameplay) {
+    categories.push(buildGameplayCategory(context));
+  }
+
+  if (includeAudio) {
+    categories.push(buildAudioCategory(context));
+  }
+
+  if (includeAccessibility) {
+    categories.push(buildAccessibilityCategory(context));
+  }
+
+  return categories;
+};

--- a/packages/ui/src/settings/types.ts
+++ b/packages/ui/src/settings/types.ts
@@ -1,0 +1,108 @@
+import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
+
+export interface LayoutPreset {
+  id: string;
+  name: string;
+  description: string;
+  icon?: IconDefinition;
+}
+
+export type SettingValue = string | number | boolean;
+
+export type SettingType = 'toggle' | 'select' | 'range' | 'preset' | 'number';
+
+interface BaseSettingItem<TType extends SettingType, TValue> {
+  id: string;
+  name: string;
+  description: string;
+  type: TType;
+  value: TValue;
+}
+
+export type ToggleChangeHandler = (value: boolean) => void;
+export type NumericChangeHandler = (value: number) => void;
+export type SelectChangeHandler<TValue extends SettingValue = SettingValue> = (
+  value: TValue,
+) => void;
+
+export interface ToggleSettingItem
+  extends BaseSettingItem<'toggle', boolean> {
+  onChange: ToggleChangeHandler;
+}
+
+export interface RangeSettingItem extends BaseSettingItem<'range', number> {
+  min: number;
+  max: number;
+  step?: number;
+  onChange: NumericChangeHandler;
+}
+
+export interface NumberSettingItem extends BaseSettingItem<'number', number> {
+  onChange: NumericChangeHandler;
+}
+
+export interface SelectOption<TValue extends SettingValue = SettingValue> {
+  value: TValue;
+  label: string;
+}
+
+export interface SelectSettingItem<
+  TValue extends SettingValue = SettingValue,
+> extends BaseSettingItem<'select', TValue> {
+  options: SelectOption<TValue>[];
+  onChange: SelectChangeHandler<TValue>;
+}
+
+export interface PresetSettingItem extends BaseSettingItem<'preset', string> {
+  options: SelectOption<string>[];
+  onChange: SelectChangeHandler<string>;
+}
+
+export type SettingItem =
+  | ToggleSettingItem
+  | RangeSettingItem
+  | NumberSettingItem
+  | SelectSettingItem
+  | PresetSettingItem;
+
+export interface SettingCategory {
+  id: string;
+  name: string;
+  icon: IconDefinition;
+  description: string;
+  settings: SettingItem[];
+}
+
+export interface ToggleSettingConfig {
+  value: boolean;
+  onChange: ToggleChangeHandler;
+}
+
+export interface NumericSettingConfig {
+  value: number;
+  onChange: NumericChangeHandler;
+}
+
+export interface CategoryBuilderContext {
+  onAnyChange: () => void;
+}
+
+export const isToggleSetting = (
+  setting: SettingItem,
+): setting is ToggleSettingItem => setting.type === 'toggle';
+
+export const isRangeSetting = (
+  setting: SettingItem,
+): setting is RangeSettingItem => setting.type === 'range';
+
+export const isNumberSetting = (
+  setting: SettingItem,
+): setting is NumberSettingItem => setting.type === 'number';
+
+export const isSelectSetting = <TValue extends SettingValue = SettingValue>(
+  setting: SettingItem,
+): setting is SelectSettingItem<TValue> => setting.type === 'select';
+
+export const isPresetSetting = (
+  setting: SettingItem,
+): setting is PresetSettingItem => setting.type === 'preset';

--- a/packages/ui/src/settings/utils.ts
+++ b/packages/ui/src/settings/utils.ts
@@ -1,0 +1,24 @@
+import type {
+  NumericChangeHandler,
+  ToggleChangeHandler,
+} from './types';
+
+export const createToggleHandler = (
+  handler: ToggleChangeHandler,
+  onAnyChange: () => void,
+): ToggleChangeHandler => {
+  return (value: boolean) => {
+    handler(Boolean(value));
+    onAnyChange();
+  };
+};
+
+export const createNumericHandler = (
+  handler: NumericChangeHandler,
+  onAnyChange: () => void,
+): NumericChangeHandler => {
+  return (value: number) => {
+    handler(Number(value));
+    onAnyChange();
+  };
+};

--- a/src/components/game/SettingsPanel.tsx
+++ b/src/components/game/SettingsPanel.tsx
@@ -1,13 +1,22 @@
 'use client';
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useCallback } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTimes, faCog, faInfoCircle, faUndo, faSave } from '@/lib/icons';
 import '../../styles/design-tokens.css';
 import '../../styles/animations.css';
 
-import { ActionButton, SettingsSearchBar, SettingCategory, createSettingsConfig } from '@arcane/ui';
-import type { LayoutPreset, SettingCategory as UISettingCategory } from '@arcane/ui/settings/config';
+import {
+  ActionButton,
+  SettingsSearchBar,
+  SettingCategory,
+  createSettingsConfig,
+} from '@arcane/ui';
+import type {
+  LayoutPreset,
+  SettingCategory as UISettingCategory,
+  WorldCategoryOptions,
+} from '@arcane/ui/settings/config';
 
 export interface SettingsPanelProps {
   isOpen: boolean;
@@ -115,48 +124,91 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
   const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set(['display', 'gameplay', 'time']));
   const [hasChanges, setHasChanges] = useState(false);
 
-  const categories: UISettingCategory[] = useMemo(
-    () =>
-      createSettingsConfig({
+  const handleAnyChange = useCallback(() => setHasChanges(true), []);
+
+  const categories: UISettingCategory[] = useMemo(() => {
+    const worldOptions: WorldCategoryOptions = {};
+
+    if (typeof onToggleRoads === 'function') {
+      worldOptions.showRoads = {
+        value: Boolean(showRoads),
+        onChange: onToggleRoads,
+      };
+    }
+
+    if (typeof onToggleCitizens === 'function') {
+      worldOptions.showCitizens = {
+        value: Boolean(showCitizens),
+        onChange: onToggleCitizens,
+      };
+    }
+
+    if (typeof onToggleAutoAssignWorkers === 'function') {
+      worldOptions.autoAssignWorkers = {
+        value: Boolean(autoAssignWorkers),
+        onChange: onToggleAutoAssignWorkers,
+      };
+    }
+
+    if (typeof onToggleEdgeScroll === 'function') {
+      worldOptions.edgeScrollEnabled = {
+        value: Boolean(edgeScrollEnabled),
+        onChange: onToggleEdgeScroll,
+      };
+    }
+
+    if (typeof onToggleRoadConfirm === 'function') {
+      worldOptions.requireRoadConfirm = {
+        value: Boolean(requireRoadConfirm),
+        onChange: onToggleRoadConfirm,
+      };
+    }
+
+    if (typeof onChangeCitizensCount === 'function') {
+      worldOptions.citizensCount = {
+        value: typeof citizensCount === 'number' ? citizensCount : 8,
+        onChange: onChangeCitizensCount,
+      };
+    }
+
+    if (typeof onChangeCitizensSeed === 'function') {
+      worldOptions.citizensSeed = {
+        value: typeof citizensSeed === 'number' ? citizensSeed : 0,
+        onChange: onChangeCitizensSeed,
+      };
+    }
+
+    const hasWorldSettings = Object.keys(worldOptions).length > 0;
+
+    return createSettingsConfig({
+      onAnyChange: handleAnyChange,
+      display: {
         layoutPresets,
         currentPreset,
         onPresetChange,
-        onAnyChange: () => setHasChanges(true),
-        showRoads,
-        onToggleRoads,
-        showCitizens,
-        onToggleCitizens,
-        autoAssignWorkers,
-        onToggleAutoAssignWorkers,
-        edgeScrollEnabled,
-        onToggleEdgeScroll,
-        requireRoadConfirm,
-        onToggleRoadConfirm,
-        citizensCount,
-        onChangeCitizensCount,
-        citizensSeed,
-        onChangeCitizensSeed,
-      }),
-    [
-      layoutPresets,
-      currentPreset,
-      onPresetChange,
-      showRoads,
-      onToggleRoads,
-      showCitizens,
-      onToggleCitizens,
-      autoAssignWorkers,
-      onToggleAutoAssignWorkers,
-      edgeScrollEnabled,
-      onToggleEdgeScroll,
-      requireRoadConfirm,
-      onToggleRoadConfirm,
-      citizensCount,
-      onChangeCitizensCount,
-      citizensSeed,
-      onChangeCitizensSeed,
-    ],
-  );
+      },
+      world: hasWorldSettings ? worldOptions : undefined,
+    });
+  }, [
+    autoAssignWorkers,
+    citizensCount,
+    citizensSeed,
+    currentPreset,
+    edgeScrollEnabled,
+    handleAnyChange,
+    layoutPresets,
+    onChangeCitizensCount,
+    onChangeCitizensSeed,
+    onPresetChange,
+    onToggleAutoAssignWorkers,
+    onToggleCitizens,
+    onToggleEdgeScroll,
+    onToggleRoadConfirm,
+    onToggleRoads,
+    requireRoadConfirm,
+    showCitizens,
+    showRoads,
+  ]);
 
   const toggleCategory = (categoryId: string) => {
     setExpandedCategories(prev => {


### PR DESCRIPTION
## Summary
- introduce typed settings item definitions, handler factories, and category builders for world/display/etc.
- update the settings composer to assemble enabled categories and wire SettingsPanel into the new API
- add vitest coverage for handler wrapping and default display values

## Testing
- npm run lint
- npm run test *(fails: existing useCityManagement tests and Vitest glob resolution errors)*
- CI=1 npm run build *(fails: duplicate function implementation reported in packages/engine/src/simulation/citizenAI.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68cac6eaeec08325a862aae1cee74f45