### PR TITLE
Refactor constellation skill tree state into hook

### DIFF
--- a/src/components/game/skills/ConstellationCanvas.tsx
+++ b/src/components/game/skills/ConstellationCanvas.tsx
@@ -1,0 +1,147 @@
+import React, { useEffect, useMemo, useRef } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+import type { ConstellationLayout } from './layout/constellation';
+import type {
+  ConstellationNode,
+  SkillNode,
+  SkillTree,
+  TooltipState,
+  Vec2,
+} from './types';
+import { useConstellationRenderer } from './hooks/useConstellationRenderer';
+import {
+  useConstellationController,
+  type ControllerHandlers,
+} from './hooks/useConstellationController';
+
+interface ConstellationCanvasProps {
+  tree: SkillTree;
+  unlocked: Record<string, boolean>;
+  layout: ConstellationLayout;
+  pan: Vec2;
+  zoom: number;
+  hover: ConstellationNode | null;
+  selected: ConstellationNode | null;
+  size: { w: number; h: number };
+  tooltipState: TooltipState;
+  highlightNodes: Set<string>;
+  highlightEdges: Set<string>;
+  colorFor: (category: SkillNode['category']) => string;
+  canAfford: (node: SkillNode) => boolean;
+  checkUnlock: (node: SkillNode) => { ok: boolean; reasons: string[] };
+  onPanChange: Dispatch<SetStateAction<Vec2>>;
+  onZoomChange: Dispatch<SetStateAction<number>>;
+  onHoverChange: Dispatch<SetStateAction<ConstellationNode | null>>;
+  onSelectedChange: (node: ConstellationNode | null) => void;
+  onTooltipChange: Dispatch<SetStateAction<TooltipState>>;
+  onUnlock: (node: SkillNode) => void;
+  className?: string;
+  onControlsChange?: (handlers: ControllerHandlers) => void;
+  setSize: Dispatch<SetStateAction<{ w: number; h: number }>>;
+}
+
+export default function ConstellationCanvas({
+  tree,
+  unlocked,
+  layout,
+  pan,
+  zoom,
+  hover,
+  selected,
+  size,
+  tooltipState,
+  highlightNodes,
+  highlightEdges,
+  colorFor,
+  canAfford,
+  checkUnlock,
+  onPanChange,
+  onZoomChange,
+  onHoverChange,
+  onSelectedChange,
+  onTooltipChange,
+  onUnlock,
+  className,
+  onControlsChange,
+  setSize,
+}: ConstellationCanvasProps) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  const { updateNodeTransition, spawnParticles } = useConstellationRenderer({
+    canvasRef,
+    layout,
+    tree,
+    unlocked,
+    hover,
+    selected,
+    highlightNodes,
+    highlightEdges,
+    pan,
+    zoom,
+    size,
+    colorFor,
+    canAfford,
+    checkUnlock,
+    tooltip: tooltipState,
+    setTooltip: onTooltipChange,
+  });
+
+  const controllerHandlers = useConstellationController({
+    canvasRef,
+    layout,
+    size,
+    pan,
+    zoom,
+    hover,
+    selected,
+    onHoverChange,
+    onSelectedChange,
+    onPanChange,
+    onZoomChange,
+    onTooltipChange,
+    onUnlock,
+    colorFor,
+    checkUnlock,
+    updateNodeTransition,
+    spawnParticles,
+  });
+
+  useEffect(() => {
+    if (!onControlsChange) return;
+    onControlsChange(controllerHandlers);
+  }, [controllerHandlers, onControlsChange]);
+
+  useEffect(() => {
+    const handleResize = () => {
+      const container = canvasRef.current?.parentElement;
+      if (container) {
+        setSize({ w: container.clientWidth, h: container.clientHeight });
+      }
+    };
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [setSize]);
+
+  const eventHandlers = useMemo(
+    () => ({
+      onMouseMove: controllerHandlers.onMouseMove,
+      onMouseDown: controllerHandlers.onMouseDown,
+      onMouseUp: controllerHandlers.onMouseUp,
+      onMouseLeave: controllerHandlers.onMouseLeave,
+      onClick: controllerHandlers.onClick,
+      onWheel: controllerHandlers.onWheel,
+    }),
+    [
+      controllerHandlers.onClick,
+      controllerHandlers.onMouseDown,
+      controllerHandlers.onMouseLeave,
+      controllerHandlers.onMouseMove,
+      controllerHandlers.onMouseUp,
+      controllerHandlers.onWheel,
+    ],
+  );
+
+  return <canvas ref={canvasRef} className={className} {...eventHandlers} />;
+}

--- a/src/components/game/skills/ConstellationSkillTree.tsx
+++ b/src/components/game/skills/ConstellationSkillTree.tsx
@@ -1,192 +1,61 @@
 "use client";
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type {
-  ConstellationNode,
-  ConstellationSkillTreeProps,
-  SkillNode,
-  TooltipState,
-  Vec2,
-} from './types';
+import React from 'react';
+import ConstellationCanvas from './ConstellationCanvas';
 import SkillTooltipContent from './SkillTooltipContent';
-import { collectUnlockBlockers } from './unlock';
-import { createConstellationLayout } from './layout/constellation';
-import { computeHighlight } from './layout/highlights';
-import { useConstellationRenderer } from './hooks/useConstellationRenderer';
-import { useConstellationController } from './hooks/useConstellationController';
+import type { ConstellationSkillTreeProps } from './types';
+import { useConstellationSkillTree } from './hooks/useConstellationSkillTree';
 
-const initialTooltipState: TooltipState = {
-  visible: false,
-  x: 0,
-  y: 0,
-  node: null,
-  fadeIn: 0,
-  anchor: 'top',
-  offset: { x: 0, y: 0 },
-};
-
-export default function ConstellationSkillTree({
-  tree,
-  unlocked,
-  onUnlock,
-  colorFor,
-  focusNodeId,
-  resources,
-  onSelectNode,
-}: ConstellationSkillTreeProps) {
-  const canvasRef = useRef<HTMLCanvasElement | null>(null);
-  const [size, setSize] = useState<{ w: number; h: number }>({ w: 1200, h: 800 });
-  const [hover, setHover] = useState<ConstellationNode | null>(null);
-  const [selected, setSelected] = useState<ConstellationNode | null>(null);
-  const [pan, setPan] = useState<Vec2>({ x: 0, y: 0 });
-  const [zoom, setZoom] = useState<number>(0.8);
-  const [tooltip, setTooltip] = useState<TooltipState>(initialTooltipState);
-  const lastAutoFitRadius = useRef<number | null>(null);
-
-  const layout = useMemo(() => createConstellationLayout(tree), [tree]);
-  const layoutById = useMemo(() => {
-    const map = new Map<string, ConstellationNode>();
-    layout.nodes.forEach((node) => {
-      map.set(node.node.id, node);
-    });
-    return map;
-  }, [layout.nodes]);
-
-  const checkUnlock = useCallback(
-    (node: SkillNode) => {
-      const reasons = collectUnlockBlockers({ node, unlocked, nodes: tree.nodes });
-      return { ok: reasons.length === 0, reasons };
-    },
-    [tree.nodes, unlocked],
-  );
-
-  const canAfford = useCallback(
-    (node: SkillNode) => {
-      if (!resources) return true;
-      const cost = node.cost ?? {};
-      if (typeof cost.coin === 'number' && (resources.coin || 0) < cost.coin) return false;
-      if (typeof cost.mana === 'number' && (resources.mana || 0) < cost.mana) return false;
-      if (typeof cost.favor === 'number' && (resources.favor || 0) < cost.favor) return false;
-      return true;
-    },
-    [resources],
-  );
-
-  const highlightTargetId = hover?.node.id ?? selected?.node.id ?? null;
-  const { nodes: highlightNodes, edges: highlightEdges } = useMemo(
-    () => computeHighlight({ targetId: highlightTargetId, tree, layoutNodes: layout.nodes }),
-    [highlightTargetId, tree, layout.nodes],
-  );
-
-  const { updateNodeTransition, spawnParticles } = useConstellationRenderer({
-    canvasRef,
-    layout,
-    tree,
-    unlocked,
-    hover,
-    selected,
-    highlightNodes,
-    highlightEdges,
-    pan,
-    zoom,
-    size,
-    colorFor,
-    canAfford,
-    checkUnlock,
-    tooltip,
-    setTooltip,
-  });
-
-  const handleSelectedChange = useCallback(
-    (node: ConstellationNode | null) => {
-      setSelected(node);
-      onSelectNode?.(node?.node.id ?? null);
-    },
-    [onSelectNode],
-  );
+export default function ConstellationSkillTree(props: ConstellationSkillTreeProps) {
+  const { tree, unlocked, onUnlock, colorFor } = props;
 
   const {
-    onMouseMove,
-    onMouseDown,
-    onMouseUp,
-    onMouseLeave,
-    onClick,
-    onWheel,
-    zoomIn,
-    zoomOut,
-    resetZoom,
-    fitToView,
-    zoomTo,
-  } = useConstellationController({
-    canvasRef,
     layout,
-    size,
-    pan,
-    zoom,
     hover,
     selected,
-    onHoverChange: setHover,
-    onSelectedChange: handleSelectedChange,
-    onPanChange: setPan,
-    onZoomChange: setZoom,
-    onTooltipChange: setTooltip,
-    onUnlock,
-    colorFor,
+    pan,
+    zoom,
+    size,
+    tooltip,
+    highlightNodes,
+    highlightEdges,
+    canAfford,
     checkUnlock,
-    updateNodeTransition,
-    spawnParticles,
-  });
-
-  useEffect(() => {
-    if (!focusNodeId) return;
-    const node = layoutById.get(focusNodeId);
-    if (!node) return;
-    zoomTo(Math.min(2.5, Math.max(0.7, 1.4)));
-    setPan({ x: -node.x, y: -node.y });
-    handleSelectedChange(node);
-  }, [focusNodeId, layoutById, zoomTo, handleSelectedChange]);
-
-  useEffect(() => {
-    if (layout.nodes.length === 0) return;
-    const maxRadius = layout.metrics?.maxConstellationRadius ?? 0;
-    const previous = lastAutoFitRadius.current;
-
-    if (focusNodeId) {
-      lastAutoFitRadius.current = maxRadius;
-      return;
-    }
-
-    if (previous === null || maxRadius > previous + 1) {
-      lastAutoFitRadius.current = maxRadius;
-      fitToView();
-    } else if (previous !== maxRadius) {
-      lastAutoFitRadius.current = maxRadius;
-    }
-  }, [fitToView, focusNodeId, layout.metrics?.maxConstellationRadius, layout.nodes.length]);
-
-  useEffect(() => {
-    const handleResize = () => {
-      const container = canvasRef.current?.parentElement;
-      if (container) {
-        setSize({ w: container.clientWidth, h: container.clientHeight });
-      }
-    };
-
-    handleResize();
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
+    setHover,
+    handleSelectedChange,
+    setPan,
+    setZoom,
+    setSize,
+    setTooltip,
+    registerControls,
+    controls,
+  } = useConstellationSkillTree(props);
 
   return (
     <div className="relative w-full h-full overflow-hidden bg-gray-900">
-      <canvas
-        ref={canvasRef}
+      <ConstellationCanvas
+        tree={tree}
+        unlocked={unlocked}
+        layout={layout}
+        pan={pan}
+        zoom={zoom}
+        hover={hover}
+        selected={selected}
+        size={size}
+        tooltipState={tooltip}
+        highlightNodes={highlightNodes}
+        highlightEdges={highlightEdges}
+        colorFor={colorFor}
+        canAfford={canAfford}
+        checkUnlock={checkUnlock}
+        onPanChange={setPan}
+        onZoomChange={setZoom}
+        onHoverChange={setHover}
+        onSelectedChange={handleSelectedChange}
+        onTooltipChange={setTooltip}
+        onUnlock={onUnlock}
         className="absolute inset-0 cursor-grab active:cursor-grabbing"
-        onMouseMove={onMouseMove}
-        onMouseDown={onMouseDown}
-        onMouseUp={onMouseUp}
-        onMouseLeave={onMouseLeave}
-        onClick={onClick}
-        onWheel={onWheel}
+        onControlsChange={registerControls}
+        setSize={setSize}
       />
 
       {tooltip.visible && tooltip.node && (
@@ -222,28 +91,28 @@ export default function ConstellationSkillTree({
 
       <div className="absolute top-4 right-4 flex flex-col gap-2 bg-gray-800/90 backdrop-blur-sm rounded-lg p-2 border border-gray-600">
         <button
-          onClick={zoomIn}
+          onClick={() => controls?.zoomIn()}
           className="w-10 h-10 bg-gray-700 hover:bg-gray-600 text-white rounded flex items-center justify-center transition-colors font-bold"
           title="Zoom In"
         >
           +
         </button>
         <button
-          onClick={zoomOut}
+          onClick={() => controls?.zoomOut()}
           className="w-10 h-10 bg-gray-700 hover:bg-gray-600 text-white rounded flex items-center justify-center transition-colors font-bold"
           title="Zoom Out"
         >
           −
         </button>
         <button
-          onClick={resetZoom}
+          onClick={() => controls?.resetZoom()}
           className="w-10 h-10 bg-gray-700 hover:bg-gray-600 text-white rounded flex items-center justify-center transition-colors text-xs"
           title="Reset View"
         >
           ⌂
         </button>
         <button
-          onClick={fitToView}
+          onClick={() => controls?.fitToView()}
           className="w-10 h-10 bg-gray-700 hover:bg-gray-600 text-white rounded flex items-center justify-center transition-colors text-xs"
           title="Fit to View"
         >

--- a/src/components/game/skills/hooks/useConstellationController.ts
+++ b/src/components/game/skills/hooks/useConstellationController.ts
@@ -44,7 +44,7 @@ interface UseConstellationControllerOptions {
   ) => void;
 }
 
-interface ControllerHandlers {
+export interface ControllerHandlers {
   onMouseMove: (event: ReactMouseEvent<HTMLCanvasElement>) => void;
   onMouseDown: (event: ReactMouseEvent<HTMLCanvasElement>) => void;
   onMouseUp: () => void;

--- a/src/components/game/skills/hooks/useConstellationSkillTree.test.ts
+++ b/src/components/game/skills/hooks/useConstellationSkillTree.test.ts
@@ -1,0 +1,204 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useConstellationSkillTree } from './useConstellationSkillTree';
+import type { ConstellationLayout } from '../layout/constellation';
+import type { ConstellationNode, SkillNode, Vec2 } from '../types';
+import type { ControllerHandlers } from './useConstellationController';
+
+vi.mock('../layout/constellation', () => ({
+  createConstellationLayout: vi.fn(),
+}));
+
+vi.mock('../layout/highlights', () => ({
+  computeHighlight: vi.fn(() => ({ nodes: new Set<string>(), edges: new Set<string>() })),
+}));
+
+vi.mock('../unlock', () => ({
+  collectUnlockBlockers: vi.fn(() => []),
+}));
+
+import { createConstellationLayout } from '../layout/constellation';
+import { computeHighlight } from '../layout/highlights';
+import { collectUnlockBlockers } from '../unlock';
+
+const createSkillNode = (overrides: Partial<SkillNode> = {}): SkillNode => ({
+  id: overrides.id ?? 'node-1',
+  title: overrides.title ?? 'Node 1',
+  description: overrides.description ?? 'Test node',
+  category: overrides.category ?? 'economic',
+  rarity: overrides.rarity ?? 'common',
+  quality: overrides.quality ?? 'common',
+  tags: overrides.tags ?? [],
+  cost: overrides.cost ?? {},
+  baseCost: overrides.baseCost ?? {},
+  effects: overrides.effects ?? [],
+  requires: overrides.requires,
+  tier: overrides.tier,
+  importance: overrides.importance,
+  unlockCount: overrides.unlockCount,
+  isRevealed: overrides.isRevealed,
+  specialAbility: overrides.specialAbility,
+  statMultiplier: overrides.statMultiplier,
+  exclusiveGroup: overrides.exclusiveGroup,
+  unlockConditions: overrides.unlockConditions,
+});
+
+const createConstellationNode = (id: string, position: Vec2): ConstellationNode => ({
+  node: createSkillNode({ id }),
+  gridX: Math.round(position.x),
+  gridY: Math.round(position.y),
+  x: position.x,
+  y: position.y,
+  constellation: 'Test',
+  tier: 0,
+});
+
+const createLayout = (nodes: ConstellationNode[], maxRadius: number): ConstellationLayout => ({
+  nodes,
+  constellations: {},
+  metrics: {
+    baseRingRadius: 0,
+    ringGap: 0,
+    radiusByTier: [0],
+    maxConstellationRadius: maxRadius,
+    maxTier: 1,
+    constellationSpacing: 0,
+  },
+});
+
+describe('useConstellationSkillTree', () => {
+  const createControllerHandlers = () => ({
+    onMouseMove: vi.fn(),
+    onMouseDown: vi.fn(),
+    onMouseUp: vi.fn(),
+    onMouseLeave: vi.fn(),
+    onClick: vi.fn(),
+    onWheel: vi.fn(),
+    zoomIn: vi.fn(),
+    zoomOut: vi.fn(),
+    resetZoom: vi.fn(),
+    fitToView: vi.fn(),
+    zoomTo: vi.fn(),
+  });
+
+  beforeEach(() => {
+    vi.mocked(computeHighlight).mockReturnValue({ nodes: new Set<string>(), edges: new Set<string>() });
+    vi.mocked(collectUnlockBlockers).mockReturnValue([]);
+  });
+
+  it('selects focused node and centers view when controls are registered', async () => {
+    const focusedNode = createConstellationNode('focus', { x: 50, y: -30 });
+    let layout = createLayout([focusedNode], 120);
+    vi.mocked(createConstellationLayout).mockImplementation(() => layout);
+
+    const onSelectNode = vi.fn();
+    const { result } = renderHook((props: Parameters<typeof useConstellationSkillTree>[0]) =>
+      useConstellationSkillTree(props),
+      {
+        initialProps: {
+          tree: { nodes: [focusedNode.node], edges: [] },
+          unlocked: {},
+          onUnlock: vi.fn(),
+          colorFor: () => '#fff',
+          focusNodeId: 'focus',
+          resources: undefined,
+          onSelectNode,
+        },
+      },
+    );
+
+    const controls = createControllerHandlers();
+    const zoomToSpy = controls.zoomTo;
+    const fitToViewSpy = controls.fitToView;
+
+    act(() => {
+      result.current.registerControls(controls as ControllerHandlers);
+    });
+
+    await waitFor(() => {
+      expect(zoomToSpy).toHaveBeenCalled();
+    });
+
+    expect(result.current.selected?.node.id).toBe('focus');
+    expect(result.current.pan).toEqual({ x: -focusedNode.x, y: -focusedNode.y });
+    expect(onSelectNode).toHaveBeenCalledWith('focus');
+    expect(fitToViewSpy).not.toHaveBeenCalled();
+  });
+
+  it('auto fits when the constellation radius grows without a focus node', async () => {
+    const node = createConstellationNode('node-1', { x: 0, y: 0 });
+    let layout = createLayout([node], 100);
+    vi.mocked(createConstellationLayout).mockImplementation(() => layout);
+
+    const { result, rerender } = renderHook((props: Parameters<typeof useConstellationSkillTree>[0]) =>
+      useConstellationSkillTree(props),
+      {
+        initialProps: {
+          tree: { nodes: [node.node], edges: [] },
+          unlocked: {},
+          onUnlock: vi.fn(),
+          colorFor: () => '#fff',
+          focusNodeId: undefined,
+          resources: undefined,
+          onSelectNode: vi.fn(),
+        },
+      },
+    );
+
+    const controls = createControllerHandlers();
+    const fitToViewSpy = controls.fitToView;
+
+    act(() => {
+      result.current.registerControls(controls as ControllerHandlers);
+    });
+
+    await waitFor(() => {
+      expect(fitToViewSpy).toHaveBeenCalledTimes(1);
+    });
+
+    layout = createLayout([node], 150);
+
+    rerender({
+      tree: { nodes: [node.node], edges: [] },
+      unlocked: {},
+      onUnlock: vi.fn(),
+      colorFor: () => '#fff',
+      focusNodeId: undefined,
+      resources: undefined,
+      onSelectNode: vi.fn(),
+    });
+
+    await waitFor(() => {
+      expect(fitToViewSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('updates selection state and notifies callback when selection changes', () => {
+    const node = createConstellationNode('node-2', { x: 10, y: -10 });
+    const layout = createLayout([node], 80);
+    vi.mocked(createConstellationLayout).mockImplementation(() => layout);
+
+    const onSelectNode = vi.fn();
+    const { result } = renderHook((props: Parameters<typeof useConstellationSkillTree>[0]) =>
+      useConstellationSkillTree(props),
+      {
+        initialProps: {
+          tree: { nodes: [node.node], edges: [] },
+          unlocked: {},
+          onUnlock: vi.fn(),
+          colorFor: () => '#fff',
+          focusNodeId: undefined,
+          resources: undefined,
+          onSelectNode,
+        },
+      },
+    );
+
+    act(() => {
+      result.current.handleSelectedChange(node);
+    });
+
+    expect(result.current.selected).toBe(node);
+    expect(onSelectNode).toHaveBeenCalledWith('node-2');
+  });
+});

--- a/src/components/game/skills/hooks/useConstellationSkillTree.ts
+++ b/src/components/game/skills/hooks/useConstellationSkillTree.ts
@@ -1,0 +1,159 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+import { collectUnlockBlockers } from '../unlock';
+import { createConstellationLayout } from '../layout/constellation';
+import { computeHighlight } from '../layout/highlights';
+import type { ConstellationNode, ConstellationSkillTreeProps, SkillNode, TooltipState, Vec2 } from '../types';
+import type { ConstellationLayout } from '../layout/constellation';
+import type { ControllerHandlers } from './useConstellationController';
+
+const INITIAL_TOOLTIP_STATE: TooltipState = {
+  visible: false,
+  x: 0,
+  y: 0,
+  node: null,
+  fadeIn: 0,
+  anchor: 'top',
+  offset: { x: 0, y: 0 },
+};
+
+interface UseConstellationSkillTreeResult {
+  layout: ConstellationLayout;
+  hover: ConstellationNode | null;
+  selected: ConstellationNode | null;
+  pan: Vec2;
+  zoom: number;
+  size: { w: number; h: number };
+  tooltip: TooltipState;
+  highlightNodes: Set<string>;
+  highlightEdges: Set<string>;
+  canAfford: (node: SkillNode) => boolean;
+  checkUnlock: (node: SkillNode) => { ok: boolean; reasons: string[] };
+  setHover: Dispatch<SetStateAction<ConstellationNode | null>>;
+  handleSelectedChange: (node: ConstellationNode | null) => void;
+  setPan: Dispatch<SetStateAction<Vec2>>;
+  setZoom: Dispatch<SetStateAction<number>>;
+  setSize: Dispatch<SetStateAction<{ w: number; h: number }>>;
+  setTooltip: Dispatch<SetStateAction<TooltipState>>;
+  registerControls: (handlers: ControllerHandlers) => void;
+  controls: ControllerHandlers | null;
+}
+
+export function useConstellationSkillTree({
+  tree,
+  unlocked,
+  focusNodeId,
+  resources,
+  onSelectNode,
+}: ConstellationSkillTreeProps): UseConstellationSkillTreeResult {
+  const [hover, setHover] = useState<ConstellationNode | null>(null);
+  const [selected, setSelected] = useState<ConstellationNode | null>(null);
+  const [pan, setPan] = useState<Vec2>({ x: 0, y: 0 });
+  const [zoom, setZoom] = useState<number>(0.8);
+  const [size, setSize] = useState<{ w: number; h: number }>({ w: 1200, h: 800 });
+  const [tooltip, setTooltip] = useState<TooltipState>(INITIAL_TOOLTIP_STATE);
+  const [controls, setControls] = useState<ControllerHandlers | null>(null);
+  const lastAutoFitRadius = useRef<number | null>(null);
+
+  const layout = useMemo(() => createConstellationLayout(tree), [tree]);
+
+  const layoutById = useMemo(() => {
+    const map = new Map<string, ConstellationNode>();
+    layout.nodes.forEach((node) => {
+      map.set(node.node.id, node);
+    });
+    return map;
+  }, [layout.nodes]);
+
+  const checkUnlock = useCallback(
+    (node: SkillNode) => {
+      const reasons = collectUnlockBlockers({ node, unlocked, nodes: tree.nodes });
+      return { ok: reasons.length === 0, reasons };
+    },
+    [tree.nodes, unlocked],
+  );
+
+  const canAfford = useCallback(
+    (node: SkillNode) => {
+      if (!resources) return true;
+      const cost = node.cost ?? {};
+      if (typeof cost.coin === 'number' && (resources.coin || 0) < cost.coin) return false;
+      if (typeof cost.mana === 'number' && (resources.mana || 0) < cost.mana) return false;
+      if (typeof cost.favor === 'number' && (resources.favor || 0) < cost.favor) return false;
+      return true;
+    },
+    [resources],
+  );
+
+  const handleSelectedChange = useCallback(
+    (node: ConstellationNode | null) => {
+      setSelected(node);
+      onSelectNode?.(node?.node.id ?? null);
+    },
+    [onSelectNode],
+  );
+
+  const highlightTargetId = hover?.node.id ?? selected?.node.id ?? null;
+  const { nodes: highlightNodes, edges: highlightEdges } = useMemo(
+    () => computeHighlight({ targetId: highlightTargetId, tree, layoutNodes: layout.nodes }),
+    [highlightTargetId, tree, layout.nodes],
+  );
+
+  const registerControls = useCallback((handlers: ControllerHandlers) => {
+    setControls((prev) => (prev === handlers ? prev : handlers));
+  }, []);
+
+  useEffect(() => {
+    if (!controls || !focusNodeId) return;
+    const node = layoutById.get(focusNodeId);
+    if (!node) return;
+
+    const targetZoom = Math.min(2.5, Math.max(0.7, 1.4));
+    controls.zoomTo(targetZoom);
+    setPan({ x: -node.x, y: -node.y });
+    handleSelectedChange(node);
+  }, [controls, focusNodeId, handleSelectedChange, layoutById]);
+
+  useEffect(() => {
+    if (!controls || layout.nodes.length === 0) return;
+
+    const maxRadius = layout.metrics?.maxConstellationRadius ?? 0;
+    const previous = lastAutoFitRadius.current;
+
+    if (focusNodeId) {
+      lastAutoFitRadius.current = maxRadius;
+      return;
+    }
+
+    if (previous === null || maxRadius > previous + 1) {
+      lastAutoFitRadius.current = maxRadius;
+      controls.fitToView();
+    } else if (previous !== maxRadius) {
+      lastAutoFitRadius.current = maxRadius;
+    }
+  }, [controls, focusNodeId, layout.metrics?.maxConstellationRadius, layout.nodes.length]);
+
+  return {
+    layout,
+    hover,
+    selected,
+    pan,
+    zoom,
+    size,
+    tooltip,
+    highlightNodes,
+    highlightEdges,
+    canAfford,
+    checkUnlock,
+    setHover,
+    handleSelectedChange,
+    setPan,
+    setZoom,
+    setSize,
+    setTooltip,
+    registerControls,
+    controls,
+  };
+}
+
+export { INITIAL_TOOLTIP_STATE as initialTooltipState };


### PR DESCRIPTION
## Summary
- add `useConstellationSkillTree` hook to encapsulate layout, interaction state, and focus/auto-fit logic
- extract a reusable `ConstellationCanvas` component responsible for renderer/controller wiring
- update the skill tree wrapper to use the hook/canvas pair and add hook-level selection and auto-fit tests

## Testing
- `npm run lint` *(fails: npm command not available in execution environment)*
- `npm run test` *(fails: npm command not available in execution environment)*
- `npm run build` *(fails: npm command not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cac6eb5c5c8325b29be2528ad19d59