### PR TITLE
Fix build by correcting engine and UI type imports

### DIFF
--- a/packages/engine/src/simulation/__tests__/zoning.test.ts
+++ b/packages/engine/src/simulation/__tests__/zoning.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import type { SimulatedBuilding } from '../buildingSimulation';
+import type { SimulatedBuilding } from '../buildings/catalog';
 import { initializeDemand } from '../zoning/demand';
 import type { ZoneCell } from '../zoning/types';
 import { areZonesCompatible } from '../zoning/zoneRules';

--- a/packages/engine/src/simulation/events/systemState.ts
+++ b/packages/engine/src/simulation/events/systemState.ts
@@ -1,5 +1,5 @@
 import type { SimResources } from '../../index';
-import type { SimulatedBuilding } from '../buildingSimulation';
+import type { SimulatedBuilding } from '../buildings/catalog';
 import type { Citizen } from '../citizens/citizen';
 import type { WorkerProfile } from '../workers/types';
 import type { SystemState } from './types';

--- a/packages/engine/src/simulation/zoning/zoneUpdates.ts
+++ b/packages/engine/src/simulation/zoning/zoneUpdates.ts
@@ -1,4 +1,4 @@
-import type { SimulatedBuilding } from '../buildingSimulation';
+import type { SimulatedBuilding } from '../buildings/catalog';
 import type { ZoneCell, ZoneDemand } from './types';
 import { inferZoneTypeFromBuilding } from './zoneRules';
 

--- a/packages/ui/src/settings/config.ts
+++ b/packages/ui/src/settings/config.ts
@@ -9,6 +9,7 @@ export type {
   SelectChangeHandler,
   SelectOption,
   SelectSettingItem,
+  SettingCategory,
   SettingItem,
   SettingType,
   SettingValue,

--- a/packages/ui/src/settings/types.ts
+++ b/packages/ui/src/settings/types.ts
@@ -99,9 +99,9 @@ export const isNumberSetting = (
   setting: SettingItem,
 ): setting is NumberSettingItem => setting.type === 'number';
 
-export const isSelectSetting = <TValue extends SettingValue = SettingValue>(
+export const isSelectSetting = (
   setting: SettingItem,
-): setting is SelectSettingItem<TValue> => setting.type === 'select';
+): setting is SelectSettingItem => setting.type === 'select';
 
 export const isPresetSetting = (
   setting: SettingItem,

--- a/src/components/game/hud/presets/types.ts
+++ b/src/components/game/hud/presets/types.ts
@@ -3,8 +3,8 @@ import type { HUDPanelConfig } from '../panelRegistryStore';
 
 export interface HUDLayoutPresetIconPath {
   d: string;
-  strokeLinecap?: 'butt' | 'round' | 'square';
-  strokeLinejoin?: 'arcs' | 'bevel' | 'miter' | 'miter-clip' | 'round';
+  strokeLinecap?: 'butt' | 'round' | 'square' | 'inherit';
+  strokeLinejoin?: 'round' | 'bevel' | 'miter' | 'inherit';
   strokeWidth?: number;
 }
 

--- a/src/components/game/skills/hooks/useConstellationSkillTree.test.ts
+++ b/src/components/game/skills/hooks/useConstellationSkillTree.test.ts
@@ -88,7 +88,7 @@ describe('useConstellationSkillTree', () => {
 
   it('selects focused node and centers view when controls are registered', async () => {
     const focusedNode = createConstellationNode('focus', { x: 50, y: -30 });
-    let layout = createLayout([focusedNode], 120);
+    const layout = createLayout([focusedNode], 120);
     vi.mocked(createConstellationLayout).mockImplementation(() => layout);
 
     const onSelectNode = vi.fn();


### PR DESCRIPTION
## Summary
- update engine simulation modules and tests to import `SimulatedBuilding` from the new buildings catalog
- expose `SettingCategory` and simplify select-setting guards so Next.js type checking succeeds
- align HUD icon path typings with React SVG props and clean up a lint warning in the constellation skill tree test

## Testing
- npm run lint
- npm run test
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cae4bef684832589f0df614f5837ee