### PR TITLE
Optimize citizen frame timing and tint updates

### DIFF
--- a/src/components/game/citizens/CitizensRenderer.tsx
+++ b/src/components/game/citizens/CitizensRenderer.tsx
@@ -24,6 +24,7 @@ export default function CitizensRenderer({ citizens, toWorld }: CitizensRenderer
     containerRef.current = container;
 
     const tick = () => {
+      const frameTime = app.ticker?.lastTime ?? performance.now();
       citizens.forEach((c) => {
         if (!c.sprite) {
           const s = new PIXI.Graphics();
@@ -59,14 +60,18 @@ export default function CitizensRenderer({ citizens, toWorld }: CitizensRenderer
             tint = 0x94a3b8;
             break;
         }
-        if (c.carrying === "grain") g.tint = 0x22c55e;
-        else if (c.carrying === "wood") g.tint = 0xb45309;
-        else if (c.carrying === "planks") g.tint = 0xf59e0b;
-        else g.tint = tint;
+        let desiredTint = tint;
+        if (c.carrying === "grain") desiredTint = 0x22c55e;
+        else if (c.carrying === "wood") desiredTint = 0xb45309;
+        else if (c.carrying === "planks") desiredTint = 0xf59e0b;
+
+        if (g.tint !== desiredTint) {
+          g.tint = desiredTint;
+        }
 
         const { worldX } = toWorld(c.x, c.y);
         c.sprite.position.set(worldX, c.baseWorldY);
-        const off = Math.sin(performance.now() / 240 + c.x * 7 + c.y * 11) * 0.2;
+        const off = Math.sin(frameTime / 240 + c.x * 7 + c.y * 11) * 0.2;
         c.sprite.y = c.baseWorldY + off;
       });
     };

--- a/src/components/game/skills/hooks/useConstellationSkillTree.test.ts
+++ b/src/components/game/skills/hooks/useConstellationSkillTree.test.ts
@@ -88,7 +88,7 @@ describe('useConstellationSkillTree', () => {
 
   it('selects focused node and centers view when controls are registered', async () => {
     const focusedNode = createConstellationNode('focus', { x: 50, y: -30 });
-    let layout = createLayout([focusedNode], 120);
+    const layout = createLayout([focusedNode], 120);
     vi.mocked(createConstellationLayout).mockImplementation(() => layout);
 
     const onSelectNode = vi.fn();


### PR DESCRIPTION
## Summary
- reuse a cached frame timestamp for citizen bobbing instead of calling `performance.now()` per sprite
- skip redundant Pixi tint writes by only updating graphics when the desired tint changes
- adjust the constellation skill tree test to satisfy the lint rule triggered during the refactor

## Testing
- npm run lint
- npm run dev (manually verified /play citizen animation and tinting)


------
https://chatgpt.com/codex/tasks/task_e_68cb00d6fa8c8325a257e84b09c2ce2c