### PR TITLE
Guard tile renderer logging behind debug level

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,15 +1,48 @@
-import log from 'loglevel';
-import { config } from '@/infrastructure/config';
+import log from "loglevel";
+import { config } from "@/infrastructure/config";
 
-const logger = log.getLogger('arcane-dominion');
+const logger = log.getLogger("arcane-dominion");
 
 const level = config.logLevel as log.LogLevelDesc;
 
 logger.setLevel(level);
 
+const toLevelNumber = (levelDesc: log.LogLevelDesc): log.LogLevelNumbers => {
+  if (typeof levelDesc === "number") {
+    return levelDesc as log.LogLevelNumbers;
+  }
+
+  const levelName = levelDesc.toString().toUpperCase();
+  const levelKey = levelName as keyof log.LogLevel;
+
+  if (levelKey in logger.levels) {
+    const resolved = logger.levels[levelKey];
+    if (typeof resolved === "number") {
+      return resolved as log.LogLevelNumbers;
+    }
+  }
+
+  const numericValue = Number(levelDesc);
+  if (Number.isFinite(numericValue)) {
+    const clamped = Math.min(
+      Math.max(numericValue, logger.levels.TRACE),
+      logger.levels.SILENT,
+    );
+    return clamped as log.LogLevelNumbers;
+  }
+
+  return logger.levels.SILENT as log.LogLevelNumbers;
+};
+
+const isLevelEnabled = (levelDesc: log.LogLevelDesc): boolean => {
+  const currentLevel = logger.getLevel();
+  const targetLevel = toLevelNumber(levelDesc);
+  return currentLevel <= targetLevel;
+};
+
 // Enhanced logger that also outputs to server console in development
 const shouldMirrorToConsole = () =>
-  config.nodeEnv === 'development' && typeof window === 'undefined';
+  config.nodeEnv === "development" && typeof window === "undefined";
 
 const enhancedLogger = {
   debug: (message: string, ...args: unknown[]) => {
@@ -35,7 +68,8 @@ const enhancedLogger = {
     if (shouldMirrorToConsole()) {
       console.error(`[ERROR] ${message}`, ...args);
     }
-  }
+  },
+  isLevelEnabled,
 };
 
 export default enhancedLogger;


### PR DESCRIPTION
## Summary
- add a small helper in `TileRenderer` to short-circuit verbose logging when debug is disabled and wrap all debug/info calls behind it
- defer timing measurements in `TileRenderer` until verbose logging runs so performance captures only occur when needed
- expose an `isLevelEnabled` helper from the shared logger to support debug-level gating

## Testing
- npm run lint *(warnings pre-existing in unrelated files)*
- npm run test -- src/components/game/grid/__tests__/chunkRenderer.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cb034f142483258c57cb9c0014aec5