### PR TITLE
Manage tile texture cache with ref counts

### DIFF
--- a/src/components/game/grid/__tests__/chunkRenderer.test.ts
+++ b/src/components/game/grid/__tests__/chunkRenderer.test.ts
@@ -96,6 +96,7 @@ describe("chunkRenderer", () => {
       tileType: "grass",
       sprite: new PIXI.Sprite(),
       dispose: vi.fn(),
+      textureCacheKey: null,
     };
     const tileB: GridTile = {
       x: 1,
@@ -105,6 +106,7 @@ describe("chunkRenderer", () => {
       tileType: "water",
       sprite: new PIXI.Sprite(),
       dispose: vi.fn(),
+      textureCacheKey: null,
     };
 
     const loadedChunk: LoadedChunk = {

--- a/src/components/game/grid/__tests__/useIsometricGridSetup.test.ts
+++ b/src/components/game/grid/__tests__/useIsometricGridSetup.test.ts
@@ -4,12 +4,14 @@ import * as PIXI from "pixi.js";
 import { updateGridTileTexture } from "../useIsometricGridSetup";
 import type { GridTile } from "../TileRenderer";
 
-const { getTileTextureMock } = vi.hoisted(() => ({
+const { getTileTextureMock, releaseTileTextureMock } = vi.hoisted(() => ({
   getTileTextureMock: vi.fn(),
+  releaseTileTextureMock: vi.fn(),
 }));
 
 vi.mock("../TileRenderer", () => ({
   getTileTexture: getTileTextureMock,
+  releaseTileTexture: releaseTileTextureMock,
   createTileSprite: vi.fn(),
 }));
 
@@ -22,6 +24,7 @@ vi.mock("../TileOverlay", () => ({
 describe("useIsometricGridSetup", () => {
   beforeEach(() => {
     getTileTextureMock.mockReset();
+    releaseTileTextureMock.mockReset();
   });
 
   it("updates the sprite texture and tile type when the renderer is available", () => {
@@ -39,6 +42,7 @@ describe("useIsometricGridSetup", () => {
       tileType: "grass",
       sprite,
       dispose: vi.fn(),
+      textureCacheKey: "grass-64x32",
     };
 
     const nextTexture = { updateUvs: vi.fn() } as unknown as PIXI.RenderTexture;
@@ -64,6 +68,7 @@ describe("useIsometricGridSetup", () => {
     );
     expect(gridTile.sprite.texture).toBe(nextTexture);
     expect(gridTile.tileType).toBe("water");
+    expect(releaseTileTextureMock).toHaveBeenCalledWith("grass-64x32");
   });
 
   it("returns false when attempting to update a destroyed sprite", () => {
@@ -81,6 +86,7 @@ describe("useIsometricGridSetup", () => {
       tileType: "grass",
       sprite,
       dispose: vi.fn(),
+      textureCacheKey: "grass-64x32",
     };
 
     const updated = updateGridTileTexture({
@@ -93,5 +99,6 @@ describe("useIsometricGridSetup", () => {
 
     expect(updated).toBe(false);
     expect(gridTile.tileType).toBe("grass");
+    expect(releaseTileTextureMock).not.toHaveBeenCalled();
   });
 });

--- a/src/components/game/grid/useIsometricGridSetup.ts
+++ b/src/components/game/grid/useIsometricGridSetup.ts
@@ -8,7 +8,7 @@ import type { Viewport } from "pixi-viewport";
 import logger from "@/lib/logger";
 
 import { TileOverlay } from "./TileOverlay";
-import { createTileSprite, getTileTexture, type GridTile } from "./TileRenderer";
+import { createTileSprite, getTileTexture, releaseTileTexture, type GridTile } from "./TileRenderer";
 
 export type VisibilityUpdateOptions = {
   overlayUpdate?: boolean;
@@ -46,6 +46,8 @@ export function updateGridTileTexture({
 
   const tileKey = `${gridTile.x},${gridTile.y}`;
   const previousType = gridTile.tileType;
+  const previousTextureKey = gridTile.textureCacheKey;
+  const nextTextureKey = `${nextType}-${tileWidth}x${tileHeight}`;
 
   const nextTexture = getTileTexture(nextType, tileWidth, tileHeight, renderer, tileKey);
 
@@ -54,7 +56,12 @@ export function updateGridTileTexture({
     gridTile.sprite.texture.updateUvs();
   }
 
+  gridTile.textureCacheKey = nextTextureKey;
   gridTile.tileType = nextType;
+
+  if (previousTextureKey && previousTextureKey !== nextTextureKey) {
+    releaseTileTexture(previousTextureKey);
+  }
 
   if (gridTile.overlay && gridTile.overlay.destroyed) {
     logger.warn(


### PR DESCRIPTION
## Summary
- replace the tile texture cache with entries that track render textures alongside a reference count
- update tile lifecycle to increment the count when textures are acquired, release them on sprite disposal or retargeting, and only purge zero-ref textures
- adjust grid renderer tests to cover the new bookkeeping helpers

## Testing
- npm run lint
- npm run test
- npm run build *(fails: Type error: Cannot find module '../buildingSimulation' or its corresponding type declarations.)*

------
https://chatgpt.com/codex/tasks/task_e_68cb034fc2008325b005f951cf48372d