### PR TITLE
Make tile interactivity opt-in for grid sprites

### DIFF
--- a/src/components/game/IsometricGrid.tsx
+++ b/src/components/game/IsometricGrid.tsx
@@ -18,6 +18,7 @@ interface IsometricGridProps {
   tileTypes?: string[][];
   onTileHover?: (x: number, y: number, tileType?: string) => void;
   onTileClick?: (x: number, y: number, tileType?: string) => void;
+  enableTileInteraction?: boolean;
 }
 
 export default function IsometricGrid({
@@ -27,6 +28,7 @@ export default function IsometricGrid({
   tileTypes = [],
   onTileHover,
   onTileClick,
+  enableTileInteraction = false,
 }: IsometricGridProps) {
   const { viewport, app } = useGameContext();
   const updateVisibilityRef = useRef<((options?: VisibilityUpdateOptions) => void) | null>(null);
@@ -43,6 +45,7 @@ export default function IsometricGrid({
     requestOverlayUpdate: (options) => {
       updateVisibilityRef.current?.(options);
     },
+    enableTileInteraction,
   });
 
   useIsometricViewportBounds({ viewport, gridSize, tileWidth, tileHeight });

--- a/src/components/game/grid/TileRenderer.ts
+++ b/src/components/game/grid/TileRenderer.ts
@@ -25,6 +25,11 @@ const MAX_CACHED_TEXTURES = 100;
 
 const ANIMATED_TILE_TYPES = new Set(["water", "forest", "river"]);
 
+export interface CreateTileSpriteOptions {
+  tileTypeOverride?: string;
+  interactive?: boolean;
+}
+
 // Clean up texture cache when it gets too large
 function cleanupTextureCache() {
   if (textureCache.size > MAX_CACHED_TEXTURES) {
@@ -172,7 +177,7 @@ export function createTileSprite(
   tileHeight: number,
   tileTypes: string[][],
   renderer: Renderer,
-  options?: { tileTypeOverride?: string },
+  options?: CreateTileSpriteOptions,
 ): GridTile {
   const startTime = performance.now();
   const tileKey = `${gridX},${gridY}`;
@@ -192,11 +197,13 @@ export function createTileSprite(
   sprite.anchor.set(0.5, 0.5);
   sprite.position.set(worldX, worldY);
   sprite.zIndex = 2;
-  (sprite as unknown as { eventMode: string }).eventMode = "static";
-  const hx = (tileWidth / 2) * 0.95;
-  const hy = (tileHeight / 2) * 0.95;
-  sprite.hitArea = new PIXI.Polygon([0, -hy, hx, 0, 0, hy, -hx, 0]);
-  sprite.cursor = "pointer";
+  if (options?.interactive) {
+    (sprite as unknown as { eventMode: string }).eventMode = "static";
+    const hx = (tileWidth / 2) * 0.95;
+    const hy = (tileHeight / 2) * 0.95;
+    sprite.hitArea = new PIXI.Polygon([0, -hy, hx, 0, 0, hy, -hx, 0]);
+    sprite.cursor = "pointer";
+  }
 
   logger.debug(`[TILE_GRAPHICS] Created sprite for ${tileKey} using cached texture`);
 

--- a/src/components/game/grid/useIsometricGridSetup.ts
+++ b/src/components/game/grid/useIsometricGridSetup.ts
@@ -77,6 +77,7 @@ interface UseIsometricGridSetupParams {
   onTileHover?: (x: number, y: number, tileType?: string) => void;
   onTileClick?: (x: number, y: number, tileType?: string) => void;
   requestOverlayUpdate: (options?: VisibilityUpdateOptions) => void;
+  enableTileInteraction?: boolean;
 }
 
 interface UseIsometricGridSetupResult {
@@ -95,6 +96,7 @@ export function useIsometricGridSetup({
   onTileHover,
   onTileClick,
   requestOverlayUpdate,
+  enableTileInteraction = false,
 }: UseIsometricGridSetupParams): UseIsometricGridSetupResult {
   const gridContainerRef = useRef<PIXI.Container | null>(null);
   const tilesRef = useRef<Map<string, GridTile>>(new Map());
@@ -174,6 +176,7 @@ export function useIsometricGridSetup({
           tileHeight,
           initialTileTypes,
           app.renderer,
+          { interactive: enableTileInteraction },
         );
         const key = `${x},${y}`;
         tiles.set(key, tile);
@@ -208,7 +211,7 @@ export function useIsometricGridSetup({
       gridContainerRef.current = null;
       initializedRef.current = false;
     };
-  }, [viewport, app, gridSize, tileWidth, tileHeight]);
+  }, [viewport, app, gridSize, tileWidth, tileHeight, enableTileInteraction]);
 
   useEffect(() => {
     const gridContainer = gridContainerRef.current;
@@ -229,6 +232,7 @@ export function useIsometricGridSetup({
             tileHeight,
             tileTypes,
             app.renderer,
+            { interactive: enableTileInteraction },
           );
           tiles.set(key, tile);
           gridContainer.addChild(tile.sprite);
@@ -241,7 +245,7 @@ export function useIsometricGridSetup({
       logger.debug(`useIsometricGridSetup: added ${added} tiles after gridSize changed to ${gridSize}`);
       requestOverlayUpdateRef.current({ overlayUpdate: true });
     }
-  }, [app, gridSize, tileHeight, tileTypes, tileWidth]);
+  }, [app, gridSize, tileHeight, tileTypes, tileWidth, enableTileInteraction]);
 
   useEffect(() => {
     const gridContainer = gridContainerRef.current;


### PR DESCRIPTION
## Summary
- add a `CreateTileSpriteOptions` flag that only applies pointer settings when tiles need to be interactive
- propagate the opt-in through `useIsometricGridSetup` and `IsometricGrid`, leaving default grids non-interactive so the overlay container handles input

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb03511ba08325a377b5d0d9806823