### PR TITLE
Align chunked tile overlays with visibility updates

### DIFF
--- a/src/components/game/ChunkedIsometricGrid.tsx
+++ b/src/components/game/ChunkedIsometricGrid.tsx
@@ -100,15 +100,38 @@ export default function ChunkedIsometricGrid({
 
       loadedChunks.forEach((chunk) => {
         chunk.tiles.forEach((tile) => {
-          const isInViewport = tile.worldX >= visibleLeft &&
-                             tile.worldX <= visibleRight &&
-                             tile.worldY >= visibleTop &&
-                             tile.worldY <= visibleBottom;
+          const isInViewport =
+            tile.worldX >= visibleLeft &&
+            tile.worldX <= visibleRight &&
+            tile.worldY >= visibleTop &&
+            tile.worldY <= visibleBottom;
 
           const shouldShowTile = scale > 0.1 && isInViewport;
 
           if (tile.sprite.visible !== shouldShowTile) {
             tile.sprite.visible = shouldShowTile;
+          }
+
+          const overlay = tile.overlay;
+          if (overlay?.destroyed) {
+            tile.overlay = undefined;
+            return;
+          }
+
+          if (overlay) {
+            if (overlay.visible !== shouldShowTile) {
+              overlay.visible = shouldShowTile;
+              if (!shouldShowTile) {
+                overlay.clear();
+              }
+            }
+
+            if (shouldShowTile) {
+              const { x: overlayX, y: overlayY } = overlay.position;
+              if (overlayX !== tile.worldX || overlayY !== tile.worldY) {
+                overlay.position.set(tile.worldX, tile.worldY);
+              }
+            }
           }
         });
       });


### PR DESCRIPTION
## Summary
- ensure chunked tile overlays mirror sprite visibility and drop destroyed references during updates
- reposition active overlays and clear them when hidden to prevent artifact leaks while streaming chunks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb036c972c8325b8ea6be3031e0e9a