### PR TITLE
Refine chunk tile layering

### DIFF
--- a/src/components/game/grid/__tests__/chunkRenderer.test.ts
+++ b/src/components/game/grid/__tests__/chunkRenderer.test.ts
@@ -78,8 +78,14 @@ describe("chunkRenderer", () => {
     });
 
     expect(container.name).toBe("chunk-0-1");
+    expect(container.sortableChildren).toBe(false);
     expect(tiles.size).toBe(4);
     expect(createTileSpriteMock).toHaveBeenCalledTimes(4);
+
+    expect(container.children).toHaveLength(2);
+    const [tileLayer, overlayLayer] = container.children as PIXI.Container[];
+    expect(tileLayer.children).toHaveLength(4);
+    expect(overlayLayer.sortableChildren).toBe(true);
 
     expect(tiles.get("0,2")?.tileType).toBe("grass");
     expect(tiles.get("1,2")?.tileType).toBe("water");

--- a/src/components/game/grid/chunkRenderer.ts
+++ b/src/components/game/grid/chunkRenderer.ts
@@ -62,7 +62,19 @@ export function createChunkContainer(
 ): { container: PIXI.Container; tiles: Map<string, GridTile> } {
   const container = new PIXI.Container();
   container.name = `chunk-${chunkData.chunkX}-${chunkData.chunkY}`;
-  container.sortableChildren = true;
+  container.sortableChildren = false;
+
+  const tileLayer = new PIXI.Container();
+  tileLayer.name = `${container.name}-tiles`;
+
+  const overlayLayer = new PIXI.Container();
+  overlayLayer.name = `${container.name}-overlays`;
+  overlayLayer.sortableChildren = true;
+  overlayLayer.zIndex = 1;
+
+  container.addChild(tileLayer);
+  container.addChild(overlayLayer);
+  container.sortableChildren = false;
 
   const tiles = new Map<string, GridTile>();
 
@@ -85,7 +97,7 @@ export function createChunkContainer(
       const tile = createTileSprite(
         globalX,
         globalY,
-        container,
+        overlayLayer,
         tileWidth,
         tileHeight,
         chunkData.tiles,
@@ -113,7 +125,7 @@ export function createChunkContainer(
 
       const key = `${globalX},${globalY}`;
       tiles.set(key, tile);
-      container.addChild(tile.sprite);
+      tileLayer.addChild(tile.sprite);
     }
   }
 


### PR DESCRIPTION
## Summary
- stop sorting chunk containers and introduce dedicated tile and overlay layers so static tiles render without z-order churn
- update the chunk renderer test to cover the new layering expectations

## Testing
- npm run lint (warnings only)
- npm run test
- npm run build *(fails: packages/engine/src/simulation/events/systemState.ts:2: Cannot find module '../buildingSimulation')*

------
https://chatgpt.com/codex/tasks/task_e_68cb08c340d48325a92a3264563e4672