### PR TITLE
Enhance quest onboarding flow and persistence

### DIFF
--- a/src/components/game/OnboardingGuide.tsx
+++ b/src/components/game/OnboardingGuide.tsx
@@ -5,53 +5,119 @@ interface OnboardingGuideProps {
   onClose: () => void;
 }
 
-const steps: Record<number, { title: string; details: string[] }> = {
+const steps: Record<
+  number,
+  {
+    chapter: string;
+    title: string;
+    details: string[];
+    context?: string;
+  }
+> = {
   1: {
-    title: 'Gather Food: Build a Farm',
+    chapter: 'Stabilize Food',
+    title: 'Survey the River Flats',
     details: [
-      'Select a grass tile and press Build → Farm.',
-      'The first Farm is free. Farms produce grain each cycle.',
+      'Drag the camera across the lowlands and pick a fertile tile near water.',
+      'Open Build → Farm to claim it; adjacency to rivers boosts output.',
     ],
+    context: 'Reliable grain prevents unrest spikes when the cycle advances.',
   },
   2: {
-    title: 'Raise Helpers: Build a House',
+    chapter: 'Stabilize Food',
+    title: 'Raise a Farmstead',
     details: [
-      'Place a House on grass to attract 5 workers.',
-      'The first House is free. Workers run your buildings.',
+      'Your first Farm is free—confirm placement to start sowing grain.',
+      'Farms feed every other plan you attempt, so protect them early.',
     ],
+    context: 'Remember: farms cannot sit on forest, rock, or water tiles.',
   },
   3: {
-    title: 'Get Production Going: Assign a Worker',
+    chapter: 'Stabilize Food',
+    title: 'House the Workers',
     details: [
-      'Open the Workers box (bottom-left) and assign 1 worker to the Farm.',
-      'You can adjust workers at any time.',
+      'Place a House on grass to welcome five new citizens into the district.',
+      'Keep Houses within a short walk of your fields to shorten commute time.',
     ],
+    context: 'Idle citizens offer no yield—balance housing with job sites.',
   },
   4: {
-    title: 'Form Your Council',
+    chapter: 'Stabilize Food',
+    title: 'Staff the Fields',
     details: [
-      'Place a Council Hall (free) to unlock proposals & decrees.',
-      'Open Council from the Actions panel to review ideas.',
+      'Open the Workers HUD and assign at least one worker to the Farm.',
+      'As capacity grows, add more workers to push grain production upward.',
     ],
+    context: 'Assignments stick through the next cycle; adjust as demand shifts.',
   },
   5: {
-    title: 'Take an Action',
+    chapter: 'Stabilize Food',
+    title: 'Prove the Harvest',
     details: [
-      'Click “Summon Proposals” and accept one modest, affordable plan.',
-      'Conservative choices keep Unrest & Threat low.',
+      'Advance the cycle once the farm is staffed to confirm net grain gain.',
+      'Aim to end the turn with ≥ 20 grain so shortages do not trigger unrest.',
     ],
+    context: 'Cycle changes also refresh trade quotas and council timers.',
   },
   6: {
-    title: 'Advance the Cycle',
+    chapter: 'Secure Trade',
+    title: 'Raise a Trade Post',
     details: [
-      'Hit Advance in the Time panel to see your gains.',
-      'Tip: keep grain stable, coin positive, and mana steady.',
+      'Unlock the Trade Post (requires Council Hall) and place it near roads.',
+      'Trade Posts convert surplus grain into coin for upkeep and expansion.',
     ],
+    context: 'Clusters of logistics buildings thrive when linked by roads.',
+  },
+  7: {
+    chapter: 'Secure Trade',
+    title: 'Link Trade Routes',
+    details: [
+      'Select a Trade Post, draft a route, and connect to another post.',
+      'Shorter routes cost less coin; consider patrols if threat rises.',
+    ],
+    context: 'Each active route nudges favor and coin—watch upkeep as they scale.',
+  },
+  8: {
+    chapter: 'Secure Trade',
+    title: 'Anchor Logistics',
+    details: [
+      'Build a Storehouse and ensure at least one route touches it.',
+      'Storehouses boost any producer connected by road or trade network.',
+    ],
+    context: 'Efficient logistics let you weather later council experiments.',
+  },
+  9: {
+    chapter: 'Unlock Council Power',
+    title: 'Seat the Council',
+    details: [
+      'Construct a Council Hall to open decrees, edicts, and skill unlocks.',
+      'Position it centrally so messengers reach every guild quickly.',
+    ],
+    context: 'The council grants proposals and unlocks advanced buildings.',
+  },
+  10: {
+    chapter: 'Unlock Council Power',
+    title: 'Summon Proposals',
+    details: [
+      'Open the Council panel and call for proposals from a guild of choice.',
+      'Accept a conservative plan to keep unrest and threat under control.',
+    ],
+    context: 'Scribing proposals spends time; pair with a stable economy.',
+  },
+  11: {
+    chapter: 'Unlock Council Power',
+    title: 'Invest in Skills',
+    details: [
+      'Spend coin, mana, or favor on a skill unlock that supports your focus.',
+      'Skills ripple across the city—confirm the tooltip before committing.',
+    ],
+    context: 'Legendary skills can redefine production; ensure inputs can cope.',
   },
 };
 
 export default function OnboardingGuide({ step, onClose }: OnboardingGuideProps) {
-  const content = steps[step] || steps[6];
+  const totalSteps = Object.keys(steps).length;
+  const content = steps[step] || steps[totalSteps];
   return (
     <div className="absolute top-24 left-4 z-50 pointer-events-auto">
       <div className="bg-gray-800/90 border border-gray-700 rounded-lg shadow-xl w-[320px]">
@@ -60,14 +126,18 @@ export default function OnboardingGuide({ step, onClose }: OnboardingGuideProps)
           <button onClick={onClose} className="text-gray-300 hover:text-white">✕</button>
         </div>
         <div className="px-4 py-3">
+          <div className="text-xs uppercase tracking-wide text-indigo-300 mb-1">{content.chapter}</div>
           <div className="text-gray-100 font-medium mb-2">{content.title}</div>
           <ul className="list-disc pl-5 space-y-1 text-sm text-gray-300">
             {content.details.map((d, i) => (
               <li key={i}>{d}</li>
             ))}
           </ul>
+          {content.context && (
+            <div className="mt-2 text-xs text-indigo-200/80">{content.context}</div>
+          )}
           <div className="mt-3 text-xs text-gray-400">
-            Step {Math.min(step, 6)} of 6
+            Step {Math.min(step, totalSteps)} of {totalSteps}
           </div>
         </div>
       </div>

--- a/src/components/game/hud/panels/ModularQuestPanel.tsx
+++ b/src/components/game/hud/panels/ModularQuestPanel.tsx
@@ -1,27 +1,149 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { ResponsivePanel } from '@arcane/ui/responsive';
 import { useHUDPanel } from '../HUDPanelRegistry';
 import { useHUDLayout } from '../HUDLayoutSystem';
 
-interface ModularQuestPanelProps {
-  completed: Record<string, boolean>;
-  variant?: 'default' | 'compact' | 'minimal';
-  collapsible?: boolean;
+type QuestObjectiveStatus = 'locked' | 'in-progress' | 'complete';
+type QuestChapterStatus = 'locked' | 'active' | 'complete';
+
+interface QuestObjectiveProgress {
+  status: QuestObjectiveStatus;
+  progress?: { current: number; target: number };
+  context?: string;
 }
 
-const QUESTS: Array<{ id: string; text: string }> = [
-  { id: 'farm', text: 'Build a Farm' },
-  { id: 'house', text: 'Build a House' },
-  { id: 'assign', text: 'Assign 1 Worker' },
-  { id: 'council', text: 'Build Council Hall' },
-  { id: 'proposals', text: 'Summon Proposals' },
-  { id: 'advance', text: 'Advance the Cycle' },
+interface QuestChapterProgress {
+  status: QuestChapterStatus;
+  objectives: Record<string, QuestObjectiveProgress>;
+}
+
+interface QuestStateSnapshot {
+  activeChapterId: string;
+  chapterOrder: string[];
+  chapters: Record<string, QuestChapterProgress>;
+}
+
+interface QuestObjectiveBlueprint {
+  id: string;
+  label: string;
+  hint?: string;
+  target?: number;
+  focus?: string;
+}
+
+interface QuestChapterBlueprint {
+  id: string;
+  title: string;
+  summary: string;
+  theme: string;
+  lore?: string;
+  objectives: QuestObjectiveBlueprint[];
+}
+
+const QUEST_BLUEPRINTS: QuestChapterBlueprint[] = [
+  {
+    id: 'stabilize-food',
+    title: 'Stabilize Food',
+    summary: 'Secure grain production and prove the harvest before unrest takes root.',
+    theme: 'Stabilize Food',
+    lore: 'Farmhands, stewards, and scribes align to keep every belly fed.',
+    objectives: [
+      { id: 'build-farm', label: 'Raise a starter Farm', hint: 'Free during onboarding—pick fertile ground near water.', target: 1 },
+      { id: 'assign-farm-worker', label: 'Assign workers to the Farm', hint: 'Open the Worker panel and slot at least one farmer.', target: 1 },
+      { id: 'secure-grain-cycle', label: 'Finish a cycle with ≥20 grain', hint: 'Advance time once staffed to confirm your surplus.', target: 20 },
+    ],
+  },
+  {
+    id: 'secure-trade',
+    title: 'Secure Trade',
+    summary: 'Turn grain into coin by linking trade posts and a storehouse.',
+    theme: 'Secure Trade',
+    lore: 'Trade caravans and quartermasters weave the logistics web.',
+    objectives: [
+      { id: 'raise-trade-post', label: 'Build a Trade Post', hint: 'Requires a Council Hall—roads improve throughput.', target: 1 },
+      { id: 'open-trade-route', label: 'Establish a trade route', hint: 'Connect two trade posts to start coin flow.', target: 1 },
+      { id: 'storehouse-network', label: 'Link a Storehouse into the network', hint: 'Ensure at least one route touches a storehouse.', target: 1 },
+    ],
+  },
+  {
+    id: 'unlock-council-power',
+    title: 'Unlock Council Power',
+    summary: 'Seat the council, call proposals, and invest in long-term skills.',
+    theme: 'Unlock Council Power',
+    lore: 'Decrees, edicts, and talents broaden the council’s influence.',
+    objectives: [
+      { id: 'build-council-hall', label: 'Seat the Council Hall', hint: 'Place centrally so messengers reach every guild.', target: 1 },
+      { id: 'summon-proposals', label: 'Summon council proposals', hint: 'Request guidance once your economy is steady.' },
+      { id: 'unlock-first-skill', label: 'Unlock your first skill', hint: 'Spend coin, mana, or favor on a lasting boon.', target: 1 },
+    ],
+  },
 ];
 
-export default function ModularQuestPanel({ completed, variant = 'default', collapsible = true }: ModularQuestPanelProps) {
-  // Default to collapsed; users can peek as needed
+const QUEST_BLUEPRINT_MAP = QUEST_BLUEPRINTS.reduce<Record<string, QuestChapterBlueprint>>((acc, chapter) => {
+  acc[chapter.id] = chapter;
+  return acc;
+}, {});
+
+const QUEST_CHAPTER_ORDER = QUEST_BLUEPRINTS.map(chapter => chapter.id);
+
+const createInitialQuestSnapshot = (): QuestStateSnapshot => {
+  const chapters: Record<string, QuestChapterProgress> = {};
+  QUEST_BLUEPRINTS.forEach((chapter, index) => {
+    const objectives: Record<string, QuestObjectiveProgress> = {};
+    chapter.objectives.forEach(obj => {
+      objectives[obj.id] = {
+        status: index === 0 ? 'in-progress' : 'locked',
+        progress: obj.target ? { current: 0, target: obj.target } : undefined,
+      };
+    });
+    chapters[chapter.id] = {
+      status: index === 0 ? 'active' : 'locked',
+      objectives,
+    };
+  });
+
+  return {
+    activeChapterId: QUEST_CHAPTER_ORDER[0],
+    chapterOrder: [...QUEST_CHAPTER_ORDER],
+    chapters,
+  };
+};
+
+interface ModularQuestPanelProps {
+  questState: QuestStateSnapshot;
+  variant?: 'default' | 'compact' | 'minimal';
+  collapsible?: boolean;
+  onSelectChapter?: (chapterId: string) => void;
+}
+
+const chapterStatusLabel: Record<QuestChapterStatus, string> = {
+  locked: 'Locked',
+  active: 'Active',
+  complete: 'Complete',
+};
+
+const chapterStatusStyles: Record<QuestChapterStatus, string> = {
+  locked: 'border-gray-700/80 bg-gray-900/50 text-gray-400',
+  active: 'border-indigo-500/80 bg-indigo-500/10 text-indigo-200',
+  complete: 'border-emerald-500/70 bg-emerald-500/10 text-emerald-200',
+};
+
+const objectiveIndicatorClasses: Record<QuestObjectiveStatus, string> = {
+  complete: 'bg-emerald-600 text-white',
+  'in-progress': 'bg-indigo-600/80 text-white',
+  locked: 'bg-gray-700 text-gray-300',
+};
+
+export default function ModularQuestPanel({
+  questState,
+  variant = 'default',
+  collapsible = true,
+  onSelectChapter,
+}: ModularQuestPanelProps) {
   const [isCollapsed, setIsCollapsed] = useState(true);
+  const [visibleChapterId, setVisibleChapterId] = useState(() => questState.activeChapterId);
   const { screenSize } = useHUDLayout();
+  const baseSnapshot = useMemo(() => createInitialQuestSnapshot(), []);
 
   useHUDPanel({
     config: {
@@ -29,18 +151,54 @@ export default function ModularQuestPanel({ completed, variant = 'default', coll
       zone: 'sidebar-right',
       priority: 6,
       responsive: { hideOnMobile: true, collapseOnMobile: true },
-      accessibility: { ariaLabel: 'Quest tracker', role: 'complementary' }
+      accessibility: { ariaLabel: 'Quest tracker', role: 'complementary' },
     },
     component: ModularQuestPanel,
-    props: { variant, collapsible }
+    props: { variant, collapsible, questState },
   });
 
-  // Count remaining to surface a smart title and auto-hide when done
-  const remaining = QUESTS.reduce((n, q) => n + (completed[q.id] ? 0 : 1), 0);
-  if (remaining === 0) {
-    return null; // hide panel entirely when all early quests are done
-  }
-  const next = QUESTS.find(q => !completed[q.id]);
+  useEffect(() => {
+    setVisibleChapterId(prev => {
+      if (!prev || !questState.chapterOrder.includes(prev)) {
+        return questState.activeChapterId;
+      }
+      const status = questState.chapters[prev]?.status;
+      if (status === 'locked' || (status === 'complete' && questState.activeChapterId !== prev)) {
+        return questState.activeChapterId;
+      }
+      return prev;
+    });
+  }, [questState.activeChapterId, questState.chapterOrder, questState.chapters]);
+
+  const activeChapterIndex = Math.max(0, questState.chapterOrder.indexOf(questState.activeChapterId));
+  const activeBlueprint = QUEST_BLUEPRINT_MAP[questState.activeChapterId] ?? QUEST_BLUEPRINTS[0];
+  const activeProgress = questState.chapters[questState.activeChapterId] ?? baseSnapshot.chapters[questState.activeChapterId];
+
+  const nextObjective = activeBlueprint.objectives.find(obj => {
+    const status = activeProgress?.objectives?.[obj.id]?.status;
+    return status !== 'complete';
+  });
+
+  const visibleBlueprint = QUEST_BLUEPRINT_MAP[visibleChapterId] ?? activeBlueprint;
+  const visibleProgress = questState.chapters[visibleBlueprint.id] ?? baseSnapshot.chapters[visibleBlueprint.id];
+
+  const handleSelectChapter = (chapterId: string) => {
+    setVisibleChapterId(chapterId);
+    if (onSelectChapter) {
+      onSelectChapter(chapterId);
+    }
+  };
+
+  const totalObjectives = questState.chapterOrder.reduce((sum, chapterId) => {
+    const blueprint = QUEST_BLUEPRINT_MAP[chapterId];
+    return sum + (blueprint ? blueprint.objectives.length : 0);
+  }, 0);
+
+  const completedObjectives = questState.chapterOrder.reduce((sum, chapterId) => {
+    const chapter = questState.chapters[chapterId];
+    if (!chapter) return sum;
+    return sum + Object.values(chapter.objectives).filter(obj => obj.status === 'complete').length;
+  }, 0);
 
   const titleIcon = (
     <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -56,30 +214,116 @@ export default function ModularQuestPanel({ completed, variant = 'default', coll
       variant={variant}
       collapsible={collapsible}
       isCollapsed={isCollapsed}
-      onToggleCollapse={() => setIsCollapsed(!isCollapsed)}
+      onToggleCollapse={() => setIsCollapsed(prev => !prev)}
       priority="low"
       actions={(
-        <div className="flex items-center gap-1">
-          <span className="px-1.5 py-0.5 rounded-full text-[10px] leading-none bg-indigo-600 text-white tabular-nums">{remaining}</span>
-          {next && (
-            <span className="max-w-[10rem] truncate px-1 py-0.5 rounded bg-gray-900/30 border border-gray-700 text-[10px] text-gray-300 hidden md:inline" title={next.text}>{next.text}</span>
+        <div className="flex items-center gap-2">
+          <span className="px-1.5 py-0.5 rounded-full text-[10px] leading-none bg-indigo-600 text-white tabular-nums">
+            {completedObjectives}/{totalObjectives}
+          </span>
+          {nextObjective && (
+            <span
+              className="max-w-[11rem] truncate px-1 py-0.5 rounded bg-gray-900/30 border border-gray-700 text-[10px] text-gray-300 hidden md:inline"
+              title={nextObjective.label}
+            >
+              Next: {nextObjective.label}
+            </span>
           )}
+          <span className="text-[10px] uppercase tracking-wide text-gray-400">
+            Chapter {activeChapterIndex + 1}/{questState.chapterOrder.length}
+          </span>
         </div>
       )}
       className="min-w-0"
     >
-      <ul className="px-1 py-1 space-y-1 text-xs text-gray-200">
-        {QUESTS.map(q => (
-          <li key={q.id} className="flex items-center gap-2">
-            <span className={`inline-flex items-center justify-center w-4 h-4 rounded-full text-[10px] ${completed[q.id] ? 'bg-emerald-600 text-white' : 'bg-gray-700 text-gray-300'}`}>
-              {completed[q.id] ? '✓' : '•'}
-            </span>
-            <span className="truncate">{q.text}</span>
-          </li>
-        ))}
+      <div className={`px-2 pt-2 ${variant === 'minimal' ? 'pb-1' : 'pb-2'}`}>
+        <div className={`flex gap-1 ${variant === 'minimal' ? 'flex-wrap' : 'flex-wrap'}`}>
+          {questState.chapterOrder.map((chapterId, idx) => {
+            const blueprint = QUEST_BLUEPRINT_MAP[chapterId];
+            const progress = questState.chapters[chapterId] ?? baseSnapshot.chapters[chapterId];
+            if (!blueprint || !progress) return null;
+            const isSelected = visibleChapterId === chapterId;
+            const baseClasses = `${chapterStatusStyles[progress.status]} border rounded-md transition focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500`;
+            const activeClasses = isSelected ? 'ring-1 ring-indigo-400/70 shadow-sm' : 'hover:border-indigo-400/60';
+            return (
+              <button
+                key={chapterId}
+                type="button"
+                onClick={() => handleSelectChapter(chapterId)}
+                className={`${baseClasses} ${activeClasses} px-2 py-1 flex-1 min-w-[6.5rem] text-left`}
+              >
+                <div className="flex items-center justify-between text-[10px] uppercase tracking-wide">
+                  <span className="tabular-nums text-gray-300/80">Ch {idx + 1}</span>
+                  <span>{chapterStatusLabel[progress.status]}</span>
+                </div>
+                <div className="text-xs font-medium text-gray-100 truncate">{blueprint.theme}</div>
+              </button>
+            );
+          })}
+        </div>
+        <div className="mt-2 text-[11px] leading-snug text-gray-300">
+          {visibleBlueprint.summary}
+        </div>
+        {visibleBlueprint.lore && variant !== 'minimal' && (
+          <div className="mt-1 text-[10px] text-indigo-200/80 leading-snug">{visibleBlueprint.lore}</div>
+        )}
+      </div>
+
+      <ul className="px-2 pb-2 space-y-2 text-xs text-gray-200">
+        {visibleBlueprint.objectives.map(objective => {
+          const progress = visibleProgress?.objectives?.[objective.id];
+          const status = progress?.status ?? 'locked';
+          const indicator = status === 'complete' ? '✓' : status === 'locked' ? '•' : '↻';
+          const pct = progress?.progress && progress.progress.target > 0
+            ? Math.min(100, Math.round((Math.max(progress.progress.current, 0) / progress.progress.target) * 100))
+            : 0;
+
+          return (
+            <li key={objective.id} className="rounded-md border border-gray-800/60 bg-gray-900/40 px-2 py-1.5">
+              <div className="flex items-start justify-between gap-2">
+                <div className="flex items-start gap-2">
+                  <span className={`inline-flex items-center justify-center w-5 h-5 rounded-full text-[11px] ${objectiveIndicatorClasses[status]}`}>
+                    {indicator}
+                  </span>
+                  <div>
+                    <div className="text-sm font-medium text-gray-100 leading-snug">{objective.label}</div>
+                    {objective.hint && (
+                      <div className="text-[11px] text-gray-400 leading-snug">{objective.hint}</div>
+                    )}
+                    {progress?.context && (
+                      <div className="text-[11px] text-indigo-200/80 leading-snug">{progress.context}</div>
+                    )}
+                  </div>
+                </div>
+                <span className="text-[10px] uppercase tracking-wide text-gray-400">{chapterStatusLabel[status === 'complete' ? 'complete' : status === 'locked' ? 'locked' : 'active']}</span>
+              </div>
+              {progress?.progress && (
+                <div className="mt-2">
+                  <div className="h-1.5 rounded bg-gray-800 overflow-hidden">
+                    <div
+                      className={`h-full ${status === 'complete' ? 'bg-emerald-500' : 'bg-indigo-500/80'}`}
+                      style={{ width: `${pct}%` }}
+                    />
+                  </div>
+                  <div className="mt-0.5 text-[10px] text-gray-400 tabular-nums">
+                    {Math.min(progress.progress.current, progress.progress.target)} / {progress.progress.target}
+                  </div>
+                </div>
+              )}
+            </li>
+          );
+        })}
       </ul>
     </ResponsivePanel>
   );
 }
 
-export type { ModularQuestPanelProps };
+export type {
+  ModularQuestPanelProps,
+  QuestStateSnapshot,
+  QuestChapterProgress,
+  QuestObjectiveProgress,
+  QuestChapterBlueprint,
+  QuestObjectiveBlueprint,
+};
+export { QUEST_BLUEPRINTS, createInitialQuestSnapshot };


### PR DESCRIPTION
## Summary
- extend the onboarding guide with chaptered steps that cover food, trade, and council goals with contextual hints
- refactor the quest HUD panel into a chapter-aware state machine that surfaces objective progress and navigation across questlines
- persist quest progression in PlayPage, deriving completion from milestones, buildings, routes, and skills so the HUD can highlight next actions

## Testing
- npm run lint
- npm run test
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb0917be5c83259a7f3ca60d2cc156