### PR TITLE
feat: pre-render tile atlas for grid textures

### DIFF
--- a/packages/engine/src/simulation/__tests__/zoning.test.ts
+++ b/packages/engine/src/simulation/__tests__/zoning.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import type { SimulatedBuilding } from '../buildingSimulation';
+import type { SimulatedBuilding } from '../buildings';
 import { initializeDemand } from '../zoning/demand';
 import type { ZoneCell } from '../zoning/types';
 import { areZonesCompatible } from '../zoning/zoneRules';

--- a/packages/engine/src/simulation/events/systemState.ts
+++ b/packages/engine/src/simulation/events/systemState.ts
@@ -1,5 +1,5 @@
 import type { SimResources } from '../../index';
-import type { SimulatedBuilding } from '../buildingSimulation';
+import type { SimulatedBuilding } from '../buildings';
 import type { Citizen } from '../citizens/citizen';
 import type { WorkerProfile } from '../workers/types';
 import type { SystemState } from './types';

--- a/packages/engine/src/simulation/zoning/zoneUpdates.ts
+++ b/packages/engine/src/simulation/zoning/zoneUpdates.ts
@@ -1,4 +1,4 @@
-import type { SimulatedBuilding } from '../buildingSimulation';
+import type { SimulatedBuilding } from '../buildings';
 import type { ZoneCell, ZoneDemand } from './types';
 import { inferZoneTypeFromBuilding } from './zoneRules';
 

--- a/packages/ui/src/settings/SettingCategory.tsx
+++ b/packages/ui/src/settings/SettingCategory.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronDown, faChevronRight } from '@fortawesome/free-solid-svg-icons';
-import type { SettingCategory as SettingCategoryType } from './config';
+import type { SettingCategory as SettingCategoryType } from './types';
 import SettingItem from './SettingItem';
 
 interface SettingCategoryProps {

--- a/src/components/game/grid/__tests__/useIsometricGridSetup.test.ts
+++ b/src/components/game/grid/__tests__/useIsometricGridSetup.test.ts
@@ -45,8 +45,12 @@ describe("useIsometricGridSetup", () => {
       textureCacheKey: "grass-64x32",
     };
 
-    const nextTexture = { updateUvs: vi.fn() } as unknown as PIXI.RenderTexture;
-    getTileTextureMock.mockReturnValue(nextTexture);
+    const nextTexture = { updateUvs: vi.fn() } as unknown as PIXI.Texture;
+    getTileTextureMock.mockReturnValue({
+      texture: nextTexture,
+      cacheKey: "water-64x32",
+      source: "atlas",
+    });
 
     const renderer = {} as PIXI.Renderer;
 

--- a/src/components/game/grid/tileArt.ts
+++ b/src/components/game/grid/tileArt.ts
@@ -1,0 +1,109 @@
+import * as PIXI from "pixi.js";
+
+import { TILE_COLORS } from "@/lib/isometric";
+
+const TILE_TYPE_LIST = Object.freeze(Object.keys(TILE_COLORS));
+
+function shade(hex: number, factor: number): number {
+  const r = Math.max(0, Math.min(255, Math.round(((hex >> 16) & 0xff) * factor)));
+  const g = Math.max(0, Math.min(255, Math.round(((hex >> 8) & 0xff) * factor)));
+  const b = Math.max(0, Math.min(255, Math.round((hex & 0xff) * factor)));
+  return (r << 16) | (g << 8) | b;
+}
+
+export function getAvailableTileTypes(): string[] {
+  return TILE_TYPE_LIST;
+}
+
+export function createTileGraphics(tileType: string, tileWidth: number, tileHeight: number): PIXI.Container {
+  const container = new PIXI.Container();
+
+  const baseGraphic = new PIXI.Graphics();
+  baseGraphic.position.set(tileWidth / 2, tileHeight / 2);
+
+  const baseColor = TILE_COLORS[tileType] ?? TILE_COLORS.unknown;
+  const lighter = shade(baseColor, 1.08);
+  const darker = shade(baseColor, 0.85);
+
+  baseGraphic.fill({ color: baseColor, alpha: 0.96 });
+  baseGraphic.moveTo(0, -tileHeight / 2);
+  baseGraphic.lineTo(tileWidth / 2, 0);
+  baseGraphic.lineTo(0, tileHeight / 2);
+  baseGraphic.lineTo(-tileWidth / 2, 0);
+  baseGraphic.closePath();
+  baseGraphic.fill();
+
+  baseGraphic.fill({ color: lighter, alpha: 0.12 });
+  baseGraphic.moveTo(0, -tileHeight * 0.36);
+  baseGraphic.lineTo(tileWidth * 0.36, 0);
+  baseGraphic.lineTo(0, tileHeight * 0.36);
+  baseGraphic.lineTo(-tileWidth * 0.36, 0);
+  baseGraphic.closePath();
+  baseGraphic.fill();
+
+  baseGraphic.setStrokeStyle({ width: 1.5, color: darker, alpha: 0.55 });
+  baseGraphic.moveTo(0, tileHeight / 2);
+  baseGraphic.lineTo(tileWidth / 2, 0);
+  baseGraphic.lineTo(0, -tileHeight / 2);
+  baseGraphic.stroke();
+
+  baseGraphic.setStrokeStyle({ width: 1, color: 0x334155, alpha: 0.35 });
+  baseGraphic.moveTo(0, -tileHeight / 2);
+  baseGraphic.lineTo(tileWidth / 2, 0);
+  baseGraphic.lineTo(0, tileHeight / 2);
+  baseGraphic.lineTo(-tileWidth / 2, 0);
+  baseGraphic.lineTo(0, -tileHeight / 2);
+  baseGraphic.stroke();
+
+  container.addChild(baseGraphic);
+
+  const detailGraphic = new PIXI.Graphics();
+  detailGraphic.position.set(tileWidth / 2, tileHeight / 2);
+  (detailGraphic as unknown as { eventMode: string }).eventMode = "none";
+
+  let hasDetail = false;
+
+  if (tileType === "water" || tileType === "river") {
+    detailGraphic.setStrokeStyle({ width: 1, color: 0x93c5fd, alpha: 0.35 });
+    const y0 = -tileHeight * 0.12;
+    const y1 = 0;
+    const y2 = tileHeight * 0.12;
+    detailGraphic.moveTo(-tileWidth * 0.25, y0);
+    detailGraphic.quadraticCurveTo(0, y0 + 2, tileWidth * 0.25, y0);
+    detailGraphic.moveTo(-tileWidth * 0.3, y1);
+    detailGraphic.quadraticCurveTo(0, y1 + 2, tileWidth * 0.3, y1);
+    detailGraphic.moveTo(-tileWidth * 0.2, y2);
+    detailGraphic.quadraticCurveTo(0, y2 + 2, tileWidth * 0.2, y2);
+    detailGraphic.stroke();
+    hasDetail = true;
+  } else if (tileType === "forest") {
+    detailGraphic.fill({ color: 0x166534, alpha: 0.12 });
+    const s = Math.max(2, Math.floor(tileHeight * 0.08));
+    detailGraphic.drawPolygon([-s, 0, 0, -s, s, 0, -s, 0]);
+    detailGraphic.endFill();
+    hasDetail = true;
+  } else if (tileType === "mountain") {
+    detailGraphic.setStrokeStyle({ width: 1, color: 0x64748b, alpha: 0.35 });
+    detailGraphic.moveTo(-tileWidth * 0.2, tileHeight * 0.05);
+    detailGraphic.lineTo(0, -tileHeight * 0.15);
+    detailGraphic.lineTo(tileWidth * 0.2, tileHeight * 0.05);
+    detailGraphic.stroke();
+    hasDetail = true;
+  } else if (tileType === "grass") {
+    detailGraphic.setStrokeStyle({ width: 1, color: 0x16a34a, alpha: 0.15 });
+    detailGraphic.moveTo(-tileWidth * 0.1, tileHeight * 0.04);
+    detailGraphic.lineTo(-tileWidth * 0.02, tileHeight * 0.01);
+    detailGraphic.moveTo(tileWidth * 0.1, -tileHeight * 0.04);
+    detailGraphic.lineTo(tileWidth * 0.02, -tileHeight * 0.01);
+    detailGraphic.stroke();
+    hasDetail = true;
+  }
+
+  if (hasDetail) {
+    container.addChild(detailGraphic);
+  } else {
+    detailGraphic.destroy();
+  }
+
+  return container;
+}

--- a/src/components/game/grid/tileAtlas.ts
+++ b/src/components/game/grid/tileAtlas.ts
@@ -1,0 +1,198 @@
+import * as PIXI from "pixi.js";
+import { Assets, ExtensionType, extensions, LoaderParserPriority, Matrix } from "pixi.js";
+import type { Renderer } from "pixi.js";
+
+import logger from "@/lib/logger";
+
+import { createTileGraphics, getAvailableTileTypes } from "./tileArt";
+
+const TILE_ATLAS_SCHEME = "tile-atlas";
+
+export interface TileAtlasResource {
+  atlasTexture: PIXI.RenderTexture;
+  textures: Record<string, PIXI.Texture>;
+  frames: Record<string, PIXI.Rectangle>;
+  tileWidth: number;
+  tileHeight: number;
+  tileTypes: string[];
+  destroy: () => void;
+}
+
+interface LoadTileAtlasOptions {
+  renderer: Renderer;
+  tileWidth: number;
+  tileHeight: number;
+  tileTypes?: string[];
+}
+
+const atlasResources = new Map<string, TileAtlasResource>();
+const atlasPromises = new Map<string, Promise<TileAtlasResource>>();
+let parserRegistered = false;
+
+function getTileAtlasKey(tileWidth: number, tileHeight: number): string {
+  return `${tileWidth}x${tileHeight}`;
+}
+
+function registerTileAtlasParser() {
+  if (parserRegistered) {
+    return;
+  }
+
+  extensions.add(tileAtlasParser);
+  parserRegistered = true;
+}
+
+function normalizeTileTypes(tileTypes?: string[]): string[] {
+  const baseList = tileTypes && tileTypes.length > 0 ? tileTypes : getAvailableTileTypes();
+  const unique = new Set(baseList);
+  unique.add("unknown");
+  return Array.from(unique);
+}
+
+function createAtlasResource({
+  renderer,
+  tileWidth,
+  tileHeight,
+  tileTypes,
+}: LoadTileAtlasOptions & { tileTypes: string[] }): TileAtlasResource {
+  const tileCount = tileTypes.length;
+  const columns = Math.max(1, Math.ceil(Math.sqrt(tileCount)));
+  const rows = Math.max(1, Math.ceil(tileCount / columns));
+  const atlasWidth = columns * tileWidth;
+  const atlasHeight = rows * tileHeight;
+
+  const atlasTexture = PIXI.RenderTexture.create({ width: atlasWidth, height: atlasHeight });
+  const textures: Record<string, PIXI.Texture> = {};
+  const frames: Record<string, PIXI.Rectangle> = {};
+
+  const start = performance.now();
+
+  for (let index = 0; index < tileCount; index += 1) {
+    const tileType = tileTypes[index];
+    const column = index % columns;
+    const row = Math.floor(index / columns);
+    const offsetX = column * tileWidth;
+    const offsetY = row * tileHeight;
+
+    const tileContainer = createTileGraphics(tileType, tileWidth, tileHeight);
+    const transform = new Matrix(1, 0, 0, 1, offsetX, offsetY);
+
+    renderer.render({
+      container: tileContainer,
+      target: atlasTexture,
+      clear: index === 0,
+      transform,
+    });
+
+    tileContainer.destroy({ children: true });
+
+    const frame = new PIXI.Rectangle(offsetX, offsetY, tileWidth, tileHeight);
+    frames[tileType] = frame;
+
+    const texture = new PIXI.Texture({ baseTexture: atlasTexture.baseTexture, frame });
+    texture.defaultAnchor.set(0.5, 0.5);
+    textures[tileType] = texture;
+  }
+
+  const duration = performance.now() - start;
+  logger.debug(
+    `[TILE_ATLAS] Generated ${tileCount} tile variants (${tileWidth}x${tileHeight}) in ${duration.toFixed(2)}ms`,
+  );
+
+  return {
+    atlasTexture,
+    textures,
+    frames,
+    tileWidth,
+    tileHeight,
+    tileTypes,
+    destroy: () => {
+      Object.values(textures).forEach((texture) => texture.destroy());
+      atlasTexture.destroy(true);
+    },
+  };
+}
+
+const tileAtlasParser = {
+  extension: {
+    type: ExtensionType.LoadParser,
+    priority: LoaderParserPriority.Normal,
+    name: TILE_ATLAS_SCHEME,
+  },
+  name: TILE_ATLAS_SCHEME,
+  id: TILE_ATLAS_SCHEME,
+  test(url: string): boolean {
+    return typeof url === "string" && url.startsWith(`${TILE_ATLAS_SCHEME}:`);
+  },
+  load(url: string, asset: { data?: Partial<LoadTileAtlasOptions> }) {
+    const data = asset.data ?? {};
+    const renderer = data.renderer;
+    if (!renderer) {
+      throw new Error(`[TILE_ATLAS] Renderer missing when loading atlas for ${url}`);
+    }
+
+    const tileWidth = typeof data.tileWidth === "number" ? data.tileWidth : 64;
+    const tileHeight = typeof data.tileHeight === "number" ? data.tileHeight : 32;
+    const tileTypes = normalizeTileTypes(data.tileTypes);
+
+    logger.debug(
+      `[TILE_ATLAS] Loading atlas via parser for ${tileWidth}x${tileHeight} with ${tileTypes.length} variants`,
+    );
+
+    return createAtlasResource({ renderer, tileWidth, tileHeight, tileTypes });
+  },
+  unload(resource: TileAtlasResource) {
+    resource.destroy();
+  },
+};
+
+export async function loadTileAtlasResource(options: LoadTileAtlasOptions): Promise<TileAtlasResource> {
+  const key = getTileAtlasKey(options.tileWidth, options.tileHeight);
+  const cached = atlasResources.get(key);
+  if (cached) {
+    return cached;
+  }
+
+  registerTileAtlasParser();
+
+  let promise = atlasPromises.get(key);
+  if (!promise) {
+    const alias = `${TILE_ATLAS_SCHEME}:${key}`;
+    promise = (Assets.load({
+      alias,
+      src: alias,
+      parser: TILE_ATLAS_SCHEME,
+      data: {
+        renderer: options.renderer,
+        tileWidth: options.tileWidth,
+        tileHeight: options.tileHeight,
+        tileTypes: normalizeTileTypes(options.tileTypes),
+      },
+    }) as Promise<TileAtlasResource>)
+      .then((resource) => {
+        atlasResources.set(key, resource);
+        return resource;
+      })
+      .catch((error) => {
+        atlasPromises.delete(key);
+        throw error;
+      });
+    atlasPromises.set(key, promise);
+  }
+
+  return promise;
+}
+
+export function getLoadedTileAtlasResource(tileWidth: number, tileHeight: number): TileAtlasResource | undefined {
+  const key = getTileAtlasKey(tileWidth, tileHeight);
+  return atlasResources.get(key);
+}
+
+export function clearTileAtlasCache() {
+  atlasPromises.clear();
+  atlasResources.forEach((resource) => {
+    resource.destroy();
+  });
+  atlasResources.clear();
+  parserRegistered = false;
+}


### PR DESCRIPTION
## Summary
- add tileArt helpers to reuse the isometric tile drawing logic and expose the available tile types
- generate tile atlases through a Pixi Assets parser so tiles share cached textures with a dev fallback path
- update the grid renderer and setup flow to load the atlas before creating sprites, adjust tests, and fix import paths revealed by strict type checks

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb08f6fc248325ab316eed908fb564