### PR TITLE
Align HUD time with server cycle and season

### DIFF
--- a/packages/engine/src/simulation/buildingSimulation.ts
+++ b/packages/engine/src/simulation/buildingSimulation.ts
@@ -1,0 +1,1 @@
+export type { SimulatedBuilding } from './buildings/catalog';

--- a/packages/ui/src/settings/config.ts
+++ b/packages/ui/src/settings/config.ts
@@ -1,4 +1,5 @@
 import type { SettingCategory } from './types';
+export type { SettingCategory } from './types';
 export type {
   CategoryBuilderContext,
   LayoutPreset,

--- a/packages/ui/src/settings/types.ts
+++ b/packages/ui/src/settings/types.ts
@@ -99,9 +99,9 @@ export const isNumberSetting = (
   setting: SettingItem,
 ): setting is NumberSettingItem => setting.type === 'number';
 
-export const isSelectSetting = <TValue extends SettingValue = SettingValue>(
+export const isSelectSetting = (
   setting: SettingItem,
-): setting is SelectSettingItem<TValue> => setting.type === 'select';
+): setting is SelectSettingItem => setting.type === 'select';
 
 export const isPresetSetting = (
   setting: SettingItem,

--- a/src/app/play/PlayPageInternal.tsx
+++ b/src/app/play/PlayPageInternal.tsx
@@ -1582,9 +1582,17 @@ export default function PlayPage({ initialState = null, initialProposals = [] }:
   const skillTreeSeed = typeof state?.skill_tree_seed === 'number' ? state.skill_tree_seed : 12345;
 
   const currentTime = timeSystem.getCurrentTime();
+  const hudCycleFromState = typeof state?.cycle === 'number' && Number.isFinite(state.cycle)
+    ? state.cycle
+    : undefined;
+  const fallbackCycle = Number.isFinite(currentTime.totalMinutes)
+    ? Math.floor(currentTime.totalMinutes / 60)
+    : 0;
   const gameTime: GameTime = {
-    cycle: Math.floor(currentTime.totalMinutes / 60), // Convert to legacy cycle for HUD compatibility
-    season: 'spring', // TODO: Implement seasons based on currentTime.month
+    cycle: hudCycleFromState ?? fallbackCycle,
+    season: typeof currentTime.season === 'string' && currentTime.season.length > 0
+      ? currentTime.season
+      : 'spring',
     timeRemaining,
   };
   const totalAssigned = placedBuildings.reduce((sum, b) => sum + b.workers, 0);

--- a/src/components/game/hud/HUDSettingsPanel.tsx
+++ b/src/components/game/hud/HUDSettingsPanel.tsx
@@ -10,15 +10,22 @@ function HUDPresetIcon({ icon }: { icon: HUDLayoutPresetIconData }) {
   const { viewBox = '0 0 24 24', paths } = icon;
   return (
     <svg fill="none" stroke="currentColor" viewBox={viewBox} aria-hidden="true">
-      {paths.map(({ d, strokeLinecap = 'round', strokeLinejoin = 'round', strokeWidth = 2 }) => (
-        <path
-          key={d}
-          d={d}
-          strokeLinecap={strokeLinecap}
-          strokeLinejoin={strokeLinejoin}
-          strokeWidth={strokeWidth}
-        />
-      ))}
+      {paths.map(({ d, strokeLinecap = 'round', strokeLinejoin = 'round', strokeWidth = 2 }) => {
+        const safeStrokeLinejoin: React.SVGProps<SVGPathElement>['strokeLinejoin'] =
+          strokeLinejoin === 'arcs' || strokeLinejoin === 'miter-clip'
+            ? 'miter'
+            : strokeLinejoin;
+
+        return (
+          <path
+            key={d}
+            d={d}
+            strokeLinecap={strokeLinecap}
+            strokeLinejoin={safeStrokeLinejoin}
+            strokeWidth={strokeWidth}
+          />
+        );
+      })}
     </svg>
   );
 }

--- a/src/components/game/hud/__tests__/TimePanels.test.tsx
+++ b/src/components/game/hud/__tests__/TimePanels.test.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { GameTime } from '../types';
+
+vi.mock('../HUDPanelRegistry', () => ({
+  useHUDPanel: () => undefined,
+}));
+
+vi.mock('../HUDLayoutSystem', () => ({
+  useHUDLayout: () => ({ screenSize: 'desktop' }),
+}));
+
+import { TimePanel } from '../TimePanel';
+import { ModularTimePanel } from '../panels/ModularTimePanel';
+
+afterEach(() => {
+  cleanup();
+});
+
+const baseTime: GameTime = {
+  cycle: 3,
+  season: 'spring',
+  timeRemaining: 90,
+};
+
+describe('TimePanel', () => {
+  it('updates the displayed cycle when the game state changes', () => {
+    const { rerender } = render(<TimePanel time={baseTime} />);
+
+    const readCycle = () => {
+      const label = screen.getByText('Cycle');
+      const container = label.parentElement as HTMLElement;
+      const value = container.lastElementChild as HTMLElement | null;
+      if (!value) {
+        throw new Error('Cycle value not found');
+      }
+      return value.textContent;
+    };
+
+    expect(readCycle()).toBe(String(baseTime.cycle));
+
+    rerender(
+      <TimePanel
+        time={{
+          ...baseTime,
+          cycle: 8,
+        }}
+      />
+    );
+
+    expect(readCycle()).toBe('8');
+  });
+
+  it('reflects seasonal changes from the time system', () => {
+    const { rerender } = render(<TimePanel time={baseTime} />);
+
+    const readSeason = () => {
+      const label = screen.getByText('Season');
+      const container = label.parentElement as HTMLElement;
+      const value = container.lastElementChild as HTMLElement | null;
+      if (!value) {
+        throw new Error('Season value not found');
+      }
+      return value.textContent;
+    };
+
+    expect(readSeason()).toBe(baseTime.season);
+
+    rerender(
+      <TimePanel
+        time={{
+          ...baseTime,
+          season: 'autumn',
+        }}
+      />
+    );
+
+    expect(readSeason()).toBe('autumn');
+  });
+});
+
+describe('ModularTimePanel', () => {
+  const renderPanel = (time: GameTime) =>
+    render(
+      <ModularTimePanel
+        time={time}
+        isPaused={false}
+        onPause={() => {}}
+        onResume={() => {}}
+        onAdvanceCycle={() => {}}
+      />
+    );
+
+  const readDisplayValue = (label: string) => {
+    const labelNodes = screen.getAllByText(label);
+    const labelNode = labelNodes[labelNodes.length - 1];
+    if (!labelNode) {
+      throw new Error(`Label "${label}" not found`);
+    }
+    const container = labelNode.closest('div') as HTMLElement;
+    const valueNode = container.querySelector('.tabular-nums') as HTMLElement;
+    return valueNode.textContent;
+  };
+
+  it('renders the latest server-reported cycle', () => {
+    const { rerender } = renderPanel(baseTime);
+
+    expect(readDisplayValue('Cycle')).toBe(String(baseTime.cycle));
+
+    rerender(
+      <ModularTimePanel
+        time={{
+          ...baseTime,
+          cycle: 12,
+        }}
+        isPaused={false}
+        onPause={() => {}}
+        onResume={() => {}}
+        onAdvanceCycle={() => {}}
+      />
+    );
+
+    expect(readDisplayValue('Cycle')).toBe('12');
+  });
+
+  it('shows the season provided by the time system as it advances', () => {
+    const { rerender } = renderPanel(baseTime);
+
+    expect(readDisplayValue('Season')).toBe(baseTime.season);
+
+    rerender(
+      <ModularTimePanel
+        time={{
+          ...baseTime,
+          season: 'winter',
+        }}
+        isPaused={false}
+        onPause={() => {}}
+        onResume={() => {}}
+        onAdvanceCycle={() => {}}
+      />
+    );
+
+    expect(readDisplayValue('Season')).toBe('winter');
+  });
+});
+


### PR DESCRIPTION
## Summary
- derive the HUD game time cycle from the hydrated game state when available and surface the engine-provided season for display
- add focused HUD time panel tests to confirm cycle and season updates propagate through classic and modular panels
- expose missing engine and UI type exports and normalize preset icon rendering to satisfy type-checking during the build

## Testing
- npm run lint
- npm run test
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb0b431618832582147e4de5fb17a8