### PR TITLE
Fix tile atlas typing for Next.js build

### DIFF
--- a/src/components/game/grid/tileArt.ts
+++ b/src/components/game/grid/tileArt.ts
@@ -11,7 +11,7 @@ function shade(hex: number, factor: number): number {
   return (r << 16) | (g << 8) | b;
 }
 
-export function getAvailableTileTypes(): string[] {
+export function getAvailableTileTypes(): readonly string[] {
   return TILE_TYPE_LIST;
 }
 

--- a/src/components/game/grid/tileAtlas.ts
+++ b/src/components/game/grid/tileAtlas.ts
@@ -22,7 +22,7 @@ interface LoadTileAtlasOptions {
   renderer: Renderer;
   tileWidth: number;
   tileHeight: number;
-  tileTypes?: string[];
+  tileTypes?: readonly string[];
 }
 
 const atlasResources = new Map<string, TileAtlasResource>();
@@ -42,7 +42,7 @@ function registerTileAtlasParser() {
   parserRegistered = true;
 }
 
-function normalizeTileTypes(tileTypes?: string[]): string[] {
+function normalizeTileTypes(tileTypes?: readonly string[]): string[] {
   const baseList = tileTypes && tileTypes.length > 0 ? tileTypes : getAvailableTileTypes();
   const unique = new Set(baseList);
   unique.add("unknown");
@@ -89,8 +89,11 @@ function createAtlasResource({
     const frame = new PIXI.Rectangle(offsetX, offsetY, tileWidth, tileHeight);
     frames[tileType] = frame;
 
-    const texture = new PIXI.Texture({ baseTexture: atlasTexture.baseTexture, frame });
-    texture.defaultAnchor.set(0.5, 0.5);
+    const texture = new PIXI.Texture({
+      source: atlasTexture.source,
+      frame,
+      defaultAnchor: { x: 0.5, y: 0.5 },
+    });
     textures[tileType] = texture;
   }
 


### PR DESCRIPTION
## Summary
- return the frozen tile type list as a readonly array so the build no longer mutates immutable data
- accept readonly tile type inputs and construct Pixi textures with the v8 API so Next.js type checking succeeds

## Testing
- npm run lint
- npm run test
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb132efa48832599e59653576795e3