### PR TITLE
Extend questline for trade and ascension

### DIFF
--- a/src/components/game/hud/panels/ModularQuestPanel.tsx
+++ b/src/components/game/hud/panels/ModularQuestPanel.tsx
@@ -77,6 +77,93 @@ const QUEST_BLUEPRINTS: QuestChapterBlueprint[] = [
       { id: 'unlock-first-skill', label: 'Unlock your first skill', hint: 'Spend coin, mana, or favor on a lasting boon.', target: 1 },
     ],
   },
+  {
+    id: 'command-trade-empire',
+    title: 'Command the Trade Empire',
+    summary: 'Scale caravans, fortify patrols, and amass the coin reserves needed for dominion-wide commerce.',
+    theme: 'Trade Empire',
+    lore: 'Quartermasters weave a lattice of caravans while brokers negotiate tariffs with iron resolve.',
+    objectives: [
+      {
+        id: 'trade-network-dominance',
+        label: 'Operate four concurrent trade routes',
+        hint: 'Grow beyond a local loop—link distant trade posts to expand your reach.',
+        target: 4,
+      },
+      {
+        id: 'trade-hub-anchor',
+        label: 'Anchor a hub with three connections',
+        hint: 'Designate one trade post as the beating heart of your network—patrols keep caravans safe.',
+        target: 3,
+      },
+      {
+        id: 'coin-stockpile',
+        label: 'Stockpile 600 coin reserves',
+        hint: 'Tune tariffs and exports until the treasury is ready for expansion.',
+        target: 600,
+      },
+    ],
+  },
+  {
+    id: 'master-the-leylines',
+    title: 'Master the Leylines',
+    summary: 'Bind distant mana wells, stabilize the flows, and keep channels thrumming in unison.',
+    theme: 'Leyline Mastery',
+    lore: 'Arcanists trace sigils through the air, coaxing luminous rivers beneath the streets.',
+    objectives: [
+      {
+        id: 'chart-leylines',
+        label: 'Weave two leylines across the city',
+        hint: 'Use the leyline tools to bridge sources and districts.',
+        target: 2,
+      },
+      {
+        id: 'attune-leylines',
+        label: 'Maintain two active leyline channels',
+        hint: 'Stabilize their anchors and toggle flows online.',
+        target: 2,
+      },
+      {
+        id: 'leyline-flow-surge',
+        label: 'Reach 150 total leyline flow',
+        hint: 'Upgrade conduits and balance capacity to push more mana.',
+        target: 150,
+      },
+    ],
+  },
+  {
+    id: 'ascension-prelude',
+    title: 'Prepare the Ascension',
+    summary: 'Lock in arcane mastery, weather looming crises, and chart omens before the final rite.',
+    theme: 'Ascension Prep',
+    lore: 'The council gathers relics, transcripts, and stellar charts to ensure the ritual does not fail.',
+    objectives: [
+      {
+        id: 'unlock-advanced-skills',
+        label: 'Unlock six council skills',
+        hint: 'Invest in talents that bind infrastructure, mysticism, and trade.',
+        target: 6,
+      },
+      {
+        id: 'weather-crises',
+        label: 'Endure two crises',
+        hint: 'Hold firm through unrest or threat spikes without toppling the city.',
+        target: 2,
+      },
+      {
+        id: 'catalog-omens',
+        label: 'Document three seasonal events',
+        hint: 'Record omens from the Omenarium or seasonal reports.',
+        target: 3,
+      },
+      {
+        id: 'mana-stockpile',
+        label: 'Bank 400 mana for the rite',
+        hint: 'Channel leylines and shrines until the ritual stores brim.',
+        target: 400,
+      },
+    ],
+  },
 ];
 
 const QUEST_BLUEPRINT_MAP = QUEST_BLUEPRINTS.reduce<Record<string, QuestChapterBlueprint>>((acc, chapter) => {

--- a/src/components/game/hud/panels/__tests__/questProgress.test.ts
+++ b/src/components/game/hud/panels/__tests__/questProgress.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { createInitialQuestSnapshot } from '../ModularQuestPanel';
+import {
+  evaluateQuestProgress,
+  type QuestComputationContext,
+  type QuestEventLogEntry,
+  type StoredBuilding,
+  type TradeRoute,
+} from '@/app/play/PlayPageInternal';
+
+const makeBuildings = (): StoredBuilding[] => [
+  { id: 'farm-1', typeId: 'farm', x: 4, y: 2, level: 1, workers: 1 },
+  { id: 'house-1', typeId: 'house', x: 5, y: 2, level: 1, workers: 0 },
+  { id: 'trade-1', typeId: 'trade_post', x: 6, y: 2, level: 1, workers: 2 },
+  { id: 'trade-2', typeId: 'trade_post', x: 8, y: 2, level: 1, workers: 2 },
+  { id: 'trade-3', typeId: 'trade_post', x: 10, y: 2, level: 1, workers: 2 },
+  { id: 'trade-4', typeId: 'trade_post', x: 12, y: 2, level: 1, workers: 2 },
+  { id: 'store-1', typeId: 'storehouse', x: 7, y: 3, level: 1, workers: 1 },
+  { id: 'council-1', typeId: 'council_hall', x: 9, y: 3, level: 1, workers: 0 },
+];
+
+const baseRoutes: TradeRoute[] = [
+  { id: 'r1', fromId: 'trade-1', toId: 'store-1', length: 3 },
+  { id: 'r2', fromId: 'trade-1', toId: 'trade-2', length: 4 },
+  { id: 'r3', fromId: 'trade-2', toId: 'trade-3', length: 5 },
+  { id: 'r4', fromId: 'trade-2', toId: 'trade-4', length: 6 },
+];
+
+describe('evaluateQuestProgress', () => {
+  it('advances through trade, leyline, and ascension chapters', () => {
+    const initial = createInitialQuestSnapshot();
+    const buildings = makeBuildings();
+
+    const earlyContext: QuestComputationContext = {
+      milestoneSnapshot: { m_farm: true, m_route: true, m_storehouse: true },
+      routes: [baseRoutes[0]],
+      buildings,
+      proposalsSummoned: true,
+      proposalsCount: 1,
+      unlockedSkillIds: ['skill-a'],
+      resources: { grain: 45, coin: 200, mana: 120 },
+      cycle: 3,
+      leylines: [],
+      edicts: { tariffs: 50, patrols: 0 },
+      crisisStats: { encountered: 0, resolved: 0 },
+      currentCrisis: null,
+      eventHistory: [],
+    };
+
+    const afterEarly = evaluateQuestProgress(initial, earlyContext);
+    expect(afterEarly.chapters['unlock-council-power'].status).toBe('complete');
+    expect(afterEarly.activeChapterId).toBe('command-trade-empire');
+
+    const tradeContext: QuestComputationContext = {
+      ...earlyContext,
+      routes: baseRoutes,
+      proposalsCount: 3,
+      unlockedSkillIds: ['skill-a', 'skill-b'],
+      resources: { grain: 60, coin: 650, mana: 180 },
+      edicts: { tariffs: 55, patrols: 1 },
+    };
+
+    const afterTrade = evaluateQuestProgress(afterEarly, tradeContext);
+    expect(afterTrade.chapters['command-trade-empire'].status).toBe('complete');
+    expect(afterTrade.activeChapterId).toBe('master-the-leylines');
+    expect(
+      afterTrade.chapters['command-trade-empire'].objectives['trade-network-dominance'].progress?.current,
+    ).toBe(4);
+
+    const leylineContext: QuestComputationContext = {
+      ...tradeContext,
+      leylines: [
+        { id: 'l1', fromX: 3, fromY: 3, toX: 9, toY: 4, capacity: 80, currentFlow: 80, isActive: true },
+        { id: 'l2', fromX: 5, fromY: 1, toX: 11, toY: 2, capacity: 90, currentFlow: 90, isActive: true },
+      ],
+    };
+
+    const afterLeylines = evaluateQuestProgress(afterTrade, leylineContext);
+    expect(afterLeylines.chapters['master-the-leylines'].status).toBe('complete');
+    expect(afterLeylines.activeChapterId).toBe('ascension-prelude');
+
+    const ascensionEvents: QuestEventLogEntry[] = [
+      { id: 'omen-1', name: 'Eclipse of Glass', occurredAt: 8, summary: 'Sky darkens' },
+      { id: 'omen-2', name: 'Harvest Bloom', occurredAt: 9, summary: 'Fields glow' },
+      { id: 'omen-3', name: 'Stellar Choir', occurredAt: 10, summary: 'Spheres resonate' },
+    ];
+
+    const ascensionContext: QuestComputationContext = {
+      ...leylineContext,
+      unlockedSkillIds: ['skill-a', 'skill-b', 'skill-c', 'skill-d', 'skill-e', 'skill-f'],
+      crisisStats: { encountered: 3, resolved: 2 },
+      resources: { grain: 120, coin: 820, mana: 450, favor: 40 },
+      eventHistory: ascensionEvents,
+      proposalsCount: 5,
+    };
+
+    const afterAscension = evaluateQuestProgress(afterLeylines, ascensionContext);
+    expect(afterAscension.chapters['ascension-prelude'].status).toBe('complete');
+    const ascensionObjectives = afterAscension.chapters['ascension-prelude'].objectives;
+    expect(ascensionObjectives['unlock-advanced-skills'].progress?.current).toBe(6);
+    expect(ascensionObjectives['weather-crises'].progress?.current).toBe(2);
+    expect(ascensionObjectives['catalog-omens'].progress?.current).toBe(3);
+    expect(ascensionObjectives['mana-stockpile'].progress?.current).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- add mid- and late-game quest chapters covering trade empires, leyline mastery, and ascension preparation
- expand quest evaluation to persist crisis/event telemetry and drive new objectives from live state
- add quest progression test coverage to ensure late chapters unlock and complete as expected

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb21bb7360832588238396cebcf094