### PR TITLE
Finalize wonder prerequisites and defense integration

### DIFF
--- a/packages/engine/__tests__/wonders.test.ts
+++ b/packages/engine/__tests__/wonders.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import {
+  produceBuildings,
+  processTick,
+  SIM_BUILDINGS,
+  type GameState,
+} from '../src';
+
+describe('wonder passive effects', () => {
+  it('applies Astral Bastion production and passives', () => {
+    const state: GameState = {
+      id: 'wonder-test',
+      cycle: 0,
+      resources: {
+        grain: 50,
+        coin: 40,
+        mana: 60,
+        favor: 10,
+        unrest: 10,
+        threat: 10,
+        wood: 0,
+        planks: 0,
+        defense: 0,
+      },
+      workers: 0,
+      buildings: [{ id: 'astral', typeId: 'astral_bastion', level: 1, workers: 0 }],
+      routes: [],
+    };
+
+    const { resources, passiveEffects } = produceBuildings(state, SIM_BUILDINGS);
+
+    expect(resources.mana).toBe(63);
+    expect(resources.defense).toBe(15);
+    expect(resources.unrest).toBe(9);
+    expect(resources.threat).toBe(8);
+    expect(passiveEffects.tickAdjustments).toMatchObject({ threat: -2, unrest: -1 });
+    expect(passiveEffects.resMul.defense).toBeCloseTo(1.2, 5);
+    expect(passiveEffects.globalResourceMultiplier).toBeCloseTo(1.05, 5);
+  });
+
+  it('boosts mana, favor, and defense across a full tick when wonders stand', () => {
+    const baseState: GameState = {
+      id: 'base-city',
+      cycle: 10,
+      resources: {
+        grain: 120,
+        coin: 150,
+        mana: 80,
+        favor: 25,
+        unrest: 18,
+        threat: 20,
+        wood: 40,
+        planks: 20,
+        defense: 0,
+      },
+      workers: 6,
+      buildings: [
+        { id: 'council', typeId: 'council_hall', level: 1, workers: 0 },
+        { id: 'shrine', typeId: 'shrine', level: 1, workers: 0 },
+      ],
+      routes: [],
+      quests_completed: 3,
+    };
+
+    const wonderState: GameState = {
+      ...baseState,
+      id: 'wonder-city',
+      buildings: [
+        ...baseState.buildings!,
+        { id: 'astral', typeId: 'astral_bastion', level: 1, workers: 0 },
+        { id: 'archive', typeId: 'eternal_archive', level: 1, workers: 0 },
+      ],
+    };
+
+    const baseResult = processTick(baseState, [], SIM_BUILDINGS);
+    const wonderResult = processTick(wonderState, [], SIM_BUILDINGS);
+
+    const baseResources = baseResult.state.resources;
+    const wonderResources = wonderResult.state.resources;
+
+    expect(wonderResources.mana).toBeGreaterThan(baseResources.mana);
+    expect(wonderResources.favor).toBeGreaterThanOrEqual(baseResources.favor);
+    expect(wonderResources.defense).toBeGreaterThan(baseResources.defense);
+    expect(wonderResources.threat).toBeLessThanOrEqual(baseResources.threat);
+    expect(wonderResources.unrest).toBeLessThanOrEqual(baseResources.unrest);
+  });
+});
+

--- a/packages/engine/src/simulation/__tests__/buildingPipeline.test.ts
+++ b/packages/engine/src/simulation/__tests__/buildingPipeline.test.ts
@@ -11,7 +11,8 @@ const baseResources: SimResources = {
   favor: 5,
   workers: 30,
   wood: 60,
-  planks: 25
+  planks: 25,
+  defense: 0,
 };
 
 describe('runBuildingPipeline', () => {

--- a/packages/engine/src/simulation/__tests__/buildings.maintenance.test.ts
+++ b/packages/engine/src/simulation/__tests__/buildings.maintenance.test.ts
@@ -16,7 +16,8 @@ const ampleResources: SimResources = {
   favor: 50,
   workers: 50,
   wood: 200,
-  planks: 200
+  planks: 200,
+  defense: 0,
 };
 
 describe('building maintenance calculations', () => {

--- a/packages/engine/src/simulation/__tests__/buildings.production.test.ts
+++ b/packages/engine/src/simulation/__tests__/buildings.production.test.ts
@@ -14,7 +14,8 @@ const baseResources = (): SimResources => ({
   favor: 20,
   workers: 40,
   wood: 80,
-  planks: 40
+  planks: 40,
+  defense: 0,
 });
 
 describe('building production adjustments', () => {

--- a/packages/engine/src/simulation/__tests__/citizenPipeline.test.ts
+++ b/packages/engine/src/simulation/__tests__/citizenPipeline.test.ts
@@ -12,7 +12,8 @@ const baselineResources: SimResources = {
   favor: 10,
   workers: 25,
   wood: 35,
-  planks: 15
+  planks: 15,
+  defense: 0,
 };
 
 describe('runCitizenPipeline', () => {

--- a/packages/engine/src/simulation/__tests__/eventPipeline.test.ts
+++ b/packages/engine/src/simulation/__tests__/eventPipeline.test.ts
@@ -15,7 +15,8 @@ const eventResources: SimResources = {
   favor: 12,
   workers: 45,
   wood: 55,
-  planks: 22
+  planks: 22,
+  defense: 0,
 };
 
 afterEach(() => {

--- a/packages/engine/src/simulation/__tests__/skillsTickEffects.test.ts
+++ b/packages/engine/src/simulation/__tests__/skillsTickEffects.test.ts
@@ -56,6 +56,7 @@ describe('skill modifiers integration', () => {
         workers: 50,
         wood: 30,
         planks: 0,
+        defense: 0,
         unrest: 0,
         threat: 0,
       },

--- a/packages/engine/src/simulation/__tests__/workerPipeline.test.ts
+++ b/packages/engine/src/simulation/__tests__/workerPipeline.test.ts
@@ -14,7 +14,8 @@ const workerResources: SimResources = {
   favor: 8,
   workers: 40,
   wood: 45,
-  planks: 18
+  planks: 18,
+  defense: 0,
 };
 
 describe('runWorkerPipeline', () => {

--- a/packages/engine/src/simulation/buildingCatalog.ts
+++ b/packages/engine/src/simulation/buildingCatalog.ts
@@ -1,3 +1,5 @@
+import { ERA_DEFINITIONS } from '../progression/eraSystem';
+
 export interface SimResources {
   grain: number;
   coin: number;
@@ -6,6 +8,7 @@ export interface SimResources {
   workers: number;
   wood: number;
   planks: number;
+  defense: number;
 }
 
 export interface SimBuildingType {
@@ -18,6 +21,101 @@ export interface SimBuildingType {
   workCapacity?: number;
   /** Maximum upgrade level (>=1). Default 3. */
   maxLevel?: number;
+  /** Optional thematic category (economic, mystical, etc.). */
+  category?: 'economic' | 'military' | 'mystical' | 'infrastructure' | 'diplomatic' | 'social';
+  /** Optional prerequisite metadata that controls when the building unlocks. */
+  prerequisites?: BuildingPrerequisites;
+  /** Passive effects applied while the structure exists. */
+  passiveEffects?: BuildingPassiveEffects;
+  /** Marks a structure as unique – only one copy may exist. */
+  unique?: boolean;
+}
+
+export interface BuildingPrerequisites {
+  /** Required skill or mitigation identifiers. */
+  skills?: string[];
+  /** Quest chapter identifiers that must be completed. */
+  quests?: string[];
+  /** Minimum era identifier required to unlock construction. */
+  era?: string;
+}
+
+export interface BuildingPassiveEffects {
+  /** Per-cycle adjustments applied after building production. */
+  tickResourceAdjustments?: Partial<Record<string, number>>;
+  /** Multipliers applied to resource outputs. */
+  resourceMultipliers?: Partial<Record<string, number>>;
+  /** Multipliers applied to building outputs by type. */
+  buildingMultipliers?: Record<string, number>;
+  /** Adjusts the global building output multiplier. */
+  globalBuildingMultiplier?: number;
+  /** Adjusts the global resource output multiplier. */
+  globalResourceMultiplier?: number;
+  /** Additional multiplier for route coin yield. */
+  routeCoinMultiplier?: number;
+  /** Multiplier applied to patrol upkeep. */
+  patrolCoinUpkeepMultiplier?: number;
+  /** Multiplier applied to building input consumption. */
+  buildingInputMultiplier?: number;
+  /** Adds to the per-worker upkeep delta (can be negative). */
+  upkeepDelta?: number;
+}
+
+export interface AggregatedBuildingPassives {
+  resMul: Record<string, number>;
+  bldMul: Record<string, number>;
+  globalBuildingMultiplier: number;
+  globalResourceMultiplier: number;
+  routeCoinMultiplier: number;
+  patrolCoinUpkeepMultiplier: number;
+  buildingInputMultiplier: number;
+  tickAdjustments: Record<string, number>;
+  upkeepDelta: number;
+}
+
+export interface BuildingPrerequisiteContext {
+  unlockedSkills: string[];
+  completedQuests: string[];
+  currentEraId?: string | null;
+}
+
+export interface BuildingPrerequisiteStatus {
+  meetsRequirements: boolean;
+  missingSkills: string[];
+  missingQuests: string[];
+  missingEra?: string;
+}
+
+const ERA_INDEX_LOOKUP: Record<string, number> = ERA_DEFINITIONS.reduce<Record<string, number>>((acc, era, index) => {
+  acc[era.id] = index;
+  return acc;
+}, {});
+
+export function evaluateBuildingPrerequisites(
+  prerequisites: BuildingPrerequisites | undefined,
+  context: BuildingPrerequisiteContext,
+): BuildingPrerequisiteStatus {
+  if (!prerequisites) {
+    return { meetsRequirements: true, missingSkills: [], missingQuests: [] };
+  }
+
+  const unlocked = new Set(context.unlockedSkills);
+  const completed = new Set(context.completedQuests);
+  const missingSkills = (prerequisites.skills || []).filter(id => !unlocked.has(id));
+  const missingQuests = (prerequisites.quests || []).filter(id => !completed.has(id));
+
+  let missingEra: string | undefined;
+  if (prerequisites.era) {
+    const current = context.currentEraId ?? null;
+    const requiredIndex = ERA_INDEX_LOOKUP[prerequisites.era];
+    const currentIndex = current ? ERA_INDEX_LOOKUP[current] ?? -1 : -1;
+    if (requiredIndex !== undefined && (currentIndex < requiredIndex)) {
+      missingEra = prerequisites.era;
+    }
+  }
+
+  const meetsRequirements = missingSkills.length === 0 && missingQuests.length === 0 && !missingEra;
+  return { meetsRequirements, missingSkills, missingQuests, missingEra };
 }
 
 type ExtractString<T> = T extends string ? T : never;
@@ -40,6 +138,7 @@ export const SIM_BUILDINGS = defineSimBuildings({
     outputs: { favor: 1 },
     workCapacity: 0,
     maxLevel: 3,
+    category: 'infrastructure',
   },
   trade_post: {
     id: 'trade_post',
@@ -50,6 +149,7 @@ export const SIM_BUILDINGS = defineSimBuildings({
     outputs: { coin: 8 },
     workCapacity: 0,
     maxLevel: 3,
+    category: 'economic',
   },
   automation_workshop: {
     id: 'automation_workshop',
@@ -60,6 +160,7 @@ export const SIM_BUILDINGS = defineSimBuildings({
     outputs: { coin: 6 },
     workCapacity: 0,
     maxLevel: 3,
+    category: 'economic',
   },
   farm: {
     id: 'farm',
@@ -69,6 +170,7 @@ export const SIM_BUILDINGS = defineSimBuildings({
     outputs: { grain: 10 },
     workCapacity: 5,
     maxLevel: 3,
+    category: 'economic',
   },
   lumber_camp: {
     id: 'lumber_camp',
@@ -78,6 +180,7 @@ export const SIM_BUILDINGS = defineSimBuildings({
     outputs: { wood: 8 },
     workCapacity: 4,
     maxLevel: 3,
+    category: 'infrastructure',
   },
   sawmill: {
     id: 'sawmill',
@@ -87,6 +190,7 @@ export const SIM_BUILDINGS = defineSimBuildings({
     outputs: { planks: 6 },
     workCapacity: 4,
     maxLevel: 3,
+    category: 'infrastructure',
   },
   storehouse: {
     id: 'storehouse',
@@ -96,6 +200,7 @@ export const SIM_BUILDINGS = defineSimBuildings({
     outputs: {},
     workCapacity: 0,
     maxLevel: 1,
+    category: 'infrastructure',
   },
   house: {
     id: 'house',
@@ -105,6 +210,7 @@ export const SIM_BUILDINGS = defineSimBuildings({
     outputs: { workers: 5 },
     workCapacity: 0,
     maxLevel: 3,
+    category: 'social',
   },
   shrine: {
     id: 'shrine',
@@ -114,6 +220,102 @@ export const SIM_BUILDINGS = defineSimBuildings({
     outputs: { favor: 2 },
     workCapacity: 2,
     maxLevel: 3,
+    category: 'mystical',
+  },
+  arcane_conduit: {
+    id: 'arcane_conduit',
+    name: 'Arcane Conduit',
+    cost: { coin: 120, mana: 25, planks: 20 },
+    inputs: { mana: 2 },
+    outputs: { mana: 10, favor: 1 },
+    workCapacity: 3,
+    maxLevel: 3,
+    category: 'mystical',
+    prerequisites: { skills: ['leyline_capacitors'], quests: ['master-the-leylines'] },
+    passiveEffects: {
+      resourceMultipliers: { mana: 1.1 },
+      buildingMultipliers: { shrine: 1.1 },
+      tickResourceAdjustments: { mana: 2 },
+    },
+  },
+  warden_barracks: {
+    id: 'warden_barracks',
+    name: "Warden's Barracks",
+    cost: { coin: 140, grain: 30, planks: 20 },
+    inputs: { grain: 3 },
+    outputs: { defense: 6 },
+    workCapacity: 4,
+    maxLevel: 3,
+    category: 'military',
+    prerequisites: { skills: ['militia_watch'], quests: ['secure-trade'] },
+    passiveEffects: {
+      tickResourceAdjustments: { threat: -1 },
+      upkeepDelta: -0.05,
+      resourceMultipliers: { defense: 1.1 },
+    },
+  },
+  prismatic_workshop: {
+    id: 'prismatic_workshop',
+    name: 'Prismatic Workshop',
+    cost: { coin: 160, mana: 20, planks: 30 },
+    inputs: { wood: 3, mana: 1 },
+    outputs: { coin: 14, mana: 4 },
+    workCapacity: 4,
+    maxLevel: 3,
+    category: 'infrastructure',
+    prerequisites: { skills: ['leyline_capacitors'], quests: ['command-trade-empire'] },
+    passiveEffects: {
+      buildingMultipliers: { automation_workshop: 1.15 },
+      resourceMultipliers: { coin: 1.05 },
+    },
+  },
+  sky_dock: {
+    id: 'sky_dock',
+    name: 'Sky Dock',
+    cost: { coin: 220, mana: 40, planks: 40 },
+    inputs: { grain: 2, coin: 4 },
+    outputs: { coin: 20, favor: 3 },
+    workCapacity: 5,
+    maxLevel: 3,
+    category: 'economic',
+    prerequisites: { quests: ['command-trade-empire'], era: 'expansion_age' },
+    passiveEffects: {
+      routeCoinMultiplier: 1.2,
+    },
+  },
+  astral_bastion: {
+    id: 'astral_bastion',
+    name: 'Astral Bastion',
+    cost: { coin: 300, mana: 80, favor: 40, planks: 60 },
+    inputs: { mana: 3 },
+    outputs: { defense: 12, mana: 6 },
+    workCapacity: 0,
+    maxLevel: 1,
+    category: 'military',
+    prerequisites: { era: 'ascension_age', skills: ['astral_bastion'], quests: ['ascension-prelude'] },
+    passiveEffects: {
+      tickResourceAdjustments: { threat: -2, unrest: -1 },
+      resourceMultipliers: { defense: 1.2 },
+      globalResourceMultiplier: 1.05,
+    },
+    unique: true,
+  },
+  eternal_archive: {
+    id: 'eternal_archive',
+    name: 'Eternal Archive',
+    cost: { coin: 260, mana: 90, favor: 60, planks: 50 },
+    inputs: { mana: 2 },
+    outputs: { favor: 6, mana: 4 },
+    workCapacity: 0,
+    maxLevel: 1,
+    category: 'mystical',
+    prerequisites: { era: 'ascension_age', skills: ['crown_conclave'], quests: ['ascension-prelude'] },
+    passiveEffects: {
+      buildingMultipliers: { shrine: 1.25, council_hall: 1.1 },
+      tickResourceAdjustments: { mana: 3 },
+      globalBuildingMultiplier: 1.03,
+    },
+    unique: true,
   },
 });
 

--- a/packages/engine/src/simulation/effects/testUtils.ts
+++ b/packages/engine/src/simulation/effects/testUtils.ts
@@ -30,7 +30,8 @@ export function createMockResources(overrides: Partial<SimResources> = {}): SimR
     favor: 10,
     workers: 50,
     wood: 80,
-    planks: 40
+    planks: 40,
+    defense: 0,
   };
 
   return { ...base, ...overrides };

--- a/packages/engine/src/simulation/workers/__tests__/workerSimulationSystem.test.ts
+++ b/packages/engine/src/simulation/workers/__tests__/workerSimulationSystem.test.ts
@@ -72,6 +72,7 @@ describe('WorkerSimulationSystem integration', () => {
       workers: 1,
       wood: 50,
       planks: 20,
+      defense: 0,
     };
 
     system.updateSystem(

--- a/src/components/game/GameLayers.tsx
+++ b/src/components/game/GameLayers.tsx
@@ -20,12 +20,11 @@ import type { GameResources } from './hud/types';
 
 import type { VisualIndicator } from '@engine';
 
-import type { BuildTypeId } from './panels/TileInfoPanel';
+import type { BuildTypeId, BuildingAvailability } from './simCatalog';
 
 import ConnectedBuildingsLayer from './layers/ConnectedBuildingsLayer';
-import { useBuildPlacementHints } from './layers/useBuildPlacementHints';
 import { useLayerDatasets } from './layers/useLayerDatasets';
-import type { Marker, StoredBuilding, TileSelection, TradeRoute } from './layers/types';
+import type { Marker, StoredBuilding, TileSelection, TradeRoute, BuildPlacementHintsResult } from './layers/types';
 
 export interface GameLayersProps {
   tileTypes: string[][];
@@ -66,6 +65,8 @@ export interface GameLayersProps {
     type: 'building' | 'upgrading' | 'demolishing';
     timestamp: number;
   }>;
+  buildingAvailability: Record<BuildTypeId, BuildingAvailability>;
+  placementHints: BuildPlacementHintsResult;
 }
 
 const GameLayers: React.FC<GameLayersProps> = ({
@@ -101,15 +102,9 @@ const GameLayers: React.FC<GameLayersProps> = ({
   resources,
   cycle,
   constructionEvents,
+  buildingAvailability,
+  placementHints,
 }) => {
-  const placementHints = useBuildPlacementHints({
-    previewTypeId,
-    hoverTile,
-    selectedTile,
-    placedBuildings,
-    tutorialFree,
-    simResources,
-  });
 
   const { buildings, storeConnectedIds, routeDefs, routeBuildings, workingCitizens } = useLayerDatasets({
     placedBuildings,

--- a/src/components/game/PreviewLayer.tsx
+++ b/src/components/game/PreviewLayer.tsx
@@ -4,8 +4,7 @@ import { useEffect, useRef } from "react";
 import * as PIXI from "pixi.js";
 import { useGameContext } from "./GameContext";
 import { gridToWorld } from "@/lib/isometric";
-import { SIM_BUILDINGS } from "./simCatalog";
-type BuildTypeId = keyof typeof SIM_BUILDINGS;
+import { SIM_BUILDINGS, BUILDABLE_TILES, type BuildTypeId } from "./simCatalog";
 
 interface PreviewLayerProps {
   hoverTile: { x: number; y: number; tileType?: string } | null;
@@ -46,17 +45,7 @@ export default function PreviewLayer({ hoverTile, selectedTile, tileTypes, build
 
     // Optional: highlight all placeable tiles for current preview type
     if (previewTypeId && highlightAllPlaceable) {
-      const allowedTerrain: Record<BuildTypeId, string[]> = {
-        council_hall: ['grass','mountain'],
-        trade_post: ['grass'],
-        automation_workshop: ['grass'],
-        farm: ['grass'],
-        lumber_camp: ['forest'],
-        sawmill: ['grass'],
-        storehouse: ['grass'],
-        house: ['grass'],
-        shrine: ['grass']
-      };
+      const allowedTerrain = BUILDABLE_TILES;
       const needsCouncil = (previewTypeId === 'trade_post' || previewTypeId === 'automation_workshop');
       const councilOk = !needsCouncil || !!hasCouncil;
       const globallyOk = councilOk && (affordable !== false);
@@ -97,17 +86,7 @@ export default function PreviewLayer({ hoverTile, selectedTile, tileTypes, build
     const occupied = buildings.some(b => b.x === x && b.y === y);
 
     // Terrain validity for current preview type
-    const allowedTerrain: Record<BuildTypeId, string[]> = {
-      council_hall: ['grass','mountain'],
-      trade_post: ['grass'],
-      automation_workshop: ['grass'],
-      farm: ['grass'],
-      lumber_camp: ['forest'],
-      sawmill: ['grass'],
-      storehouse: ['grass'],
-      house: ['grass'],
-      shrine: ['grass']
-    };
+    const allowedTerrain = BUILDABLE_TILES;
     let terrainOk = true;
     if (previewTypeId && tile.tileType) {
       terrainOk = (allowedTerrain[previewTypeId] || []).includes(tile.tileType);

--- a/src/components/game/layers/types.ts
+++ b/src/components/game/layers/types.ts
@@ -1,4 +1,4 @@
-import type { BuildTypeId } from '../panels/TileInfoPanel';
+import type { BuildTypeId, BuildingAvailability } from '../simCatalog';
 import type { SimResources } from '../resourceUtils';
 import type { SimpleBuilding } from '../types';
 import type { RouteDef, RouteBuildingRef } from '../../../../apps/web/features/routes';
@@ -50,6 +50,7 @@ export interface BuildPlacementInput {
   placedBuildings: StoredBuilding[];
   tutorialFree: Partial<Record<BuildTypeId, number>>;
   simResources: SimResources | null;
+  buildingAvailability: Record<BuildTypeId, BuildingAvailability>;
 }
 
 export interface LayerBuilding extends SimpleBuilding {

--- a/src/components/game/resourceUtils.test.ts
+++ b/src/components/game/resourceUtils.test.ts
@@ -32,7 +32,7 @@ describe('applyProduction', () => {
   };
 
   it('produces outputs when inputs are available', () => {
-    const res: SimResources = { grain: 5, coin: 0, mana: 0, favor: 0, workers: 0, wood: 0, planks: 0 };
+    const res: SimResources = { grain: 5, coin: 0, mana: 0, favor: 0, workers: 0, wood: 0, planks: 0, defense: 0 };
     const { updated, shortages } = applyProduction(res, [{ typeId: 'mill', workers: 1 }], catalog);
     expect(updated.grain).toBe(3);
     expect(updated.coin).toBe(1);
@@ -40,7 +40,7 @@ describe('applyProduction', () => {
   });
 
   it('records shortages when inputs are missing', () => {
-    const res: SimResources = { grain: 1, coin: 0, mana: 0, favor: 0, workers: 0, wood: 0, planks: 0 };
+    const res: SimResources = { grain: 1, coin: 0, mana: 0, favor: 0, workers: 0, wood: 0, planks: 0, defense: 0 };
     const { updated, shortages } = applyProduction(res, [{ typeId: 'mill', workers: 1 }], catalog);
     expect(updated.grain).toBe(1);
     expect(updated.coin).toBe(0);
@@ -49,7 +49,7 @@ describe('applyProduction', () => {
 });
 
 describe('canAfford and applyCost', () => {
-  const base: SimResources = { grain: 5, coin: 5, mana: 5, favor: 5, workers: 0, wood: 0, planks: 0 };
+  const base: SimResources = { grain: 5, coin: 5, mana: 5, favor: 5, workers: 0, wood: 0, planks: 0, defense: 0 };
 
   it('determines affordability correctly', () => {
     expect(canAfford({ grain: 3, coin: 2 }, base)).toBe(true);
@@ -174,7 +174,7 @@ function serverSim(
 
 describe('server tick production parity', () => {
   it('matches projectCycleDeltas for sample scenario', () => {
-    const base: SimResources = { grain: 20, coin: 20, mana: 10, favor: 0, workers: 9, wood: 20, planks: 0 };
+    const base: SimResources = { grain: 20, coin: 20, mana: 10, favor: 0, workers: 9, wood: 20, planks: 0, defense: 0 };
     const buildings = [
       { id: 's1', typeId: 'storehouse' },
       { id: 'f1', typeId: 'farm', workers: 5, traits: { waterAdj: 2 } },
@@ -195,7 +195,7 @@ describe('server tick production parity', () => {
 
 describe('projectCycleDeltas modifiers', () => {
   it('scales route coin output by multiplier', () => {
-    const base: SimResources = { grain: 0, coin: 0, mana: 0, favor: 0, workers: 0, wood: 0, planks: 0 };
+    const base: SimResources = { grain: 0, coin: 0, mana: 0, favor: 0, workers: 0, wood: 0, planks: 0, defense: 0 };
     const buildings = [
       { id: 'hub', typeId: 'storehouse' },
       { id: 'farm', typeId: 'farm', workers: 0 },
@@ -211,7 +211,7 @@ describe('projectCycleDeltas modifiers', () => {
   });
 
   it('reduces building input consumption when multiplier is below 1', () => {
-    const base: SimResources = { grain: 0, coin: 10, mana: 0, favor: 0, workers: 5, wood: 0, planks: 0 };
+    const base: SimResources = { grain: 0, coin: 10, mana: 0, favor: 0, workers: 5, wood: 0, planks: 0, defense: 0 };
     const buildings = [{ typeId: 'farm', workers: 5 }];
     const normal = projectCycleDeltas(base, buildings as any, [], SIM_BUILDINGS, { totalWorkers: 5 });
     const reduced = projectCycleDeltas(base, buildings as any, [], SIM_BUILDINGS, {
@@ -223,7 +223,7 @@ describe('projectCycleDeltas modifiers', () => {
   });
 
   it('applies global building and resource multipliers to outputs', () => {
-    const base: SimResources = { grain: 0, coin: 10, mana: 0, favor: 0, workers: 5, wood: 0, planks: 0 };
+    const base: SimResources = { grain: 0, coin: 10, mana: 0, favor: 0, workers: 5, wood: 0, planks: 0, defense: 0 };
     const buildings = [{ typeId: 'farm', workers: 5 }];
     const normal = projectCycleDeltas(base, buildings as any, [], SIM_BUILDINGS, { totalWorkers: 5 });
     const boosted = projectCycleDeltas(base, buildings as any, [], SIM_BUILDINGS, {

--- a/src/components/game/simCatalog.ts
+++ b/src/components/game/simCatalog.ts
@@ -1,8 +1,17 @@
-import { SIM_BUILDINGS, type SimBuildingType } from '@engine';
+import {
+  SIM_BUILDINGS,
+  evaluateBuildingPrerequisites,
+  type BuildingPrerequisiteContext,
+  type BuildingPrerequisiteStatus,
+  type SimBuildingType,
+} from '@engine';
+
 export { SIM_BUILDINGS };
 export type { SimBuildingType };
 
-export const BUILDABLE_TILES: Record<keyof typeof SIM_BUILDINGS, string[]> = {
+export type BuildTypeId = keyof typeof SIM_BUILDINGS;
+
+export const BUILDABLE_TILES: Record<BuildTypeId, string[]> = {
   council_hall: ['grass', 'mountain'],
   trade_post: ['grass'],
   automation_workshop: ['grass'],
@@ -12,4 +21,117 @@ export const BUILDABLE_TILES: Record<keyof typeof SIM_BUILDINGS, string[]> = {
   lumber_camp: ['forest'],
   sawmill: ['grass'],
   storehouse: ['grass'],
+  arcane_conduit: ['grass'],
+  warden_barracks: ['grass'],
+  prismatic_workshop: ['grass'],
+  sky_dock: ['grass'],
+  astral_bastion: ['grass', 'mountain'],
+  eternal_archive: ['grass'],
 };
+
+export interface BuildMenuGroup {
+  id: string;
+  label: string;
+  types: BuildTypeId[];
+}
+
+export const BUILD_MENU_GROUPS: BuildMenuGroup[] = [
+  {
+    id: 'foundations',
+    label: 'Foundations',
+    types: ['farm', 'house', 'council_hall', 'storehouse', 'lumber_camp', 'sawmill'],
+  },
+  {
+    id: 'commerce',
+    label: 'Commerce & Arcana',
+    types: ['trade_post', 'automation_workshop', 'prismatic_workshop', 'shrine', 'arcane_conduit'],
+  },
+  {
+    id: 'defense',
+    label: 'Defense & Logistics',
+    types: ['warden_barracks', 'sky_dock'],
+  },
+  {
+    id: 'wonders',
+    label: 'Unique Wonders',
+    types: ['astral_bastion', 'eternal_archive'],
+  },
+];
+
+export interface BuildingAvailabilityContext extends BuildingPrerequisiteContext {
+  existingBuildings?: Array<{ typeId: BuildTypeId | string }>;
+  skillLabels?: Record<string, string>;
+  questLabels?: Record<string, string>;
+  eraLabels?: Record<string, string>;
+}
+
+export interface BuildingAvailability {
+  typeId: BuildTypeId;
+  status: BuildingPrerequisiteStatus;
+  meetsPrerequisites: boolean;
+  uniqueLocked: boolean;
+  reasons: string[];
+  requirementSummaries: string[];
+}
+
+export function evaluateBuildingAvailability(
+  typeId: BuildTypeId,
+  context: BuildingAvailabilityContext,
+): BuildingAvailability {
+  const def = SIM_BUILDINGS[typeId];
+  const status = evaluateBuildingPrerequisites(def?.prerequisites, context);
+  const existing = context.existingBuildings ?? [];
+  const uniqueLocked = Boolean(def?.unique && existing.some(b => String(b.typeId) === typeId));
+  const reasons: string[] = [];
+  if (uniqueLocked) {
+    reasons.push('Unique structure already constructed');
+  }
+  const labelSkill = (id: string) => context.skillLabels?.[id] ?? id;
+  const labelQuest = (id: string) => context.questLabels?.[id] ?? id;
+  const labelEra = (id: string) => context.eraLabels?.[id] ?? id;
+  if (status.missingSkills.length > 0) {
+    status.missingSkills.forEach(id => {
+      reasons.push(`Unlock skill: ${labelSkill(id)}`);
+    });
+  }
+  if (status.missingQuests.length > 0) {
+    status.missingQuests.forEach(id => {
+      reasons.push(`Complete quest: ${labelQuest(id)}`);
+    });
+  }
+  if (status.missingEra) {
+    reasons.push(`Reach ${labelEra(status.missingEra)}`);
+  }
+  const requirementSummaries: string[] = [];
+  if (def?.unique) {
+    requirementSummaries.push('Unique wonder (only one may stand)');
+  }
+  const prereq = def?.prerequisites;
+  if (prereq?.skills && prereq.skills.length > 0) {
+    const parts = prereq.skills.map(id => {
+      const name = labelSkill(id);
+      return status.missingSkills.includes(id) ? `${name} (locked)` : `${name} (met)`;
+    });
+    requirementSummaries.push(`Skills: ${parts.join(', ')}`);
+  }
+  if (prereq?.quests && prereq.quests.length > 0) {
+    const parts = prereq.quests.map(id => {
+      const name = labelQuest(id);
+      return status.missingQuests.includes(id) ? `${name} (locked)` : `${name} (met)`;
+    });
+    requirementSummaries.push(`Quests: ${parts.join(', ')}`);
+  }
+  if (prereq?.era) {
+    const name = labelEra(prereq.era);
+    const met = !status.missingEra;
+    requirementSummaries.push(`Era: ${name}${met ? ' (met)' : ' (locked)'}`);
+  }
+  return {
+    typeId,
+    status,
+    meetsPrerequisites: status.meetsRequirements && !uniqueLocked,
+    uniqueLocked,
+    reasons,
+    requirementSummaries,
+  };
+}


### PR DESCRIPTION
## Summary
- expand the engine building catalog with mid/late-game facilities, unique wonders, and prerequisite metadata while aggregating passive effects through `produceBuildings`
- wire prerequisite awareness and defense resource handling through the client simulation utilities, build layers, and play page UI
- standardize defense defaults across simulation fixtures and add wonder regression coverage for mana/defense loops

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb21bcfb2883259d575f326dafdc24